### PR TITLE
Allow adding circuits to larger ones

### DIFF
--- a/doc/source/advancedexamples.rst
+++ b/doc/source/advancedexamples.rst
@@ -335,7 +335,33 @@ for example:
 
     # Create the total circuit as subroutine + middle + subroutine^{-1}
     circuit = subroutine + middle + subroutine.invert()
+    
 
+Note that circuit addition works only between circuits that act on the same number
+of qubits. It is often useful to add subroutines only on a subset of qubits of the 
+large circuit. This is possible using the :meth:`qibo.base.circuit.BaseCircuit.on_qubits`
+method. For example:
+
+.. code-block:: python
+
+    import numpy as np
+    from qibo.models import Circuit
+    from qibo import gates
+    
+    # Create a small circuit of 4 qubits
+    smallc = Circuit(4)
+    smallc.add((gates.RX(i, theta=0.1) for i in range(4)))
+    smallc.add((gates.CNOT(0, 1), CNOT(2, 3)))
+
+    # Create a large circuit on 8 qubits
+    largec = Circuit(8)
+    # Add the small circuit on even qubits
+    largec.add(smallc.on_qubits(*range(0, 8, 2)))
+    # Add a QFT on odd qubits
+    largec.add(models.QFT(4).on_qubits(*range(1, 8, 2)))
+    # Add an inverse QFT on first 6 qubits
+    largec.add(models.QFT(6).invert().on_qubits(*range(6)))
+    
 
 .. _vqe-example:
 

--- a/doc/source/advancedexamples.rst
+++ b/doc/source/advancedexamples.rst
@@ -320,7 +320,6 @@ for example:
 
 .. code-block:: python
 
-    import numpy as np
     from qibo.models import Circuit
     from qibo import gates
 
@@ -344,7 +343,6 @@ method. For example:
 
 .. code-block:: python
 
-    import numpy as np
     from qibo import models, gates
 
     # Create a small circuit of 4 qubits

--- a/doc/source/advancedexamples.rst
+++ b/doc/source/advancedexamples.rst
@@ -335,33 +335,32 @@ for example:
 
     # Create the total circuit as subroutine + middle + subroutine^{-1}
     circuit = subroutine + middle + subroutine.invert()
-    
+
 
 Note that circuit addition works only between circuits that act on the same number
-of qubits. It is often useful to add subroutines only on a subset of qubits of the 
+of qubits. It is often useful to add subroutines only on a subset of qubits of the
 large circuit. This is possible using the :meth:`qibo.base.circuit.BaseCircuit.on_qubits`
 method. For example:
 
 .. code-block:: python
 
     import numpy as np
-    from qibo.models import Circuit
-    from qibo import gates
-    
+    from qibo import models, gates
+
     # Create a small circuit of 4 qubits
-    smallc = Circuit(4)
+    smallc = models.Circuit(4)
     smallc.add((gates.RX(i, theta=0.1) for i in range(4)))
-    smallc.add((gates.CNOT(0, 1), CNOT(2, 3)))
+    smallc.add((gates.CNOT(0, 1), gates.CNOT(2, 3)))
 
     # Create a large circuit on 8 qubits
-    largec = Circuit(8)
+    largec = models.Circuit(8)
     # Add the small circuit on even qubits
     largec.add(smallc.on_qubits(*range(0, 8, 2)))
     # Add a QFT on odd qubits
     largec.add(models.QFT(4).on_qubits(*range(1, 8, 2)))
     # Add an inverse QFT on first 6 qubits
     largec.add(models.QFT(6).invert().on_qubits(*range(6)))
-    
+
 
 .. _vqe-example:
 

--- a/src/qibo/base/circuit.py
+++ b/src/qibo/base/circuit.py
@@ -164,7 +164,7 @@ class BaseCircuit(object):
         if len(q) != self.nqubits:
             raise_error(ValueError, "Cannot return gates on {} qubits because "
                                     "the circuit contains {} qubits."
-                                    "".format(len(qubits), self.nqubits))
+                                    "".format(len(q), self.nqubits))
         for gate in self.queue:
             yield gate.on_qubits(*(q[i] for i in gate.qubits))
 

--- a/src/qibo/base/circuit.py
+++ b/src/qibo/base/circuit.py
@@ -139,6 +139,28 @@ class BaseCircuit(object):
         return newcircuit
 
     def on_qubits(self, *q) -> Iterable[gates.Gate]:
