### PR TITLE
Custom operator for normalization in Collapse gate

### DIFF
--- a/doc/source/examples.rst
+++ b/doc/source/examples.rst
@@ -180,14 +180,17 @@ Unmeasured qubits are ignored by the measurement objects. Also, the
 order that qubits appear in the results is defined by the order the user added
 the measurements and not the qubit ids.
 
-The measurement gate is only used to sample the measured bitstrings and does not
-have  any effect on the state vector. If the user wishes to access the full
-state vector of a circuit that was measured, this is possible using the
+If the user wishes to access the full state vector of a circuit that was
+measured, this is possible using the
 :py:attr:`qibo.base.circuit.BaseCircuit.final_state` property of circuits.
-There reasons that measurement gates do not affect the state are first that
-when more than one measurement shots are used, then the final collapsed state
-is not uniquely defined and second that the user may wish to resample the final
-state vector to obtain more shots, without having to re-execute the simulation.
+Note that the state vector accessed this way corresponds to the state as if no
+measurements occurred, that is the state is not collapsed during the measurement.
+This is because measurement gates are only used to sample bitstrings and do not
+have  any effect on the state vector. There are two reasons for this choice.
+First, when more than one measurement shots are used the final collapsed state
+is not uniquely defined as it would be different for each measurement result.
+Second the user may wish to re-sample the final state vector in order to
+obtain more measurement shots without having to re-execute the full simulation.
 
 For applications that require the state vector to be collapsed according to a
 single-shot measurement, Qibo provides the :class:`qibo.base.gates.Collapse`

--- a/src/qibo/tensorflow/custom_operators/cc/kernels/apply_gate.h
+++ b/src/qibo/tensorflow/custom_operators/cc/kernels/apply_gate.h
@@ -112,7 +112,7 @@ struct ApplyFsimFunctor : BaseTwoQubitGateFunctor<Device, T> {};
 template <typename Device, typename T>
 struct ApplySwapFunctor : BaseTwoQubitGateFunctor<Device, T> {};
 
-template <typename Device, typename T>
+template <typename Device, typename T, typename NormType>
 struct CollapseStateFunctor {
   void operator()(const OpKernelContext* context, const Device& d, T* state,
                   int nqubits, bool normalize, int ntargets,

--- a/src/qibo/tensorflow/custom_operators/cc/kernels/apply_gate.h
+++ b/src/qibo/tensorflow/custom_operators/cc/kernels/apply_gate.h
@@ -115,8 +115,8 @@ struct ApplySwapFunctor : BaseTwoQubitGateFunctor<Device, T> {};
 template <typename Device, typename T>
 struct CollapseStateFunctor {
   void operator()(const OpKernelContext* context, const Device& d, T* state,
-                  int nqubits, int ntargets, const int32* qubits,
-                  const int64* result) const;
+                  int nqubits, bool normalize, int ntargets,
+                  const int32* qubits, const int64* result) const;
 };
 
 }  // namespace functor

--- a/src/qibo/tensorflow/custom_operators/cc/kernels/apply_gate_kernels.cc
+++ b/src/qibo/tensorflow/custom_operators/cc/kernels/apply_gate_kernels.cc
@@ -14,6 +14,24 @@ namespace functor {
 
 using thread::ThreadPool;
 
+// Helper methods for complex numbers
+template <typename T>
+T cmult(T a, T b) {
+  return T(a.real() * b.real() - a.imag() * b.imag(),
+           a.real() * b.imag() + a.imag() * b.real());
+}
+
+template <typename T>
+T cadd(T a, T b) {
+  return T(a.real() + b.real(), a.imag() + b.imag());
+}
+
+template <typename T>
+double AbsSquare(T x) {
+  return x.real() * x.real() + x.imag() * x.imag();
+}
+
+
 template <typename T>
 struct BaseOneQubitGateFunctor<CPUDevice, T> {
   virtual void apply(T& state1, T& state2, const T* gate = NULL) const {}
@@ -64,17 +82,6 @@ struct BaseOneQubitGateFunctor<CPUDevice, T> {
     }
   }
 };
