### PR TITLE
Calculate correct circuit depth

### DIFF
--- a/doc/source/examples.rst
+++ b/doc/source/examples.rst
@@ -58,7 +58,7 @@ backend which uses custom tensorflow operators to apply gates.
 How to print a circuit summary?
 -------------------------------
 
-It is possible to print a summary of the circuit using ``circuit.summary``.
+It is possible to print a summary of the circuit using ``circuit.summary()``.
 This will print basic information about the circuit, including its depth, the
 total number of qubits and all gates in order of the number of times they appear.
 The QASM name is used as identifier of gates.
@@ -76,10 +76,11 @@ For example
     c.add(gates.CNOT(1, 2))
     c.add(gates.H(2))
     c.add(gates.TOFFOLI(0, 1, 2))
-    print(c.summary)
+    print(c.summary())
     # Prints
     '''
-    Circuit depth = 6
+    Circuit depth = 5
+    Total number of gates = 6
     Number of qubits = 3
     Most common gates:
     h: 3

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -5,11 +5,16 @@
 Welcome to Qibo!
 ================
 
-Qibo is a Python library for classical simulation of
-quantum algorithms. Qibo provides a standard interface for the implementation and extension of quantum algorithms in double precision. Simulation takes full advantage of hardware accelerators such as GPU and CPU with multi-threading support. The package includes a multi-GPU distributed approach for circuit simulation.
+Qibo is a Python library for classical simulation of quantum algorithms.
+Qibo provides a standard interface for the implementation and extension of
+quantum algorithms in double precision. Simulation takes full advantage of
+hardware accelerators such as GPU and CPU with multi-threading support.
+The package includes a multi-GPU distributed approach for circuit simulation.
 
 .. image:: https://zenodo.org/badge/DOI/10.5281/zenodo.3997195.svg
    :target: https://doi.org/10.5281/zenodo.3997195
+
+This documentation refers to Qibo |release|.
 
 .. toctree::
     :maxdepth: 2

--- a/src/qibo/__init__.py
+++ b/src/qibo/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.1.0-dev"
+__version__ = "0.1.1-dev"
 from qibo.config import set_precision, set_backend, set_device, get_backend, get_precision, get_device, matrices, K
 from qibo import callbacks
 from qibo import evolution

--- a/src/qibo/__init__.py
+++ b/src/qibo/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.1.0"
+__version__ = "0.1.0-dev"
 from qibo.config import set_precision, set_backend, set_device, get_backend, get_precision, get_device, matrices, K
 from qibo import callbacks
 from qibo import evolution

--- a/src/qibo/base/circuit.py
+++ b/src/qibo/base/circuit.py
@@ -10,7 +10,7 @@ NoiseMapType = Union[Tuple[int, int, int],
                      Dict[int, Tuple[int, int, int]]]
 
 
-class _ParametrizedGates:
+class _ParametrizedGates(list):
     """Simple data structure for keeping track of parametrized gates.
 
     Useful for the ``circuit.set_parameters()`` method.
@@ -19,20 +19,14 @@ class _ParametrizedGates:
     """
 
     def __init__(self):
-        self.list = []
+        super(_ParametrizedGates, self).__init__(self)
         self.set = set()
         self.nparams = 0
 
     def append(self, gate: gates.ParametrizedGate):
-        self.list.append(gate)
+        super(_ParametrizedGates, self).append(gate)
         self.set.add(gate)
         self.nparams += gate.nparams
-
-    def __len__(self):
-        return len(self.list)
-
-    def __iter__(self):
-        return iter(self.list)
 
 
 class BaseCircuit(object):

--- a/src/qibo/base/circuit.py
+++ b/src/qibo/base/circuit.py
@@ -573,7 +573,6 @@ class BaseCircuit(object):
         else:
             raise_error(ValueError, f"Unknown format {format} given in ``get_parameters``.")
 
-    @property
     def summary(self) -> str:
         """Generates a summary of the circuit.
 

--- a/src/qibo/base/circuit.py
+++ b/src/qibo/base/circuit.py
@@ -486,6 +486,8 @@ class BaseCircuit(object):
             for i, gate in enumerate(self.parametrized_gates):
                 gate.parameter = parameters[i]
         elif n == self.parametrized_gates.nparams:
+            import numpy as np
+            parameters = np.array(parameters)
             k = 0
             for i, gate in enumerate(self.parametrized_gates):
                 gate.parameter = parameters[i + k: i + k + gate.nparams]

--- a/src/qibo/base/circuit.py
+++ b/src/qibo/base/circuit.py
@@ -30,25 +30,25 @@ class _ParametrizedGates(list):
 
 
 class _Queue(list):
-  """List that holds the queue of gates of a circuit.
+    """List that holds the queue of gates of a circuit.
 
-  In addition to the queue, it holds a list of gate moments, where each gate
-  is placed in the earliest possible position depending for the qubits it acts.
-  """
+    In addition to the queue, it holds a list of gate moments, where each gate
+    is placed in the earliest possible position depending for the qubits it acts.
+    """
 
-  def __init__(self, nqubits):
-      super(_Queue, self).__init__(self)
-      self.nqubits = nqubits
-      self.moments = [nqubits * [None]]
+    def __init__(self, nqubits):
+        super(_Queue, self).__init__(self)
+        self.nqubits = nqubits
+        self.moments = [nqubits * [None]]
 
-  def append(self, gate: gates.ParametrizedGate):
-      super(_Queue, self).append(gate)
-      for q in gate.qubits:
-          if self.moments[-1][q] is not None:
-              # Add a moment
-              self.moments.append(len(self.moments[-1]) * [None])
-      for q in gate.qubits:
-          self.moments[-1][q] = gate
+    def append(self, gate: gates.ParametrizedGate):
+        super(_Queue, self).append(gate)
+        for q in gate.qubits:
+            if self.moments[-1][q] is not None:
+                # Add a moment
+                self.moments.append(len(self.moments[-1]) * [None])
+        for q in gate.qubits:
+            self.moments[-1][q] = gate
 
 
 class BaseCircuit(object):

--- a/src/qibo/tests/test_base.py
+++ b/src/qibo/tests/test_base.py
@@ -185,7 +185,7 @@ def test_gates_of_type():
 
 
 def test_summary():
-    """Check ``BaseCircuit.summary`` method."""
+    """Check ``BaseCircuit.summary()`` method."""
     c = Circuit(3)
     c.add(H(0))
     c.add(H(1))
@@ -198,9 +198,7 @@ def test_summary():
                                 "Number of qubits = 3",
                                 "Most common gates:",
                                 "h: 3", "cx: 2", "ccx: 1"])
-    print(target_summary)
-    print(c.summary)
-    assert c.summary == target_summary
+    assert c.summary() == target_summary
 
 
 @pytest.mark.parametrize("deep", [False, True])

--- a/src/qibo/tests/test_density_matrix.py
+++ b/src/qibo/tests/test_density_matrix.py
@@ -370,7 +370,8 @@ def test_circuit_with_noise_gates():
     c.add([gates.H(0), gates.H(1), gates.CNOT(0, 1)])
     noisy_c = c.with_noise((0.1, 0.2, 0.3))
 
-    assert noisy_c.depth == 9
+    assert noisy_c.depth == 6
+    assert noisy_c.ngates == 9
     from qibo.tensorflow import gates as native_gates
     for i in [1, 2, 4, 5, 7, 8]:
         assert isinstance(noisy_c.queue[i], native_gates.NoiseChannel)

--- a/src/qibo/tests/test_parametrized.py
+++ b/src/qibo/tests/test_parametrized.py
@@ -85,12 +85,12 @@ def test_circuit_set_parameters_with_list(backend, accelerators):
     c.set_parameters(params)
     np.testing.assert_allclose(c(), target_c())
 
-    # Attempt using a flat list / np.ndarray
-    new_params = np.random.random(4)
-    params = [new_params[0], new_params[1], (new_params[2], new_params[3])]
-    target_c.set_parameters(params)
-    c.set_parameters(new_params)
-    np.testing.assert_allclose(c(), target_c())
+    # Attempt using a flat np.ndarray/list
+    for new_params in (np.random.random(4), list(np.random.random(4))):
+        params = [new_params[0], new_params[1], (new_params[2], new_params[3])]
+        target_c.set_parameters(params)
+        c.set_parameters(new_params)
+        np.testing.assert_allclose(c(), target_c())
     qibo.set_backend(original_backend)
 
 

--- a/src/qibo/tests/test_qasm.py
+++ b/src/qibo/tests/test_qasm.py
@@ -170,7 +170,7 @@ h q[0];
 h q[1];"""
     c = Circuit.from_qasm(target, accelerators)
     assert c.nqubits == 2
-    assert c.depth == 2
+    assert c.depth == 1
     assert isinstance(c.queue[0], gates.H)
     assert isinstance(c.queue[1], gates.H)
 
@@ -201,7 +201,8 @@ cx q[1],q[0];
 ccx q[1],q[2],q[0];"""
     c = Circuit.from_qasm(target, accelerators)
     assert c.nqubits == 3
-    assert c.depth == 5
+    assert c.depth == 4
+    assert c.ngates == 5
     assert isinstance(c.queue[0], gates.CNOT)
     assert c.queue[0].qubits == (0, 2)
     assert isinstance(c.queue[1], gates.X)
@@ -228,7 +229,7 @@ swap a[0],c[1];
 ccx b[0],c[1],c[0];"""
     c = Circuit.from_qasm(target)
     assert c.nqubits == 5
-    assert c.depth == 4
+    assert c.depth == 3
     assert isinstance(c.queue[0], gates.CNOT)
     assert c.queue[0].qubits == (0, 2)
     assert isinstance(c.queue[1], gates.X)
@@ -375,7 +376,7 @@ rx(0.1234) q[0];
 rz(0.4321) q[1];
 crz(0.567) q[0],q[1];"""
     c = Circuit.from_qasm(target)
-    assert c.depth == 3
+    assert c.depth == 2
     assert isinstance(c.queue[0], gates.RX)
     assert isinstance(c.queue[1], gates.RZ)
     assert isinstance(c.queue[2], gates.CZPow)
@@ -425,7 +426,7 @@ creg a[2]; h q[0];x q[1]; cx q[0], q[1];
 measure q[0] -> a[0];measure q[1]->a[1]"""
     c = Circuit.from_qasm(target)
     assert c.nqubits == 2
-    assert c.depth == 3
+    assert c.depth == 2
     assert isinstance(c.queue[0], gates.H)
     assert isinstance(c.queue[1], gates.X)
     assert isinstance(c.queue[2], gates.CNOT)

--- a/src/qibo/tests/test_qft.py
+++ b/src/qibo/tests/test_qft.py
@@ -34,7 +34,8 @@ def test_qft_sanity():
     """Check QFT circuit size and depth."""
     c = models.QFT(4)
     assert c.size == 4
-    assert c.depth == 12
+    assert c.depth == 9
+    assert c.ngates == 12
 
 
 @pytest.mark.parametrize("nqubits", [4, 5])


### PR DESCRIPTION
Implements the changes discussed in #238, particularly the following:
* Cast parameters given as a flat list to `circuit.set_parameters()` to `np.array` so that the snippet from #238 works.
* Change `circuit.depth` property to `circuit.ngates` as it returns the total number of gates in the circuit and not the depth.
* Create a new `circuit.depth` property that returns the actual depth, assuming that each gate is placed in the earliest possible position in the circuit according to the qubits it acts on. In order to do this calculation I extended the queue data structure slightly to hold a list of "moments" (in Cirq terminology).
* Change `circuit.summary` from `@property` to simple method so that it can be accessed as `circuit.summary()`.
* Update `circuit.summary()` to print both the (corrected) circuit depth and total number of gates.

I also updated the docs regarding the `circuit.summary()`, however it might make sense to revert these changes because the public docs will be updated while the pip Qibo version will not. However we should remember to update the docs for all changes when we release. Let me know what you think.