### PR TITLE
Increasing examples timeout

### DIFF
--- a/.github/workflows/rules.yml
+++ b/.github/workflows/rules.yml
@@ -26,9 +26,12 @@ jobs:
     - name: Test with pylint
       run: |
         pylint src -E -d E1123,E1120
-    - name: Test with pytest
+    - name: Test with pytest core
       run: |
         pytest --cov=qibo --cov-report=xml --pyargs qibo
+    - name: Test examples
+      if: startsWith(matrix.os, 'ubuntu')
+      run: |
         pytest examples/
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v1

--- a/.github/workflows/rules.yml
+++ b/.github/workflows/rules.yml
@@ -34,6 +34,7 @@ jobs:
       run: |
         pytest examples/
     - name: Upload coverage to Codecov
+      if: startsWith(matrix.os, 'ubuntu')
       uses: codecov/codecov-action@v1
       with:
         token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/rules.yml
+++ b/.github/workflows/rules.yml
@@ -30,7 +30,7 @@ jobs:
       run: |
         pytest --cov=qibo --cov-report=xml --pyargs qibo
     - name: Test examples
-      if: startsWith(matrix.os, 'ubuntu')
+      if: startsWith(matrix.os, 'ubuntu') && matrix.python-version == '3.8'
       run: |
         pytest examples/
     - name: Upload coverage to Codecov

--- a/examples/conftest.py
+++ b/examples/conftest.py
@@ -1,2 +1,2 @@
 def pytest_addoption(parser):
-    parser.addoption("--examples-timeout", type=int, default=1000)
+    parser.addoption("--examples-timeout", type=int, default=200)

--- a/examples/conftest.py
+++ b/examples/conftest.py
@@ -1,2 +1,2 @@
 def pytest_addoption(parser):
-    parser.addoption("--examples-timeout", type=int, default=200)
+    parser.addoption("--examples-timeout", type=int, default=100000)

--- a/examples/conftest.py
+++ b/examples/conftest.py
@@ -1,2 +1,2 @@
 def pytest_addoption(parser):
-    parser.addoption("--examples-timeout", type=int, default=100)
+    parser.addoption("--examples-timeout", type=int, default=1000)


### PR DESCRIPTION
Here we increase the `--examples-timeout` flag when testing examples. I have switched off these tests for macos because this can takes up to 4h, while the virtual machines for linux takes ~1h50min.