### PR TITLE
Fix backend name returned by `qibo.get_backend()`

### DIFF
--- a/src/qibo/config.py
+++ b/src/qibo/config.py
@@ -97,21 +97,19 @@ if BACKEND_NAME == "tensorflow":
             warnings.warn("Backend should not be changed after allocating gates.",
                           category=RuntimeWarning)
         if backend == 'custom':
-            BACKEND['NAME'] = backend
             BACKEND['GATES'] = 'custom'
             BACKEND['EINSUM'] = None
         elif backend == 'defaulteinsum':
             from qibo.tensorflow import einsum
-            BACKEND['NAME'] = backend
             BACKEND['GATES'] = 'native'
             BACKEND['EINSUM'] = einsum.DefaultEinsum()
         elif backend == 'matmuleinsum':
             from qibo.tensorflow import einsum
-            BACKEND['NAME'] = backend
             BACKEND['GATES'] = 'native'
             BACKEND['EINSUM'] = einsum.MatmulEinsum()
         else:
             raise_error(RuntimeError, f"Gate backend '{backend}' not supported.")
+        BACKEND['STRING'] = backend
 
     def get_backend():
         """Get backend used to implement gates.

--- a/src/qibo/tests/test_base.py
+++ b/src/qibo/tests/test_base.py
@@ -345,6 +345,7 @@ def test_set_backend(backend):
     original_backend = qibo.get_backend()
     qibo.set_backend(backend)
     from qibo import gates
+    assert qibo.get_backend() == backend
     if backend == "custom":
         from qibo.tensorflow import cgates as custom_gates
         assert isinstance(gates.H(0), custom_gates.TensorflowGate)

--- a/src/qibo/tests/test_gates.py
+++ b/src/qibo/tests/test_gates.py
@@ -303,6 +303,7 @@ def test_controlled_u2(backend):
     # for coverage
     gate = gates.CU2(0, 1, phi, lam)
     assert gate.parameter == (phi, lam)
+    qibo.set_backend(original_backend)
 
 
 @pytest.mark.parametrize("backend", _BACKENDS)
@@ -328,6 +329,7 @@ def test_controlled_u3(backend):
     # for coverage
     gate = gates.U3(0, theta, phi, lam)
     assert gate.parameter == (theta, phi, lam)
+    qibo.set_backend(original_backend)
 
 
 @pytest.mark.parametrize("backend", _BACKENDS)


### PR DESCRIPTION
Currently `qibo.get_backend()` is returning `"custom"` regardless of the actual current backend because there is a confusion with the `'STRING'` and `'NAME'` dictionary keys for backends. Specifically `get_backend()` returns `'STRING'`, while `set_backend` updates `'NAME'`.

This PR removes the `'NAME'` key and updates `'STRING'` in `set_backend` so that everything works as expected.