### PR TITLE
Remove references to state vector to avoid OOM errors

### DIFF
--- a/src/qibo/base/measurements.py
+++ b/src/qibo/base/measurements.py
@@ -14,9 +14,6 @@ class GateResult:
 
     Args:
         qubits: Sorted tuple of qubit ids that the measurement gate acts on.
-        state: Reference to the tensor that holds the state that was sampled.
-            The state should have shape ``nqubits * (2,)`` if it is a state vector
-            or ``2 * nqubits * (2,)`` if it is a density matrix.
         decimal_samples: Tensor holding the measured samples in decimal
             representation. Has shape (nshots,).
         binary_samples: Tensor holding the measured samples in binary
@@ -26,11 +23,9 @@ class GateResult:
     """
 
     def __init__(self, qubits: Tuple[int],
-                 state: Optional[TensorType] = None,
                  decimal_samples: Optional[TensorType] = None,
                  binary_samples: Optional[TensorType] = None):
         self.qubits = qubits
-        self.sampled_state = state
 
         if decimal_samples is not None and binary_samples is not None:
             raise_error(ValueError, "Measurement result object cannot be created "

--- a/src/qibo/tensorflow/cgates.py
+++ b/src/qibo/tensorflow/cgates.py
@@ -242,7 +242,7 @@ class M(TensorflowGate, base_gates.M):
         if samples_only:
             return samples_dec
         return self.measurements.GateResult(
-            self.qubits, state, decimal_samples=samples_dec)
+            self.qubits, decimal_samples=samples_dec)
 
 
 class RX(MatrixGate, base_gates.RX):

--- a/src/qibo/tensorflow/circuit.py
+++ b/src/qibo/tensorflow/circuit.py
@@ -116,7 +116,7 @@ class TensorflowCircuit(circuit.BaseCircuit):
                                         is_density_matrix=self.using_density_matrix)
 
         self.measurement_gate_result = measurements.GateResult(
-            self.measurement_gate.qubits, state, decimal_samples=samples)
+            self.measurement_gate.qubits, decimal_samples=samples)
         return measurements.CircuitResult(
             self.measurement_tuples, self.measurement_gate_result)
 

--- a/src/qibo/tensorflow/circuit.py
+++ b/src/qibo/tensorflow/circuit.py
@@ -198,7 +198,8 @@ class TensorflowCircuit(circuit.BaseCircuit):
         if isinstance(state, tf.Tensor):
             return state
         elif isinstance(state, np.ndarray):
-            return tf.cast(state, dtype=DTYPES.get('DTYPECPX'))
+            return tf.cast(state.astype(DTYPES.get('NPTYPECPX')),
+                           dtype=DTYPES.get('DTYPECPX'))
         raise_error(TypeError, "Initial state type {} is not recognized."
                                 "".format(type(state)))
 

--- a/src/qibo/tensorflow/circuit.py
+++ b/src/qibo/tensorflow/circuit.py
@@ -89,6 +89,7 @@ class TensorflowCircuit(circuit.BaseCircuit):
                  nshots: Optional[int] = None) -> OutputType:
         """Performs ``circuit.execute`` on specified device."""
         self.using_density_matrix = False
+        self._final_state = None
         state = self.get_initial_state(initial_state)
 
         if self.using_tfgates:

--- a/src/qibo/tensorflow/distcircuit.py
+++ b/src/qibo/tensorflow/distcircuit.py
@@ -185,6 +185,7 @@ class TensorflowDistributedCircuit(circuit.TensorflowCircuit):
     def _execute(self, initial_state: Optional[InitStateType] = None,
                  nshots: Optional[int] = None) -> OutputType:
         """Performs ``circuit.execute``."""
+        self._final_state = None
         state = self.get_initial_state(initial_state)
 
         special_gates = iter(self.queues.special_queue)

--- a/src/qibo/tensorflow/distcircuit.py
+++ b/src/qibo/tensorflow/distcircuit.py
@@ -209,7 +209,7 @@ class TensorflowDistributedCircuit(circuit.TensorflowCircuit):
             samples = self.measurement_gate(state.vector, nshots, samples_only=True,
                                             is_density_matrix=self.using_density_matrix)
             self.measurement_gate_result = measurements.GateResult(
-                self.measurement_gate.qubits, state, decimal_samples=samples)
+                self.measurement_gate.qubits, decimal_samples=samples)
             result = measurements.CircuitResult(
                 self.measurement_tuples, self.measurement_gate_result)
         return result


### PR DESCRIPTION
As discussed this removes the references to the state tensor before executing a circuit to avoid OOM errors when a circuit is executed multiple times on the same script. Note that if the user uses an additional reference to the final state (eg. `state = circuit()`, then `state` should also be deleted manually (`del(state)`) to avoid OOMs.

I tested this and it works when the default initial state is used. The situation is a bit more complicated when using a custom initial state. For example
```Python
initial_state = tf.zeros(2 ** nqubits, dtype=tf.complex128)
for i in range(nreps):
    initial_state = tf.zeros(2 ** nqubits, dtype=tf.complex128)
    state = circuit(initial_state)
    del(state)
```
works, however
```Python
for i in range(nreps):
    initial_state = tf.zeros(2 ** nqubits, dtype=tf.complex128)
    state = circuit(initial_state)
    del(state)
```
runs out of memory for nreps > 1 when `nqubits` is the maximum the GPU can run in single rep. 

I also noticed that using numpy array for initialization leads to OOM if the numpy dtype is different than the tf dtype used in Qibo. I added an `.astype` in the casting function to fix this issue.