### PR TITLE
Use tf primitives for GPU allocation

### DIFF
--- a/src/qibo/tensorflow/custom_operators/cc/kernels/apply_gate.h
+++ b/src/qibo/tensorflow/custom_operators/cc/kernels/apply_gate.h
@@ -114,7 +114,7 @@ struct ApplySwapFunctor : BaseTwoQubitGateFunctor<Device, T> {};
 
 template <typename Device, typename T, typename NormType>
 struct CollapseStateFunctor {
-  void operator()(const OpKernelContext* context, const Device& d, T* state,
+  void operator()(OpKernelContext* context, const Device& d, T* state,
                   int nqubits, bool normalize, int ntargets,
                   const int32* qubits, const int64* result) const;
 };

--- a/src/qibo/tensorflow/custom_operators/cc/kernels/apply_gate_kernels.cc
+++ b/src/qibo/tensorflow/custom_operators/cc/kernels/apply_gate_kernels.cc
@@ -233,7 +233,7 @@ struct ApplySwapFunctor<CPUDevice, T> : BaseTwoQubitGateFunctor<CPUDevice, T> {
 // Apply Collapse gate
 template <typename T, typename NormType>
 struct CollapseStateFunctor<CPUDevice, T, NormType> {
-  void operator()(const OpKernelContext* context, const CPUDevice& d, T* state,
+  void operator()(OpKernelContext* context, const CPUDevice& d, T* state,
                   int nqubits, bool normalize, int ntargets,
                   const int32* qubits, const int64* result) const {
     int64 nstates = (int64)1 << (nqubits - ntargets);


### PR DESCRIPTION
Replaces cudaMalloc/cudaFree with temporary Tensors.