+        """Generator of gates contained in the circuit acting on specified qubits.
+
+        Useful for adding a circuit as a subroutine in a larger circuit.
+
+        Args:
+            q (int): Qubit ids that the gates should act.
+
+        Example:
+            ::
+
+                from qibo.models import Circuit
+                from qibo import gates
+                # create small circuit on 4 qubits
+                smallc = Circuit(4)
+                smallc.add((gates.RX(i, theta=0.1) for i in range(4)))
+                smallc.add((gates.CNOT(0, 1), CNOT(2, 3)))
+                # create large circuit on 8 qubits
+                largec = Circuit(8)
+                largec.add((gates.RY(i, theta=0.1) for i in range(8)))
+                # add the small circuit to the even qubits of the large one
+                largec.add(smallc.on_qubits(*range(0, 8, 2)))
+        """
         if len(q) != self.nqubits:
             raise_error(ValueError, "Cannot return gates on {} qubits because "
                                     "the circuit contains {} qubits."

--- a/src/qibo/base/circuit.py
+++ b/src/qibo/base/circuit.py
@@ -149,14 +149,13 @@ class BaseCircuit(object):
         Example:
             ::
 
-                from qibo.models import Circuit
-                from qibo import gates
+                from qibo import gates, models
                 # create small circuit on 4 qubits
-                smallc = Circuit(4)
+                smallc = models.Circuit(4)
                 smallc.add((gates.RX(i, theta=0.1) for i in range(4)))
-                smallc.add((gates.CNOT(0, 1), CNOT(2, 3)))
+                smallc.add((gates.CNOT(0, 1), gates.CNOT(2, 3)))
                 # create large circuit on 8 qubits
-                largec = Circuit(8)
+                largec = models.Circuit(8)
                 largec.add((gates.RY(i, theta=0.1) for i in range(8)))
                 # add the small circuit to the even qubits of the large one
                 largec.add(smallc.on_qubits(*range(0, 8, 2)))
@@ -247,9 +246,8 @@ class BaseCircuit(object):
         Example:
             ::
 
-                from qibo.models import Circuit
-                from qibo import gates
-                c = Circuit(2)
+                from qibo import models, gates
+                c = models.Circuit(2)
                 c.add([gates.H(0), gates.H(1)])
                 c.add(gates.CNOT(0, 1))
                 c.add([gates.Y(0), gates.Y(1)])

--- a/src/qibo/base/circuit.py
+++ b/src/qibo/base/circuit.py
@@ -138,6 +138,14 @@ class BaseCircuit(object):
             newcircuit.measurement_gate._add(c2.measurement_gate.target_qubits)
         return newcircuit
 
+    def on_qubits(self, *q) -> Iterable[gates.Gate]:
+        if len(q) != self.nqubits:
+            raise_error(ValueError, "Cannot return gates on {} qubits because "
+                                    "the circuit contains {} qubits."
+                                    "".format(len(qubits), self.nqubits))
+        for gate in self.queue:
+            yield gate.on_qubits(*(q[i] for i in gate.qubits))
+
     def copy(self, deep: bool = False) -> "BaseCircuit":
         """Creates a copy of the current ``circuit`` as a new ``Circuit`` model.
 

--- a/src/qibo/base/gates.py
+++ b/src/qibo/base/gates.py
@@ -1383,7 +1383,7 @@ class Unitary(ParametrizedGate):
         return len(self.target_qubits)
 
     def _new_args(self, *q) -> "Gate":
-        args = self.init_args[0]
+        args = [self.init_args[0]]
         args.extend(q)
         return args
 

--- a/src/qibo/base/gates.py
+++ b/src/qibo/base/gates.py
@@ -1657,7 +1657,8 @@ class Flatten(Gate):
         self.is_special_gate = True
 
     def on_qubits(self, *q):
-        return self.__class__(*self.init_args)
+        raise_error(NotImplementedError,
+                    "Cannot use `Flatten` gate on subroutine.")
 
 
 class CallbackGate(Gate):
@@ -1677,7 +1678,8 @@ class CallbackGate(Gate):
         self.is_special_gate = True
 
     def on_qubits(self, *q):
-        return self.__class__(*self.init_args)
+        raise_error(NotImplementedError,
+                    "Cannot use `CallbackGate` on subroutine.")
 
     @Gate.nqubits.setter
     def nqubits(self, n: int):

--- a/src/qibo/tensorflow/distcircuit.py
+++ b/src/qibo/tensorflow/distcircuit.py
@@ -74,6 +74,12 @@ class TensorflowDistributedCircuit(circuit.TensorflowCircuit):
             raise_error(ValueError, "Attempting to add gate with preset number of "
                                     "qubits in distributed circuit.")
 
+    def on_qubits(self, *q):
+        if self.queues.queues:
+            raise_error(RuntimeError, "Cannot use distributed circuit as a "
+                                      "subroutine after it was executed.")
+        return super(TensorflowDistributedCircuit, self).on_qubits(*q)
+
     def copy(self, deep: bool = True) -> "TensorflowDistributedCircuit":
         if not deep:
             raise_error(ValueError, "Non-deep copy is not allowed for distributed "

--- a/src/qibo/tests/test_circuits.py
+++ b/src/qibo/tests/test_circuits.py
@@ -378,6 +378,7 @@ def test_circuit_gate_generator_with_varlayer(backend, accelerators):
 
 @pytest.mark.parametrize(("backend", "accelerators"), _DEVICE_BACKENDS)
 def test_circuit_gate_generator_errors(backend, accelerators):
+    from qibo import callbacks
     original_backend = qibo.get_backend()
     qibo.set_backend(backend)
 
@@ -385,6 +386,16 @@ def test_circuit_gate_generator_errors(backend, accelerators):
     smallc.add((gates.H(i) for i in range(2)))
     with pytest.raises(ValueError):
         next(smallc.on_qubits(0, 1, 2))
+
+    smallc = Circuit(2, accelerators=accelerators)
+    smallc.add(gates.Flatten(np.ones(4) / np.sqrt(2)))
+    with pytest.raises(NotImplementedError):
+        next(smallc.on_qubits(0, 1))
+
+    smallc = Circuit(4, accelerators=accelerators)
+    smallc.add(gates.CallbackGate(callbacks.EntanglementEntropy([0, 1])))
+    with pytest.raises(NotImplementedError):
+        next(smallc.on_qubits(0, 1, 2, 3))
     qibo.set_backend(original_backend)
 
 

--- a/src/qibo/tests/test_circuits.py
+++ b/src/qibo/tests/test_circuits.py
@@ -262,6 +262,36 @@ def test_circuit_invert_with_addition(backend, accelerators):
     qibo.set_backend(original_backend)
 
 
+@pytest.mark.parametrize(("backend", "accelerators"), _DEVICE_BACKENDS)
+def test_circuit_gate_generator(backend, accelerators):
+    original_backend = qibo.get_backend()
+    qibo.set_backend(backend)
+
+    targetc = Circuit(6)
+    targetc.add((gates.RY(i, theta=i + 0.2) for i in range(0, 6, 2)))
+    targetc.add((gates.RX(i, theta=i // 2 + 0.1) for i in range(1, 6, 2)))
+    targetc.add((gates.CNOT(1, 3), gates.CZ(3, 5)))
+
+    smallc = Circuit(3)
+    smallc.add((gates.RX(i, theta=i + 0.1) for i in range(3)))
+    smallc.add((gates.CNOT(0, 1), gates.CZ(1, 2)))
+    largec = Circuit(6, accelerators=accelerators)
+    largec.add((gates.RY(i, theta=i + 0.2) for i in range(0, 6, 2)))
+    largec.add(smallc.on_qubits(1, 3, 5))
+    assert largec.depth == targetc.depth
+    np.testing.assert_allclose(largec(), targetc())
+
+    smallc = Circuit(3, accelerators=accelerators)
+    smallc.add((gates.RX(i, theta=i + 0.1) for i in range(3)))
+    smallc.add((gates.CNOT(0, 1), gates.CZ(1, 2)))
+    largec = Circuit(6, accelerators=accelerators)
+    largec.add((gates.RY(i, theta=i + 0.2) for i in range(0, 6, 2)))
+    largec.add(smallc.on_qubits(1, 3, 5))
+    assert largec.depth == targetc.depth
+    np.testing.assert_allclose(largec(), targetc())
+    qibo.set_backend(original_backend)
+
+
 @pytest.mark.linux
 @pytest.mark.parametrize("accelerators", [None, {"/GPU:0": 2}])
 def test_memory_error(accelerators):

--- a/src/qibo/tests/test_circuits.py
+++ b/src/qibo/tests/test_circuits.py
@@ -377,32 +377,14 @@ def test_circuit_gate_generator_with_varlayer(backend, accelerators):
 
 
 @pytest.mark.parametrize(("backend", "accelerators"), _DEVICE_BACKENDS)
-def test_circuit_gate_generator(backend, accelerators):
+def test_circuit_gate_generator_errors(backend, accelerators):
     original_backend = qibo.get_backend()
     qibo.set_backend(backend)
 
-    targetc = Circuit(6)
-    targetc.add((gates.RY(i, theta=i + 0.2) for i in range(0, 6, 2)))
-    targetc.add((gates.RX(i, theta=i // 2 + 0.1) for i in range(1, 6, 2)))
-    targetc.add((gates.CNOT(1, 3), gates.CZ(3, 5)))
-
-    smallc = Circuit(3)
-    smallc.add((gates.RX(i, theta=i + 0.1) for i in range(3)))
-    smallc.add((gates.CNOT(0, 1), gates.CZ(1, 2)))
-    largec = Circuit(6, accelerators=accelerators)
-    largec.add((gates.RY(i, theta=i + 0.2) for i in range(0, 6, 2)))
-    largec.add(smallc.on_qubits(1, 3, 5))
-    assert largec.depth == targetc.depth
-    np.testing.assert_allclose(largec(), targetc())
-
-    smallc = Circuit(3, accelerators=accelerators)
-    smallc.add((gates.RX(i, theta=i + 0.1) for i in range(3)))
-    smallc.add((gates.CNOT(0, 1), gates.CZ(1, 2)))
-    largec = Circuit(6, accelerators=accelerators)
-    largec.add((gates.RY(i, theta=i + 0.2) for i in range(0, 6, 2)))
-    largec.add(smallc.on_qubits(1, 3, 5))
-    assert largec.depth == targetc.depth
-    np.testing.assert_allclose(largec(), targetc())
+    smallc = Circuit(2, accelerators=accelerators)
+    smallc.add((gates.H(i) for i in range(2)))
+    with pytest.raises(ValueError):
+        next(smallc.on_qubits(0, 1, 2))
     qibo.set_backend(original_backend)
 
 


### PR DESCRIPTION
Closes #253 by implementing a `circuit.on_qubits(*q)` method on circuits that returns a generator of gates that exist in `circuit` acting on the specified `qubits`.

Example:
```Python
from qibo import models, gates

# Create a large circuit on 8 qubits
circuit = models.Circuit(8)
# Add a QFT on even qubits
circuit.add(models.QFT(4).on_qubits(*range(0, 8, 2)))
# Add rotations to all 8 qubits
circuit.add((gates.RX(i, theta=0) for i in range(8)))
# Add an inverse QFT on odd qubits
circuit.add(models.QFT(4).invert().on_qubits(*range(1, 8, 2)))
```

Regarding the performance issue I mentioned in #253, I did some quick benchmarks on this on my local laptop. Particularly, I compare the above script with creating the QFT and inverse QFT gates with a custom generator from scratch (instead of using the QFT model and `on_qubits`). I see no difference in execution time, but as expected there is some difference in circuit creation time.

Creation time
nqubits | custom creation | using `on_qubits` |
-- | -- | --
10 | 0.01617 | 0.02304
12 | 0.00878 | 0.01711
14 | 0.01048 | 0.01804
16 | 0.01176 | 0.02001
18 | 0.02110 | 0.02792
20 | 0.01309 | 0.03663
22 | 0.02233 | 0.03643
24 | 0.02970 | 0.04299
26 | 0.03967 | 0.07076

Execution time
nqubits | custom creation | using `on_qubits` |
-- | -- | --
10 | 0.00409 | 0.00301
12 | 0.00456 | 0.00292
14 | 0.00444 | 0.00381
16 | 0.00871 | 0.00688
18 | 0.02110 | 0.03392
20 | 0.17917 | 0.17245
22 | 0.93621 | 0.99574
24 | 4.46404 | 4.38530
26 | 19.7839 | 18.7598

Given that that the difference is small and typically creation time << execution time and also that Qibo provides several functions to avoid circuit re-creation whenever possible (such as `set_parameters`), I believe using `on_qubits` should be fine in terms of performance.