### PR TITLE
Fix circuit depth calculation

### DIFF
--- a/src/qibo/base/circuit.py
+++ b/src/qibo/base/circuit.py
@@ -40,15 +40,19 @@ class _Queue(list):
         super(_Queue, self).__init__(self)
         self.nqubits = nqubits
         self.moments = [nqubits * [None]]
+        self.moment_index = nqubits * [0]
 
     def append(self, gate: gates.ParametrizedGate):
         super(_Queue, self).append(gate)
+        # Calculate moment index for this gate
+        if gate.qubits:
+            idx = max(self.moment_index[q] for q in gate.qubits)
         for q in gate.qubits:
-            if self.moments[-1][q] is not None:
+            if idx >= len(self.moments):
                 # Add a moment
                 self.moments.append(len(self.moments[-1]) * [None])
-        for q in gate.qubits:
-            self.moments[-1][q] = gate
+            self.moments[idx][q] = gate
+            self.moment_index[q] = idx + 1
 
 
 class BaseCircuit(object):

--- a/src/qibo/tests/test_cirq.py
+++ b/src/qibo/tests/test_cirq.py
@@ -195,6 +195,7 @@ def test_one_qubit_gates_controlled_by(backend, gate_name, nqubits, ndevices):
         assert_gates_equivalent(qibo_gate, cirq_gate, nqubits, ndevices)
     qibo.set_backend(original_backend)
 
+
 @pytest.mark.parametrize("backend", _BACKENDS)
 @pytest.mark.parametrize(("nqubits", "ndevices"),
                          [(4, None), (5, None), (8, None),
@@ -218,6 +219,7 @@ def test_two_qubit_gates_controlled_by(backend, nqubits, ndevices):
         assert_gates_equivalent(qibo_gate, cirq_gate, nqubits, ndevices)
     qibo.set_backend(original_backend)
 
+
 @pytest.mark.parametrize("backend", _BACKENDS)
 @pytest.mark.parametrize("nqubits", [5, 12, 13, 14])
 @pytest.mark.parametrize("ntargets", [1, 2])
@@ -234,6 +236,7 @@ def test_unitary_matrix_gate_controlled_by(backend, nqubits, ntargets, ndevices)
         cirq_gate = [(cirq.MatrixGate(matrix).controlled(len(activeq) - ntargets), activeq)]
         assert_gates_equivalent(qibo_gate, cirq_gate, nqubits, ndevices)
     qibo.set_backend(original_backend)
+
 
 @pytest.mark.parametrize(("backend", "accelerators"),
                          [("custom", None), ("custom", {"/GPU:0": 4}),

--- a/src/qibo/tests/test_density_matrix.py
+++ b/src/qibo/tests/test_density_matrix.py
@@ -370,7 +370,7 @@ def test_circuit_with_noise_gates():
     c.add([gates.H(0), gates.H(1), gates.CNOT(0, 1)])
     noisy_c = c.with_noise((0.1, 0.2, 0.3))
 
-    assert noisy_c.depth == 6
+    assert noisy_c.depth == 5
     assert noisy_c.ngates == 9
     from qibo.tensorflow import gates as native_gates
     for i in [1, 2, 4, 5, 7, 8]:

--- a/src/qibo/tests/test_qasm.py
+++ b/src/qibo/tests/test_qasm.py
@@ -46,10 +46,13 @@ def test_simple_cirq():
     final_state_c1 = c1()
 
     c2 = circuit_from_qasm(c1.to_qasm())
+    c2depth = len(cirq.Circuit(c2.all_operations()))
+    assert c1.depth == c2depth
     final_state_c2 = cirq.Simulator().simulate(c2).final_state
     np.testing.assert_allclose(final_state_c1, final_state_c2, atol=_atol)
 
     c3 = Circuit.from_qasm(c2.to_qasm())
+    assert c3.depth == c2depth
     final_state_c3 = c3()
     np.testing.assert_allclose(final_state_c3, final_state_c2, atol=_atol)
 
@@ -101,10 +104,13 @@ def test_multiqubit_gates_cirq():
     final_state_c1 = c1()
 
     c2 = circuit_from_qasm(c1.to_qasm())
+    c2depth = len(cirq.Circuit(c2.all_operations()))
+    assert c1.depth == c2depth
     final_state_c2 = cirq.Simulator().simulate(c2).final_state
     np.testing.assert_allclose(final_state_c1, final_state_c2, atol=_atol)
 
     c3 = Circuit.from_qasm(c2.to_qasm())
+    assert c3.depth == c2depth
     final_state_c3 = c3()
     np.testing.assert_allclose(final_state_c3, final_state_c2, atol=_atol)
 
@@ -141,10 +147,13 @@ def test_toffoli_cirq():
     final_state_c1 = c1()
 
     c2 = circuit_from_qasm(c1.to_qasm())
+    c2depth = len(cirq.Circuit(c2.all_operations()))
+    assert c1.depth == c2depth
     final_state_c2 = cirq.Simulator().simulate(c2).final_state
     np.testing.assert_allclose(final_state_c1, final_state_c2, atol=_atol)
 
     c3 = Circuit.from_qasm(c2.to_qasm())
+    assert c3.depth == c2depth
     final_state_c3 = c3()
     np.testing.assert_allclose(final_state_c3, final_state_c2, atol=_atol)
 
@@ -169,6 +178,8 @@ def test_parametrized_gate_cirq():
     final_state_c1 = c1()
 
     c2 = circuit_from_qasm(c1.to_qasm())
+    c2depth = len(cirq.Circuit(c2.all_operations()))
+    assert c1.depth == c2depth
     final_state_c2 = cirq.Simulator().simulate(c2).final_state
     np.testing.assert_allclose(final_state_c1, final_state_c2, atol=_atol)
 
@@ -234,10 +245,13 @@ def test_ugates_cirq():
     final_state_c1 = c1()
 
     c2 = circuit_from_qasm(c1.to_qasm())
+    c2depth = len(cirq.Circuit(c2.all_operations()))
+    assert c1.depth == c2depth
     final_state_c2 = cirq.Simulator().simulate(c2).final_state
     np.testing.assert_allclose(final_state_c1, final_state_c2, atol=_atol)
 
     c3 = Circuit.from_qasm(c2.to_qasm())
+    assert c3.depth == c2depth
     final_state_c3 = c3()
     np.testing.assert_allclose(final_state_c3, final_state_c2, atol=_atol)
 

--- a/src/qibo/tests/test_qft.py
+++ b/src/qibo/tests/test_qft.py
@@ -34,7 +34,7 @@ def test_qft_sanity():
     """Check QFT circuit size and depth."""
     c = models.QFT(4)
     assert c.size == 4
-    assert c.depth == 9
+    assert c.depth == 8
     assert c.ngates == 12
 
 


### PR DESCRIPTION
Many thanks to @igres26 again for pointing out that the depth calculation was not correct. This PR fixes the issue and adds comparisons to depths calculated by Cirq in both `test_cirq.py` and `test_qasm.py` tests. 

If anyone has circuits available in either Qibo, Qasm or Cirq, we can cross-check that the depth calculated by Qibo agrees with Cirq in these cases as well.