-
-template <typename T>
-T cmult(T a, T b) {
-  return T(a.real() * b.real() - a.imag() * b.imag(),
-           a.real() * b.imag() + a.imag() * b.real());
-}
-
-template <typename T>
-T cadd(T a, T b) {
-  return T(a.real() + b.real(), a.imag() + b.imag());
-}
 
 // Apply general one-qubit gate via gate matrix
 template <typename T>
@@ -261,10 +268,6 @@ struct CollapseStateFunctor<CPUDevice, T> {
         i += ((int64)((int)(h >> iq) % 2) * k);
       }
       return i;
-    };
-
-    auto AbsSquare = [&](T& x) {
-      return x.real() * x.real() + x.imag() * x.imag();
     };
 
     // Define vector that holds norms during parallel calculation

--- a/src/qibo/tensorflow/custom_operators/cc/kernels/apply_gate_kernels.cc
+++ b/src/qibo/tensorflow/custom_operators/cc/kernels/apply_gate_kernels.cc
@@ -272,10 +272,6 @@ struct CollapseStateFunctor<CPUDevice, T, NormType> {
     Eigen::Matrix<NormType, Eigen::Dynamic, 1> norms(nnorms);
     norms.setZero();
 
-    auto AbsSquare = [&](T x) {
-      return x.real() * x.real() + x.imag() * x.imag();
-    };
-
     auto ZeroState = [&](int64 t, int64 w) {
       int n = 0;
       if (nreps > 0) {
@@ -285,7 +281,8 @@ struct CollapseStateFunctor<CPUDevice, T, NormType> {
         for (auto h = 0; h < res; h++) {
           state[GetIndex(g, h)] = 0;
         }
-        norms[n] += AbsSquare(state[GetIndex(g, res)]);
+        auto x = state[GetIndex(g, res)];
+        norms[n] += x.real() * x.real() + x.imag() * x.imag();
         for (auto h = res + 1; h < nsubstates; h++) {
           state[GetIndex(g, h)] = 0;
         }

--- a/src/qibo/tensorflow/custom_operators/cc/kernels/apply_gate_kernels.cc
+++ b/src/qibo/tensorflow/custom_operators/cc/kernels/apply_gate_kernels.cc
@@ -275,7 +275,7 @@ struct CollapseStateFunctor<CPUDevice, T> {
     if (nreps > 0 && nstates / nreps > nnorms) {
       nnorms = nstates / nreps;
     }
-    Eigen::VectorXf norms(nnorms);
+    Eigen::VectorXd norms(nnorms);
     norms.setZero();
 
     auto ZeroState = [&](int64 t, int64 w) {

--- a/src/qibo/tensorflow/custom_operators/cc/kernels/apply_gate_kernels.cu.cc
+++ b/src/qibo/tensorflow/custom_operators/cc/kernels/apply_gate_kernels.cu.cc
@@ -549,8 +549,8 @@ __global__ void CollapseStateKernel(T* state, const int* qubits,
 template <typename T>
 struct CollapseStateFunctor<GPUDevice, T> {
   void operator()(const OpKernelContext* context, const GPUDevice& d, T* state,
-                  int nqubits, int ntargets, const int32* qubits,
-                  const int64* result) const {
+                  int nqubits, bool normalize, int ntargets,
+                  const int32* qubits, const int64* result) const {
     int64 nstates = (int64)1 << (nqubits - ntargets);
     int64 nsubstates = (int64)1 << ntargets;
 

--- a/src/qibo/tensorflow/custom_operators/cc/kernels/apply_gate_kernels.cu.cc
+++ b/src/qibo/tensorflow/custom_operators/cc/kernels/apply_gate_kernels.cu.cc
@@ -578,7 +578,7 @@ __global__ void VectorReductionKernel(NormType *g_idata, NormType *g_odata) {
   }
   // write result for this block to global mem
   if (tid == 0) {
-    g_odata[blockIdx.x] = sdata[0];
+    g_odata[blockIdx.x] = std::sqrt(sdata[0]);
   }
 }
 
@@ -592,7 +592,7 @@ __global__ void NormalizeCollapsedStateKernel(T* state, NormType* norms,
   const long result = results[0];
 
   auto NormalizeComponent = [&](T& x) {
-    x = T(x.real() / std::sqrt(norms[0]), x.imag() / std::sqrt(norms[0]));
+    x = T(x.real() / norms[0], x.imag() / norms[0]);
   };
   for (auto g = tid; g < nstates; g += stride) {
     NormalizeComponent(state[GetIndex(g, result, qubits, ntargets)]);
@@ -619,7 +619,7 @@ struct CollapseStateFunctor<GPUDevice, T, NormType> {
     if (normalize) {
       NormType *block_norms, *norms;
       cudaMalloc((void**)&block_norms, sizeof(NormType) * blockSize);
-      cudaMalloc((void**)&norms, sizeof(NormType) * blockSize);
+      cudaMalloc((void**)&norms, sizeof(NormType));
 
       CalculateCollapsedNormKernel<T, NormType><<<1, blockSize, 0, d.stream()>>>(
         state, block_norms, qubits, result, nstates, ntargets);

--- a/src/qibo/tensorflow/custom_operators/cc/kernels/apply_gate_kernels.cu.cc
+++ b/src/qibo/tensorflow/custom_operators/cc/kernels/apply_gate_kernels.cu.cc
@@ -612,8 +612,8 @@ __global__ void NormalizeCollapsedStateKernel(T* state, double* norms,
 }
 
 // Collapse state gate
-template <typename T>
-struct CollapseStateFunctor<GPUDevice, T> {
+template <typename T, typename NormType>
+struct CollapseStateFunctor<GPUDevice, T, NormType> {
   void operator()(const OpKernelContext* context, const GPUDevice& d, T* state,
                   int nqubits, bool normalize, int ntargets,
                   const int32* qubits, const int64* result) const {
@@ -653,6 +653,7 @@ struct CollapseStateFunctor<GPUDevice, T> {
   template struct FUNCTOR<GPUDevice, complex64>; \
   template struct FUNCTOR<GPUDevice, complex128>;
 
+
 REGISTER_TEMPLATE(BaseOneQubitGateFunctor);
 REGISTER_TEMPLATE(ApplyGateFunctor);
 REGISTER_TEMPLATE(ApplyXFunctor);
@@ -663,7 +664,8 @@ REGISTER_TEMPLATE(BaseTwoQubitGateFunctor);
 REGISTER_TEMPLATE(ApplyTwoQubitGateFunctor);
 REGISTER_TEMPLATE(ApplyFsimFunctor);
 REGISTER_TEMPLATE(ApplySwapFunctor);
-REGISTER_TEMPLATE(CollapseStateFunctor);
+template struct CollapseStateFunctor<GPUDevice, complex64, float>;
+template struct CollapseStateFunctor<GPUDevice, complex128, double>;
 }  // end namespace functor
 }  // end namespace tensorflow
 #endif  // GOOGLE_CUDA

--- a/src/qibo/tensorflow/custom_operators/cc/ops/custom_ops.cc
+++ b/src/qibo/tensorflow/custom_operators/cc/ops/custom_ops.cc
@@ -42,6 +42,7 @@ REGISTER_OP("CollapseState")            \
     .Input("qubits: int32")             \
     .Input("result: int64")             \
     .Attr("nqubits: int")               \
+    .Attr("normalize: bool")            \
     .Output("out: T")                   \
     .SetShapeFn(::tensorflow::shape_inference::UnchangedShape);
 

--- a/src/qibo/tensorflow/custom_operators/python/ops/qibo_tf_custom_operators.py
+++ b/src/qibo/tensorflow/custom_operators/python/ops/qibo_tf_custom_operators.py
@@ -64,8 +64,9 @@ apply_fsim = custom_module.apply_fsim
 apply_swap = custom_module.apply_swap
 
 def collapse_state(state, qubits, result, nqubits, normalize=True):
-    state = custom_module.collapse_state(state, qubits, result, nqubits)
-    if normalize:
-        norm = tf.reduce_sum(tf.math.square(tf.abs(state)))
-        return state / tf.cast(tf.math.sqrt(norm), dtype=state.dtype)
-    return state
+    return custom_module.collapse_state(state, qubits, result, nqubits)
+    #state = custom_module.collapse_state(state, qubits, result, nqubits)
+    #if normalize:
+    #    norm = tf.reduce_sum(tf.math.square(tf.abs(state)))
+    #    return state / tf.cast(tf.math.sqrt(norm), dtype=state.dtype)
+    #return state

--- a/src/qibo/tensorflow/custom_operators/python/ops/qibo_tf_custom_operators.py
+++ b/src/qibo/tensorflow/custom_operators/python/ops/qibo_tf_custom_operators.py
@@ -65,9 +65,4 @@ apply_fsim = custom_module.apply_fsim
 apply_swap = custom_module.apply_swap
 
 def collapse_state(state, qubits, result, nqubits, normalize=True):
-    state = custom_module.collapse_state(state, qubits, result, nqubits, normalize)
-    #if normalize and "GPU" in get_device(): # pragma: no cover
-    #    # case not covered by GitHub workflows because it requires GPU
-    #    norm = tf.reduce_sum(tf.math.square(tf.abs(state)))
-    #    return state / tf.cast(tf.math.sqrt(norm), dtype=state.dtype)
-    return state
+    return custom_module.collapse_state(state, qubits, result, nqubits, normalize)

--- a/src/qibo/tensorflow/custom_operators/python/ops/qibo_tf_custom_operators.py
+++ b/src/qibo/tensorflow/custom_operators/python/ops/qibo_tf_custom_operators.py
@@ -66,8 +66,8 @@ apply_swap = custom_module.apply_swap
 
 def collapse_state(state, qubits, result, nqubits, normalize=True):
     state = custom_module.collapse_state(state, qubits, result, nqubits, normalize)
-    if normalize and "GPU" in get_device(): # pragma: no cover
-        # case not covered by GitHub workflows because it requires GPU
-        norm = tf.reduce_sum(tf.math.square(tf.abs(state)))
-        return state / tf.cast(tf.math.sqrt(norm), dtype=state.dtype)
+    #if normalize and "GPU" in get_device(): # pragma: no cover
+    #    # case not covered by GitHub workflows because it requires GPU
+    #    norm = tf.reduce_sum(tf.math.square(tf.abs(state)))
+    #    return state / tf.cast(tf.math.sqrt(norm), dtype=state.dtype)
     return state

--- a/src/qibo/tensorflow/custom_operators/python/ops/qibo_tf_custom_operators.py
+++ b/src/qibo/tensorflow/custom_operators/python/ops/qibo_tf_custom_operators.py
@@ -64,7 +64,7 @@ apply_fsim = custom_module.apply_fsim
 apply_swap = custom_module.apply_swap
 
 def collapse_state(state, qubits, result, nqubits, normalize=True):
-    return custom_module.collapse_state(state, qubits, result, nqubits)
+    return custom_module.collapse_state(state, qubits, result, nqubits, normalize)
     #state = custom_module.collapse_state(state, qubits, result, nqubits)
     #if normalize:
     #    norm = tf.reduce_sum(tf.math.square(tf.abs(state)))

--- a/src/qibo/tensorflow/custom_operators/python/ops/qibo_tf_custom_operators.py
+++ b/src/qibo/tensorflow/custom_operators/python/ops/qibo_tf_custom_operators.py
@@ -4,6 +4,7 @@ import tensorflow as tf
 import numpy as np
 from tensorflow.python.framework import load_library
 from tensorflow.python.platform import resource_loader
+from qibo.config import get_device
 
 
 if tf.config.list_physical_devices("GPU"): # pragma: no cover
@@ -64,9 +65,9 @@ apply_fsim = custom_module.apply_fsim
 apply_swap = custom_module.apply_swap
 
 def collapse_state(state, qubits, result, nqubits, normalize=True):
-    return custom_module.collapse_state(state, qubits, result, nqubits, normalize)
-    #state = custom_module.collapse_state(state, qubits, result, nqubits)
-    #if normalize:
-    #    norm = tf.reduce_sum(tf.math.square(tf.abs(state)))
-    #    return state / tf.cast(tf.math.sqrt(norm), dtype=state.dtype)
-    #return state
+    state = custom_module.collapse_state(state, qubits, result, nqubits, normalize)
+    if normalize and "GPU" in get_device(): # pragma: no cover
+        # case not covered by GitHub workflows because it requires GPU
+        norm = tf.reduce_sum(tf.math.square(tf.abs(state)))
+        return state / tf.cast(tf.math.sqrt(norm), dtype=state.dtype)
+    return state

--- a/src/qibo/tests/test_custom_operators.py
+++ b/src/qibo/tests/test_custom_operators.py
@@ -299,10 +299,13 @@ def test_apply_swap_general(nqubits, targets, controls, compile):
 
 @pytest.mark.parametrize("nqubits,targets,results",
                          [(2, [0], [1]), (2, [1], [0]), (3, [1], [1]),
-                          (4, [1, 3], [1, 0]), (5, [1, 2, 4], [0, 1, 1])])
-def test_collapse_state(nqubits, targets, results):
+                          (4, [1, 3], [1, 0]), (5, [1, 2, 4], [0, 1, 1]),
+                          (15, [4, 7], [0, 0]), (16, [8, 12, 15], [1, 0, 1])])
+@pytest.mark.parametrize("dtype", [tf.float32, tf.float64])
+def test_collapse_state(nqubits, targets, results, dtype):
     """Check ``collapse_state`` kernel."""
-    state = utils.random_tensorflow_complex((2 ** nqubits,), dtype=tf.float64)
+    atol = 1e-7 if dtype == tf.float32 else 1e-14
+    state = utils.random_tensorflow_complex((2 ** nqubits,), dtype=dtype)
     slicer = nqubits * [slice(None)]
     for t, r in zip(targets, results):
         slicer[t] = r
@@ -317,7 +320,8 @@ def test_collapse_state(nqubits, targets, results):
     b2d = 2 ** np.arange(len(results) - 1, -1, -1)
     result = np.array(results).dot(b2d)
     state = op.collapse_state(state, qubits, result, nqubits)
-    np.testing.assert_allclose(state, target_state)
+    print((np.abs(state.numpy()) ** 2).sum())
+    np.testing.assert_allclose(state, target_state, atol=atol)
 
 
 # this test fails when compiling due to in-place updates of the state


### PR DESCRIPTION
As discussed in #262 this implements the state normalization required in the Collapse gate within the custom kernel instead of using Tensorflow primitives. Performance is very close to using the tf norm:

nqubits | Collapse with tf norm | Collapse with custom norm 
-- | -- | --
27 | 0.56978 | 0.51419
28 | 1.06392 | 0.85471
29 | 2.01795 | 1.91229
30 | 4.01938 | 3.68727
31 | 7.89229 | 7.67427
32 | 15.8202 | 14.4606

however the custom norm is more stable in terms of RAM usage and uses the memory required for a single state copy. For example at 32 qubits double precision the custom norm uses 64GB, while the tf norm goes up to 120GB.

Currently the custom norm is implemented for CPU only and works with multi-threading. There are two issues to resolve (decide how to approach):

* Regarding GPU, after a look at the [reduction slides](https://developer.download.nvidia.com/assets/cuda/files/reduction.pdf), it seems to me that we need a copy of the vector in order to calculate its sum using reduction methods. The reason is that half of the elements of the original array are modified in order to calculate the sum, so this operation cannot be done in-place. With this in mind, I am not sure if we would get over the current `tf.reduce_sum` implementation both in terms of memory and performance. In fact this may be one of the reasons that Tensorflow (which is GPU oriented) avoids in-place updates?

* Regarding the distributed implementation, as I mentioned in #262, we cannot do the normalization in parallel in each device because the total norm is the sum of "norms" of each device piece. For this I have a `normalize` flag inside the `Collapse` gate which is always `True` except for the case that this gate is used in a distributed circuit where normalization is handled separately. Currently this normalization happens on CPU using `tf.reduce_sum`. There are various ways this could be improved, either by doing this on GPU (I am not sure about the communication overhead) or writing a separate custom norm operator for CPU, I am just not sure if this is sufficiently important to complicate at this stage to complicate our code-base with more custom operators.