### PR TITLE
Thermal relaxation error channel

### DIFF
--- a/doc/source/advancedexamples.rst
+++ b/doc/source/advancedexamples.rst
@@ -625,12 +625,11 @@ initial density matrix by passing the corresponding array when executing the
 circuit. If a state vector is passed as an initial state in a density matrix
 circuit, it will be transformed automatically to the equivalent density matrix.
 
-Qibo currently provides the following channels that can be used during a
-density matrix simulation: :class:`qibo.base.gates.KrausChannel`,
-:class:`qibo.base.gates.UnitaryChannel` and
-:class:`qibo.base.gates.PauliNoiseChannel`.
-We refer to the documentation of each channel for more details.
-Noise can be simulated using these channels, for example:
+Additionally, Qibo provides several gates that represent channels which can
+be used during a density matrix simulation. We refer to the
+:ref:`Channels <Channels>` section of the documentation for a complete list of
+the available channels. Noise can be simulated using these channels,
+for example:
 
 .. code-block:: python
 

--- a/doc/source/qibo.rst
+++ b/doc/source/qibo.rst
@@ -163,8 +163,8 @@ _______________________
 Gates
 -----
 
-All supported gates can be accessed from the `qibo.gates` module and inherit
-the base gate object :class:`qibo.base.gates.Gate`. Read bellow for a complete
+All supported gates can be accessed from the ``qibo.gates`` module and inherit
+the base gate object :class:`qibo.base.gates.Gate`. Read below for a complete
 list of supported gates.
 
 All gates support the ``controlled_by`` method that allows to control
@@ -186,7 +186,13 @@ _______________________
 Channels
 --------
 
-Write something here
+Channels are implemented in Qibo as additional gates and can be accessed from
+the ``qibo.gates`` module. Channels can be used on density matrices to perform
+noisy simulations. Channels that inherit :class:`qibo.base.gates.UnitaryChannel`
+can also be applied to state vectors using sampling and repeated execution.
+For more information on the use of channels to simulate noise we refer to
+:ref:`How to perform noisy simulation? <noisy-example>`
+The following channels are currently implemented:
 
 .. autoclass:: qibo.base.gates.KrausChannel
     :members:

--- a/doc/source/qibo.rst
+++ b/doc/source/qibo.rst
@@ -177,6 +177,32 @@ the gate on an arbitrary number of qubits. For example
 .. automodule:: qibo.base.gates
    :members:
    :member-order: bysource
+   :exclude-members: KrausChannel, UnitaryChannel, PauliNoiseChannel, ResetChannel, ThermalRelaxationChannel
+
+_______________________
+
+.. _Channels:
+
+Channels
+--------
+
+Write something here
+
+.. autoclass:: qibo.base.gates.KrausChannel
+    :members:
+    :member-order: bysource
+.. autoclass:: qibo.base.gates.UnitaryChannel
+    :members:
+    :member-order: bysource
+.. autoclass:: qibo.base.gates.PauliNoiseChannel
+    :members:
+    :member-order: bysource
+.. autoclass:: qibo.base.gates.ResetChannel
+    :members:
+    :member-order: bysource
+.. autoclass:: qibo.base.gates.ThermalRelaxationChannel
+    :members:
+    :member-order: bysource
 
 _______________________
 

--- a/src/qibo/base/circuit.py
+++ b/src/qibo/base/circuit.py
@@ -432,7 +432,7 @@ class BaseCircuit(object):
             self._add_measurement(gate)
         elif isinstance(gate, gates.VariationalLayer):
             self._add_layer(gate)
-        elif (isinstance(gate, (gates.UnitaryChannel, gates.ResetChannel)) and
+        elif (isinstance(gate, gates.UnitaryChannel) and
               not self.density_matrix):
             self.repeated_execution = True
             self.queue.append(gate)

--- a/src/qibo/base/circuit.py
+++ b/src/qibo/base/circuit.py
@@ -432,7 +432,8 @@ class BaseCircuit(object):
             self._add_measurement(gate)
         elif isinstance(gate, gates.VariationalLayer):
             self._add_layer(gate)
-        elif isinstance(gate, gates.UnitaryChannel) and not self.density_matrix:
+        elif (isinstance(gate, (gates.UnitaryChannel, gates.ResetChannel)) and
+              not self.density_matrix):
             self.repeated_execution = True
             self.queue.append(gate)
         else:

--- a/src/qibo/base/gates.py
+++ b/src/qibo/base/gates.py
@@ -1826,3 +1826,20 @@ class PauliNoiseChannel(UnitaryChannel):
 
         self.init_args = [q]
         self.init_kwargs = {"px": px, "py": py, "pz": pz, "seed": seed}
+
+
+class ResetChannel(UnitaryChannel):
+
+    def __init__(self, *q, p0=0.0, p1=0.0, seed=None):
+        probs, gates = [], []
+        for r, p in enumerate([p0, p1]):
+            if p > 0:
+                probs.append(p)
+                gates.append(gates.Collapse(*q, result=r))
+
+        super(ResetChannel, self).__init__(probs, gates, seed=seed)
+        self.name = "ResetChannel"
+        assert self.target_qubits == tuple(q)
+
+        self.init_args = [q]
+        self.init_kwargs = {"p0": p0, "p1": p1, "seed": seed}

--- a/src/qibo/base/gates.py
+++ b/src/qibo/base/gates.py
@@ -1669,23 +1669,6 @@ class CallbackGate(Gate):
         self.callback.nqubits = n
 
 
-class ResetChannel(Gate):
-
-    def __init__(self, q, p0=0.0, p1=0.0, seed=None):
-        super(ResetChannel, self).__init__()
-        self.name = "ResetChannel"
-        self.target_qubits == (q,)
-        self.seed = seed
-
-        self.p0, self.p1 = p0, p1
-        self.psum = p0 + p1
-        self.collapse = self.module.Collapse(q)
-        self.flip = self.module.X(q)
-
-        self.init_args = [q]
-        self.init_kwargs = {"p0": p0, "p1": p1, "seed": seed}
-
-
 class KrausChannel(Gate):
     """General channel defined by arbitrary Krauss operators.
 
@@ -1845,6 +1828,19 @@ class PauliNoiseChannel(UnitaryChannel):
         self.init_kwargs = {"px": px, "py": py, "pz": pz, "seed": seed}
 
 
+class ResetChannel(UnitaryChannel):
+
+    def __init__(self, q, p0=0.0, p1=0.0, seed=None):
+        probs = [p0, p1]
+        gates = [self.module.Collapse(q), self.module.X(q)]
+        super(ResetChannel, self).__init__(probs, gates, seed=seed)
+        self.name = "ResetChannel"
+        assert self.target_qubits == (q,)
+
+        self.init_args = [q]
+        self.init_kwargs = {"p0": p0, "p1": p1, "seed": seed}
+
+
 class ThermalRelaxationChannel(UnitaryChannel):
 
     def __init__(self, q, t1, t2, time, excited_population=0, seed=None):
@@ -1869,9 +1865,11 @@ class ThermalRelaxationChannel(UnitaryChannel):
         if time < 0:
             raise_error(ValueError, "Invalid gate_time ({} < 0)".format(time))
         if t1 <= 0:
-            raise_error(ValueError, "Invalid T_1 relaxation time parameter: T_1 <= 0.")
+            raise_error(ValueError, "Invalid T_1 relaxation time parameter: "
+                                    "T_1 <= 0.")
         if t2 <= 0:
-            raise_error(ValueError, "Invalid T_2 relaxation time parameter: T_2 <= 0.")
+            raise_error(ValueError, "Invalid T_2 relaxation time parameter: "
+                                    "T_2 <= 0.")
         if t2 - 2 * t1 > 0:
             raise_error(ValueError, "Invalid T_2 relaxation time parameter: "
                                     "T_2 greater than 2 * T_1.")

--- a/src/qibo/base/gates.py
+++ b/src/qibo/base/gates.py
@@ -1934,10 +1934,6 @@ class ThermalRelaxationChannel:
             instead of density matrices is used to simulate this gate.
     """
 
-    def __new__(cls, q, t1, t2, time, excited_population=0, seed=None):
-        # abstract method
-        raise_error(NotImplementedError)
-
     def __init__(self, q, t1, t2, time, excited_population=0, seed=None):
         self.name = "ThermalRelaxationChannel"
         self.init_args = [q, t1, t2, time]

--- a/src/qibo/base/gates.py
+++ b/src/qibo/base/gates.py
@@ -1871,7 +1871,29 @@ class PauliNoiseChannel(UnitaryChannel):
 
 
 class ResetChannel(UnitaryChannel):
-    # TODO: Add docstring
+    """Single-qubit reset channel.
+
+    Implements the following transformation:
+
+    .. math::
+        \\mathcal{E}(\\rho ) = (1 - p_0 - p_1) \\rho +
+        + p_0 (|0\\rangle \\langle 0| \\otimes \\tilde{\\rho })
+        + p_1 (|1\\rangle \langle 1| \otimes \\tilde{\\rho })
+
+    with
+
+    .. math::
+        \\tilde{\\rho } = \\frac{\langle 0|\\rho |0\\rangle }{\mathrm{Tr}\langle 0|\\rho |0\\rangle}
+
+    using :class:`qibo.base.gates.Collapse`.
+
+    Args:
+        q (int): Qubit id that the channel acts on.
+        p0 (float): Probability to reset to 0.
+        p1 (float): Probability to reset to 1.
+        seed (int): Optional seed for the random number generator when sampling
+            instead of density matrices is used to simulate this gate.
+    """
 
     def __init__(self, q, p0=0.0, p1=0.0, seed=None):
         probs = [p0, p1]
@@ -1893,8 +1915,8 @@ class ThermalRelaxationChannel:
 
     .. math::
         \\mathcal{E} [\\rho ] = (1 - p_z - p_0 - p_1)\\rho + p_zZ\\rho Z
-        + p_0 (|0\\rangle \\langle 0|) \\otimes \\tilde{\\rho }
-        + p_1 (|1\\rangle \langle 1|) \otimes \\tilde{\\rho }
+        + p_0 (|0\\rangle \\langle 0| \\otimes \\tilde{\\rho })
+        + p_1 (|1\\rangle \langle 1| \otimes \\tilde{\\rho })
 
     with
 

--- a/src/qibo/base/gates.py
+++ b/src/qibo/base/gates.py
@@ -1802,7 +1802,7 @@ class UnitaryChannel(KrausChannel):
         p (list): List of floats that correspond to the probability that each
             unitary Uk is applied.
         gates (list): List of  operators as pairs ``(qubits, Uk)`` where
-            ``qubits``refers the qubit ids that ``Uk`` acts on and ``Uk`` is
+            ``qubits`` refers the qubit ids that ``Uk`` acts on and ``Uk`` is
             the corresponding matrix as a ``np.ndarray``/``tf.Tensor``.
             Must have the same length as the given probabilities ``p``.
         seed (int): Optional seed for the random number generator when sampling
@@ -1871,6 +1871,7 @@ class PauliNoiseChannel(UnitaryChannel):
 
 
 class ResetChannel(UnitaryChannel):
+    # TODO: Add docstring
 
     def __init__(self, q, p0=0.0, p1=0.0, seed=None):
         probs = [p0, p1]
@@ -1884,8 +1885,54 @@ class ResetChannel(UnitaryChannel):
 
 
 class ThermalRelaxationChannel:
-    # T1 relaxation rate
-    # T2 dephasing rate
+    """Single-qubit thermal relaxation error channel.
+
+    Implements the following transformation:
+
+    If :math:`T_1 \\geq T_2`:
+
+    .. math::
+        \\mathcal{E} [\\rho ] = (1 - p_z - p_0 - p_1)\\rho + p_zZ\\rho Z
+        + p_0 (|0\\rangle \\langle 0|) \\otimes \\tilde{\\rho }
+        + p_1 (|1\\rangle \langle 1|) \otimes \\tilde{\\rho }
+
+    with
+
+    .. math::
+        \\tilde{\\rho } = \\frac{\langle 0|\\rho |0\\rangle }{\mathrm{Tr}\langle 0|\\rho |0\\rangle}
+
+    while if :math:`T_1 < T_2`:
+
+    .. math::
+        \\mathcal{E}(\\rho ) = \\mathrm{Tr} _\\mathcal{X}\\left [\\Lambda _{\\mathcal{X}\\mathcal{Y}}(\\rho _\\mathcal{X} ^T \\otimes \\mathbb{I}_\\mathcal{Y})\\right ]
+
+    with
+
+    .. math::
+        \\Lambda = \\begin{pmatrix}
+        1 - p_1 & 0 & 0 & e^{-t / T_2} \\\\
+        0 & p_1 & 0 & 0 \\\\
+        0 & 0 & p_0 & 0 \\\\
+        e^{-t / T_2} & 0 & 0 & 1 - p_0
+        \\end{pmatrix}
+
+    where :math:`p_0 = (1 - e^{-t / T_1})(1 - \\eta )` :math:`p_1 = (1 - e^{-t / T_1})\\eta`
+    and :math:`p_z = 1 - e^{-t / T_1} + e^{-t / T_2} - e^{t / T_1 - t / T_2}`.
+    Here :math:`\\eta` is the ``excited_population``
+    and :math:`t` is the ``time``, both controlled by the user.
+    This gate is based on
+    `Qiskit's thermal relaxation error channel <https://qiskit.org/documentation/stubs/qiskit.providers.aer.noise.thermal_relaxation_error.html#qiskit.providers.aer.noise.thermal_relaxation_error>`_.
+
+    Args:
+        q (int): Qubit id that the noise channel acts on.
+        t1 (float): T1 relaxation time.
+        t2 (float): T2 dephasing time.
+        time (float): the gate time for relaxation error.
+        excited_population (float): the population of the excited state at
+            equilibrium. Default is 0.
+        seed (int): Optional seed for the random number generator when sampling
+            instead of density matrices is used to simulate this gate.
+    """
 
     def __new__(cls, q, t1, t2, time, excited_population=0, seed=None):
         # abstract method

--- a/src/qibo/base/gates.py
+++ b/src/qibo/base/gates.py
@@ -1669,6 +1669,23 @@ class CallbackGate(Gate):
         self.callback.nqubits = n
 
 
+class ResetChannel(Gate):
+
+    def __init__(self, q, p0=0.0, p1=0.0, seed=None):
+        super(ResetChannel, self).__init__()
+        self.name = "ResetChannel"
+        self.target_qubits == (q,)
+        self.seed = seed
+
+        self.p0, self.p1 = p0, p1
+        self.psum = p0 + p1
+        self.collapse = self.module.Collapse(q)
+        self.flip = self.module.X(q)
+
+        self.init_args = [q]
+        self.init_kwargs = {"p0": p0, "p1": p1, "seed": seed}
+
+
 class KrausChannel(Gate):
     """General channel defined by arbitrary Krauss operators.
 
@@ -1826,20 +1843,3 @@ class PauliNoiseChannel(UnitaryChannel):
 
         self.init_args = [q]
         self.init_kwargs = {"px": px, "py": py, "pz": pz, "seed": seed}
-
-
-class ResetChannel(UnitaryChannel):
-
-    def __init__(self, *q, p0=0.0, p1=0.0, seed=None):
-        probs, gates = [], []
-        for r, p in enumerate([p0, p1]):
-            if p > 0:
-                probs.append(p)
-                gates.append(gates.Collapse(*q, result=r))
-
-        super(ResetChannel, self).__init__(probs, gates, seed=seed)
-        self.name = "ResetChannel"
-        assert self.target_qubits == tuple(q)
-
-        self.init_args = [q]
-        self.init_kwargs = {"p0": p0, "p1": p1, "seed": seed}

--- a/src/qibo/base/gates.py
+++ b/src/qibo/base/gates.py
@@ -178,6 +178,7 @@ class Gate(object):
         self._nqubits = n
         self._nstates = 2**n
         self._calculate_qubits_tensor()
+        self._calculate_einsum_cache()
         self._prepare()
 
     @property
@@ -235,7 +236,11 @@ class Gate(object):
         return self.__matmul__(other)
 
     def _calculate_qubits_tensor(self):
-        """Calculates ``qubits`` tensor required for applying gates using custom operators."""
+        """Calculates qubits tensor required for applying gates using custom operators."""
+        pass
+
+    def _calculate_einsum_cache(self):
+        """Calculates einsum cache required for applying gates using Tensorflow ops."""
         pass
 
     def _prepare(self): # pragma: no cover

--- a/src/qibo/base/gates.py
+++ b/src/qibo/base/gates.py
@@ -1876,7 +1876,7 @@ class ResetChannel(UnitaryChannel):
     Implements the following transformation:
 
     .. math::
-        \\mathcal{E}(\\rho ) = (1 - p_0 - p_1) \\rho +
+        \\mathcal{E}(\\rho ) = (1 - p_0 - p_1) \\rho
         + p_0 (|0\\rangle \\langle 0| \\otimes \\tilde{\\rho })
         + p_1 (|1\\rangle \langle 1| \otimes \\tilde{\\rho })
 
@@ -1947,8 +1947,9 @@ class ThermalRelaxationChannel:
 
     Args:
         q (int): Qubit id that the noise channel acts on.
-        t1 (float): T1 relaxation time.
+        t1 (float): T1 relaxation time. Should satisfy ``t1 > 0``.
         t2 (float): T2 dephasing time.
+            Should satisfy ``t1 > 0`` and ``t2 < 2 * t1``.
         time (float): the gate time for relaxation error.
         excited_population (float): the population of the excited state at
             equilibrium. Default is 0.

--- a/src/qibo/base/gates.py
+++ b/src/qibo/base/gates.py
@@ -1893,7 +1893,6 @@ class ThermalRelaxationChannel:
 
     def __init__(self, q, t1, t2, time, excited_population=0, seed=None):
         self.name = "ThermalRelaxationChannel"
-        assert self.target_qubits == (q,)
         self.init_args = [q, t1, t2, time]
         self.init_kwargs = {"excited_population": excited_population,
                             "seed": seed}
@@ -1941,6 +1940,7 @@ class _ThermalRelaxationChannelA(UnitaryChannel):
         ThermalRelaxationChannel.__init__(
             self, q, t1, t2, time, excited_population=excited_population,
             seed=seed)
+        assert self.target_qubits == (q,)
 
 
 class _ThermalRelaxationChannelB(Gate):

--- a/src/qibo/base/gates.py
+++ b/src/qibo/base/gates.py
@@ -1914,7 +1914,7 @@ class ThermalRelaxationChannel:
     If :math:`T_1 \\geq T_2`:
 
     .. math::
-        \\mathcal{E} [\\rho ] = (1 - p_z - p_0 - p_1)\\rho + p_zZ\\rho Z
+        \\mathcal{E} (\\rho ) = (1 - p_z - p_0 - p_1)\\rho + p_zZ\\rho Z
         + p_0 (|0\\rangle \\langle 0| \\otimes \\tilde{\\rho })
         + p_1 (|1\\rangle \langle 1| \otimes \\tilde{\\rho })
 

--- a/src/qibo/tensorflow/cgates.py
+++ b/src/qibo/tensorflow/cgates.py
@@ -709,7 +709,7 @@ class CallbackGate(TensorflowGate, base_gates.CallbackGate):
 class KrausChannel(TensorflowGate, base_gates.KrausChannel):
 
     def __init__(self, gates: Sequence[Tuple[Tuple[int], np.ndarray]]):
-        self.module.TensorflowGate.__init__(self)
+        TensorflowGate.__init__(self)
         base_gates.KrausChannel.__init__(self, gates)
         # create inversion gates to rest to the original state vector
         # because of the in-place updates used in custom operators
@@ -756,7 +756,7 @@ class UnitaryChannel(KrausChannel, base_gates.UnitaryChannel):
 
     def __init__(self, p: List[float], gates: List["Gate"],
                  seed: Optional[int] = None):
-        self.module.TensorflowGate.__init__(self)
+        TensorflowGate.__init__(self)
         base_gates.UnitaryChannel.__init__(self, p, gates, seed=seed)
         self.inv_gates = tuple()
 
@@ -790,7 +790,7 @@ class PauliNoiseChannel(UnitaryChannel, base_gates.PauliNoiseChannel):
 
     def __init__(self, q: int, px: float = 0, py: float = 0, pz: float = 0,
                  seed: Optional[int] = None):
-        self.module.TensorflowGate.__init__(self)
+        TensorflowGate.__init__(self)
         base_gates.PauliNoiseChannel.__init__(self, q, px, py, pz, seed=seed)
         self.inv_gates = tuple()
 
@@ -804,7 +804,7 @@ class ResetChannel(UnitaryChannel, base_gates.ResetChannel):
 
     def __init__(self, q: int, p0: float = 0.0, p1: float = 0.0,
                  seed: Optional[int] = None):
-        self.module.TensorflowGate.__init__(self)
+        TensorflowGate.__init__(self)
         base_gates.ResetChannel.__init__(self, q, p0=p0, p1=p1, seed=seed)
         self.inv_gates = tuple()
 
@@ -830,7 +830,7 @@ class ResetChannel(UnitaryChannel, base_gates.ResetChannel):
 class ThermalRelaxationChannel(ResetChannel, base_gates.ThermalRelaxationChannel):
 
     def __init__(self, q, t1, t2, time, excited_population=0, seed=None):
-        self.module.TensorflowGate.__init__(self)
+        TensorflowGate.__init__(self)
         base_gates.ThermalRelaxationChannel.__init__(
             self, q, t1, t2, time, excited_population=excited_population,
             seed=seed)

--- a/src/qibo/tensorflow/cgates.py
+++ b/src/qibo/tensorflow/cgates.py
@@ -803,8 +803,7 @@ class ResetChannel(UnitaryChannel, base_gates.ResetChannel):
         base_gates.ResetChannel.__init__(self, *q, p0=p0, p1=p1, seed=seed)
 
     def _density_matrix_call(self, state: tf.Tensor) -> tf.Tensor:
-        collapsed_states = []
-        for p, gate in self.gates:
-            collapsed_states.append(tf.zeros_like(state) + state)
-            collapsed_states[-1] = p * gate(collapsed_states[-1])
-        return (1 - self.total_p) * state + sum(collapsed_states)
+        new_state = tf.zeros_like(state)
+        for p, gate, inv_gate in zip(self.probs, self.gates, self.inv_gates):
+            new_state += p * gate(state + tf.zeros_like(state))
+        return (1 - self.psum) * state + new_state

--- a/src/qibo/tensorflow/cgates.py
+++ b/src/qibo/tensorflow/cgates.py
@@ -827,11 +827,24 @@ class ResetChannel(UnitaryChannel, base_gates.ResetChannel):
         return state
 
 
-class ThermalRelaxationChannel(ResetChannel, base_gates.ThermalRelaxationChannel):
+class ThermalRelaxationChannel(TensorflowGate, base_gates.ThermalRelaxationChannel):
+
+    def __new__(cls, q, t1, t2, time, excited_population=0, seed=None):
+        if t2 > t1:
+            return _ThermalRelaxationChannelB(
+                q, t1, t2, time, excited_population=excited_population,
+                seed=seed)
+        else:
+            return _ThermalRelaxationChannelA(
+                q, t1, t2, time, excited_population=excited_population,
+                seed=seed)
+
+
+class _ThermalRelaxationChannelA(ResetChannel, base_gates._ThermalRelaxationChannelA):
 
     def __init__(self, q, t1, t2, time, excited_population=0, seed=None):
         TensorflowGate.__init__(self)
-        base_gates.ThermalRelaxationChannel.__init__(
+        base_gates._ThermalRelaxationChannelA.__init__(
             self, q, t1, t2, time, excited_population=excited_population,
             seed=seed)
         self.inv_gates = tuple()

--- a/src/qibo/tensorflow/cgates.py
+++ b/src/qibo/tensorflow/cgates.py
@@ -709,7 +709,7 @@ class CallbackGate(TensorflowGate, base_gates.CallbackGate):
 class KrausChannel(TensorflowGate, base_gates.KrausChannel):
 
     def __init__(self, gates: Sequence[Tuple[Tuple[int], np.ndarray]]):
-        TensorflowGate.__init__(self)
+        self.module.TensorflowGate.__init__(self)
         base_gates.KrausChannel.__init__(self, gates)
         # create inversion gates to rest to the original state vector
         # because of the in-place updates used in custom operators
@@ -756,7 +756,7 @@ class UnitaryChannel(KrausChannel, base_gates.UnitaryChannel):
 
     def __init__(self, p: List[float], gates: List["Gate"],
                  seed: Optional[int] = None):
-        TensorflowGate.__init__(self)
+        self.module.TensorflowGate.__init__(self)
         base_gates.UnitaryChannel.__init__(self, p, gates, seed=seed)
         self.inv_gates = tuple()
 
@@ -770,7 +770,7 @@ class UnitaryChannel(KrausChannel, base_gates.UnitaryChannel):
             np.random.seed(self.seed)
 
     def _state_vector_call(self, state: tf.Tensor) -> tf.Tensor:
-        TensorflowGate._set_nqubits(self, state)
+        self.module.TensorflowGate._set_nqubits(self, state)
         for p, gate in zip(self.probs, self.gates):
             if np.random.random() < p:
                 state = gate(state)
@@ -790,7 +790,7 @@ class PauliNoiseChannel(UnitaryChannel, base_gates.PauliNoiseChannel):
 
     def __init__(self, q: int, px: float = 0, py: float = 0, pz: float = 0,
                  seed: Optional[int] = None):
-        TensorflowGate.__init__(self)
+        self.module.TensorflowGate.__init__(self)
         base_gates.PauliNoiseChannel.__init__(self, q, px, py, pz, seed=seed)
         self.inv_gates = tuple()
 
@@ -804,7 +804,7 @@ class ResetChannel(UnitaryChannel, base_gates.ResetChannel):
 
     def __init__(self, q: int, p0: float = 0.0, p1: float = 0.0,
                  seed: Optional[int] = None):
-        TensorflowGate.__init__(self)
+        self.module.TensorflowGate.__init__(self)
         base_gates.ResetChannel.__init__(self, q, p0=p0, p1=p1, seed=seed)
         self.inv_gates = tuple()
 
@@ -815,7 +815,7 @@ class ResetChannel(UnitaryChannel, base_gates.ResetChannel):
         return gate
 
     def _state_vector_call(self, state: tf.Tensor) -> tf.Tensor:
-        TensorflowGate._set_nqubits(self, state)
+        self.module.TensorflowGate._set_nqubits(self, state)
         not_collapsed = True
         if np.random.random() < self.probs[-2]:
             state = self.gates[-2](state)
@@ -830,14 +830,14 @@ class ResetChannel(UnitaryChannel, base_gates.ResetChannel):
 class ThermalRelaxationChannel(ResetChannel, base_gates.ThermalRelaxationChannel):
 
     def __init__(self, q, t1, t2, time, excited_population=0, seed=None):
-        TensorflowGate.__init__(self)
+        self.module.TensorflowGate.__init__(self)
         base_gates.ThermalRelaxationChannel.__init__(
             self, q, t1, t2, time, excited_population=excited_population,
             seed=seed)
         self.inv_gates = tuple()
 
     def _state_vector_call(self, state: tf.Tensor) -> tf.Tensor:
-        TensorflowGate._set_nqubits(self, state)
+        self.module.TensorflowGate._set_nqubits(self, state)
         if np.random.random() < self.probs[0]:
             state = self.gates[0](state)
         return ResetChannel._state_vector_call(self, state)

--- a/src/qibo/tensorflow/cgates.py
+++ b/src/qibo/tensorflow/cgates.py
@@ -706,6 +706,40 @@ class CallbackGate(TensorflowGate, base_gates.CallbackGate):
         return state
 
 
+class ResetChannel(TensorflowGate, base_gates.ResetChannel):
+
+    def __init__(self, *q: int, p0: float = 0.0, p1: float = 0.0,
+                 seed: Optional[int] = None):
+        TensorflowGate.__init__(self)
+        base_gates.ResetChannel.__init__(self, *q, p0=p0, p1=p1, seed=seed)
+
+    def _prepare(self):
+        for g in {self.collapse, self.flip}:
+            g.density_matrix = self.density_matrix
+            g.device = self.device
+            g.nqubits = self.nqubits
+        if self.seed is not None:
+            np.random.seed(self.seed)
+
+    def _state_vector_call(self, state: tf.Tensor) -> tf.Tensor:
+        TensorflowGate._set_nqubits(self, state)
+        not_collapsed = True
+        if np.random.random() < self.p0:
+            state = self.collapse(state)
+            not_collapsed = False
+        if np.random.random() < self.p1:
+            if not_collapsed:
+                state = self.collapse(state)
+            state = self.flip(state)
+        return state
+
+    def _density_matrix_call(self, state: tf.Tensor) -> tf.Tensor:
+        new_state = (1 - self.psum) * state
+        collapsed_state = self.collapse(state)
+        new_state += self.p0 * collapsed_state
+        return new_state + self.p1 * self.flip(collapsed_state)
+
+
 class KrausChannel(TensorflowGate, base_gates.KrausChannel):
 
     def __init__(self, gates: Sequence[Tuple[Tuple[int], np.ndarray]]):
@@ -793,17 +827,3 @@ class PauliNoiseChannel(UnitaryChannel, base_gates.PauliNoiseChannel):
     def _invert(gate):
         """For Pauli gates we can use same gate for state inversion for efficiency."""
         return gate
-
-
-class ResetChannel(UnitaryChannel, base_gates.ResetChannel):
-
-    def __init__(self, *q: int, p0: float = 0.0, p1: float = 0.0,
-                 seed: Optional[int] = None):
-        TensorflowChannel.__init__(self)
-        base_gates.ResetChannel.__init__(self, *q, p0=p0, p1=p1, seed=seed)
-
-    def _density_matrix_call(self, state: tf.Tensor) -> tf.Tensor:
-        new_state = tf.zeros_like(state)
-        for p, gate, inv_gate in zip(self.probs, self.gates, self.inv_gates):
-            new_state += p * gate(state + tf.zeros_like(state))
-        return (1 - self.psum) * state + new_state

--- a/src/qibo/tensorflow/cgates.py
+++ b/src/qibo/tensorflow/cgates.py
@@ -877,7 +877,6 @@ class _ThermalRelaxationChannelB(MatrixGate, base_gates._ThermalRelaxationChanne
         self.gate_op = op.apply_two_qubit_gate
 
     def _calculate_qubits_tensor(self) -> tf.Tensor:
-        """Calculates ``qubits`` tensor required for applying gates using custom operators."""
         qubits = sorted(list(self.nqubits - np.array(self.control_qubits) - 1))
         qubits = self.nqubits - np.array(self.target_qubits) - 1
         qubits = np.concatenate([qubits, qubits + self.nqubits], axis=0)

--- a/src/qibo/tensorflow/cgates.py
+++ b/src/qibo/tensorflow/cgates.py
@@ -793,3 +793,18 @@ class PauliNoiseChannel(UnitaryChannel, base_gates.PauliNoiseChannel):
     def _invert(gate):
         """For Pauli gates we can use same gate for state inversion for efficiency."""
         return gate
+
+
+class ResetChannel(UnitaryChannel, base_gates.ResetChannel):
+
+    def __init__(self, *q: int, p0: float = 0.0, p1: float = 0.0,
+                 seed: Optional[int] = None):
+        TensorflowChannel.__init__(self)
+        base_gates.ResetChannel.__init__(self, *q, p0=p0, p1=p1, seed=seed)
+
+    def _density_matrix_call(self, state: tf.Tensor) -> tf.Tensor:
+        collapsed_states = []
+        for p, gate in self.gates:
+            collapsed_states.append(tf.zeros_like(state) + state)
+            collapsed_states[-1] = p * gate(collapsed_states[-1])
+        return (1 - self.total_p) * state + sum(collapsed_states)

--- a/src/qibo/tensorflow/cgates.py
+++ b/src/qibo/tensorflow/cgates.py
@@ -836,14 +836,19 @@ class ResetChannel(UnitaryChannel, base_gates.ResetChannel):
 class ThermalRelaxationChannel(TensorflowGate, base_gates.ThermalRelaxationChannel):
 
     def __new__(cls, q, t1, t2, time, excited_population=0, seed=None):
-        if t2 > t1:
-            return _ThermalRelaxationChannelB(
-                q, t1, t2, time, excited_population=excited_population,
-                seed=seed)
+        if BACKEND.get('GATES') == "custom":
+            cls_a = _ThermalRelaxationChannelA
+            cls_b = _ThermalRelaxationChannelB
         else:
-            return _ThermalRelaxationChannelA(
-                q, t1, t2, time, excited_population=excited_population,
-                seed=seed)
+            from qibo.tensorflow import gates
+            cls_a = gates._ThermalRelaxationChannelA
+            cls_b = gates._ThermalRelaxationChannelB
+        if t2 > t1:
+            cls_s = cls_b
+        else:
+            cls_s = cls_a
+        return cls_s(
+            q, t1, t2, time, excited_population=excited_population, seed=seed)
 
 
 class _ThermalRelaxationChannelA(ResetChannel, base_gates._ThermalRelaxationChannelA):

--- a/src/qibo/tensorflow/gates.py
+++ b/src/qibo/tensorflow/gates.py
@@ -604,6 +604,10 @@ class _ThermalRelaxationChannelB(TensorflowGate, base_gates._ThermalRelaxationCh
     def construct_unitary(self):
         return cgates._ThermalRelaxationChannelB.construct_unitary(self)
 
+    def _state_vector_call(self, state: tf.Tensor) -> tf.Tensor:
+        raise_error(ValueError, "Thermal relaxation cannot be applied to "
+                                "state vectors when T1 < T2.")
+
     def _density_matrix_call(self, state: tf.Tensor) -> tf.Tensor:
         einsum_str = self.calculation_cache.vector
         return self.einsum(einsum_str, state, self.matrix)

--- a/src/qibo/tensorflow/gates.py
+++ b/src/qibo/tensorflow/gates.py
@@ -564,19 +564,6 @@ class ResetChannel(UnitaryChannel, base_gates.ResetChannel):
         return new_state
 
 
-class ThermalRelaxationChannel(TensorflowGate, base_gates.ThermalRelaxationChannel):
-
-    def __new__(cls, q, t1, t2, time, excited_population=0, seed=None):
-        if t2 > t1:
-            return _ThermalRelaxationChannelB(
-                q, t1, t2, time, excited_population=excited_population,
-                seed=seed)
-        else:
-            return _ThermalRelaxationChannelA(
-                q, t1, t2, time, excited_population=excited_population,
-                seed=seed)
-
-
 class _ThermalRelaxationChannelA(ResetChannel, base_gates._ThermalRelaxationChannelA):
 
     def __init__(self, q, t1, t2, time, excited_population=0, seed=None):

--- a/src/qibo/tensorflow/gates.py
+++ b/src/qibo/tensorflow/gates.py
@@ -4,6 +4,7 @@ import numpy as np
 import tensorflow as tf
 from qibo.base import gates as base_gates
 from qibo.base import cache
+from qibo.tensorflow import cgates
 from qibo.config import tfmatrices as matrices
 from qibo.config import BACKEND, DTYPES, raise_error
 from typing import Dict, List, Optional, Sequence, Tuple
@@ -43,7 +44,6 @@ class TensorflowGate(base_gates.Gate):
 
     @staticmethod
     def control_unitary(unitary: tf.Tensor) -> tf.Tensor:
-        from qibo.tensorflow import cgates
         return cgates.TensorflowGate.control_unitary(unitary)
 
     @base_gates.Gate.nqubits.setter
@@ -192,8 +192,7 @@ class Collapse(TensorflowGate, base_gates.Collapse):
 
     @staticmethod
     def _result_to_list(res):
-        from qibo.tensorflow.cgates import Collapse
-        return Collapse._result_to_list(res)
+        return cgates.Collapse._result_to_list(res)
 
     def _prepare(self):
         self.order = list(self.sorted_qubits)
@@ -288,7 +287,6 @@ class U2(TensorflowGate, base_gates.U2):
         TensorflowGate.__init__(self)
 
     def construct_unitary(self):
-        from qibo.tensorflow import cgates
         return cgates.U2.construct_unitary(self)
 
 
@@ -299,7 +297,6 @@ class U3(TensorflowGate, base_gates.U3):
         TensorflowGate.__init__(self)
 
     def construct_unitary(self):
-        from qibo.tensorflow import cgates
         return cgates.U3.construct_unitary(self)
 
 
@@ -398,7 +395,6 @@ class fSim(TensorflowGate, base_gates.fSim):
         TensorflowGate.__init__(self)
 
     def construct_unitary(self):
-        from qibo.tensorflow import cgates
         return cgates.fSim.construct_unitary(self)
 
 
@@ -409,11 +405,9 @@ class GeneralizedfSim(TensorflowGate, base_gates.GeneralizedfSim):
         TensorflowGate.__init__(self)
 
     def construct_unitary(self):
-        from qibo.tensorflow import cgates
         return cgates.GeneralizedfSim.construct_unitary(self)
 
     def _dagger(self) -> "GeneralizedfSim":
-        from qibo.tensorflow import cgates
         return cgates.GeneralizedfSim._dagger(self)
 
 
@@ -448,13 +442,10 @@ class Unitary(TensorflowGate, base_gates.Unitary):
         return matrix
 
     def _dagger(self) -> "Unitary":
-        from qibo.tensorflow import cgates
         return cgates.Unitary._dagger(self)
 
 
 class VariationalLayer(TensorflowGate, base_gates.VariationalLayer):
-
-    from qibo.tensorflow import cgates
 
     def __init__(self, qubits: List[int], pairs: List[Tuple[int, int]],
                  one_qubit_gate, two_qubit_gate,
@@ -506,11 +497,11 @@ class VariationalLayer(TensorflowGate, base_gates.VariationalLayer):
         return matrices, additional_matrix
 
     def _prepare(self):
-        self.cgates.VariationalLayer._prepare(self)
+        cgates.VariationalLayer._prepare(self)
 
     def __call__(self, state: tf.Tensor) -> tf.Tensor: # pragma: no cover
         # impractical case because VariationalLayer is not called by circuits
-        return self.cgates.VariationalLayer.__call__(self, state)
+        return cgates.VariationalLayer.__call__(self, state)
 
 
 class KrausChannel(TensorflowGate, base_gates.KrausChannel):
@@ -526,7 +517,6 @@ class KrausChannel(TensorflowGate, base_gates.KrausChannel):
             gate.nqubits = self.nqubits
 
     def _state_vector_call(self, state: tf.Tensor) -> tf.Tensor:
-        from qibo.tensorflow import cgates
         ccls = getattr(cgates, self.__class__.__name__)
         return ccls._state_vector_call(self, state)
 

--- a/src/qibo/tensorflow/gates.py
+++ b/src/qibo/tensorflow/gates.py
@@ -569,18 +569,23 @@ class ResetChannel(UnitaryChannel, base_gates.ResetChannel):
         return new_state
 
 
-class ThermalRelaxationChannel(ResetChannel, base_gates.ThermalRelaxationChannel):
+class ThermalRelaxationChannel(TensorflowGate, base_gates.ThermalRelaxationChannel):
+
+    def __new__(cls, q, t1, t2, time, excited_population=0, seed=None):
+        if t2 > t1:
+            return _ThermalRelaxationChannelB(
+                q, t1, t2, time, excited_population=excited_population,
+                seed=seed)
+        else:
+            return _ThermalRelaxationChannelA(
+                q, t1, t2, time, excited_population=excited_population,
+                seed=seed)
+
+
+class _ThermalRelaxationChannelA(ResetChannel, base_gates._ThermalRelaxationChannelA):
 
     def __init__(self, q, t1, t2, time, excited_population=0, seed=None):
         TensorflowGate.__init__(self)
-        base_gates.ThermalRelaxationChannel.__init__(
+        base_gates._ThermalRelaxationChannelA.__init__(
             self, q, t1, t2, time, excited_population=excited_population,
             seed=seed)
-
-    def _density_matrix_call(self, state: tf.Tensor) -> tf.Tensor:
-        new_state = (1 - self.psum) * state
-        new_state = self.probs[0] * self.gates[0](state)
-        for p, gate in zip(self.probs[1:], self.gates[1:]):
-            state = gate(state)
-            new_state += p * state
-        return new_state

--- a/src/qibo/tensorflow/gates.py
+++ b/src/qibo/tensorflow/gates.py
@@ -39,6 +39,9 @@ class TensorflowGate(base_gates.Gate):
     def _calculate_einsum_cache(self):
         if self.is_controlled_by:
             if self.density_matrix:
+                # fall back to the 'defaulteinsum' backend when using
+                # density matrices with `controlled_by` gates because
+                # 'matmuleinsum' is not properly implemented for this case
                 from qibo.tensorflow import einsum
                 self.einsum = einsum.DefaultEinsum()
             self.control_cache = cache.ControlCache(self)

--- a/src/qibo/tests/test_density_matrix.py
+++ b/src/qibo/tests/test_density_matrix.py
@@ -749,6 +749,20 @@ def test_thermal_relaxation_channel(backend, t1, t2, time, excpop):
 
 
 @pytest.mark.parametrize("backend", _BACKENDS)
+@pytest.mark.parametrize("t1,t2,time,excpop",
+                         [(1.0, 0.5, 1.5, 1.5), (1.0, 0.5, -0.5, 0.5),
+                          (1.0, -0.5, 1.5, 0.5), (-1.0, 0.5, 1.5, 0.5),
+                          (1.0, 3.0, 1.5, 0.5)])
+def test_thermal_relaxation_channel_errors(backend, t1, t2, time, excpop):
+    original_backend = qibo.get_backend()
+    qibo.set_backend(backend)
+    with pytest.raises(ValueError):
+        gate = gates.ThermalRelaxationChannel(
+            0, t1, t2, time, excited_population=excpop)
+    qibo.set_backend(original_backend)
+
+
+@pytest.mark.parametrize("backend", _BACKENDS)
 def test_entanglement_entropy(backend):
     """Check that entanglement entropy calculation works for density matrices."""
     original_backend = qibo.get_backend()

--- a/src/qibo/tests/test_density_matrix.py
+++ b/src/qibo/tests/test_density_matrix.py
@@ -705,8 +705,7 @@ def test_reset_channel(backend):
     qibo.set_backend(original_backend)
 
 
-#@pytest.mark.parametrize("backend", _BACKENDS)
-@pytest.mark.parametrize("backend", ["custom"])
+@pytest.mark.parametrize("backend", _BACKENDS)
 @pytest.mark.parametrize("t1,t2,time,excpop",
                          [(0.8, 0.5, 1.0, 0.4), (0.5, 0.8, 1.0, 0.4)])
 def test_thermal_relaxation_channel(backend, t1, t2, time, excpop):

--- a/src/qibo/tests/test_density_matrix.py
+++ b/src/qibo/tests/test_density_matrix.py
@@ -690,6 +690,35 @@ def test_reset_channel(backend):
     qibo.set_backend(original_backend)
 
 
+@pytest.mark.parametrize("backend", ["custom"])
+def test_thermal_relaxation_channel(backend):
+    """Check ``gates.ThermalRelaxationChannel`` on a 3-qubit random density matrix."""
+    original_backend = qibo.get_backend()
+    qibo.set_backend(backend)
+    initial_rho = utils.random_density_matrix(3)
+    c = models.Circuit(3, density_matrix=True)
+    c.add(gates.ThermalRelaxationChannel(0, t1=0.8, t2=0.5, time=1.0,
+                                         excited_population=0.4))
+    final_rho = c(np.copy(initial_rho))
+
+    pz, p0, p1 = gates.ThermalRelaxationChannel._calculate_probs(0.8, 0.5, 1.0, 0.4)
+    pi = 1 - pz - p0 - p1
+    dtype = initial_rho.dtype
+    collapsed_rho = np.copy(initial_rho).reshape(6 * (2,))
+    collapsed_rho[0, :, :, 1, :, :] = np.zeros(4 * (2,), dtype=dtype)
+    collapsed_rho[1, :, :, 0, :, :] = np.zeros(4 * (2,), dtype=dtype)
+    collapsed_rho[1, :, :, 1, :, :] = np.zeros(4 * (2,), dtype=dtype)
+    collapsed_rho = collapsed_rho.reshape((8, 8))
+    collapsed_rho /= np.trace(collapsed_rho)
+    mx = np.kron(np.array([[0, 1], [1, 0]]), np.eye(4))
+    mz = np.kron(np.array([[1, 0], [0, -1]]), np.eye(4))
+    z_rho = mz.dot(initial_rho.dot(mz))
+    flipped_rho = mx.dot(collapsed_rho.dot(mx))
+    target_rho = pi * initial_rho + pz * z_rho + p0 * collapsed_rho + p1 * flipped_rho
+    np.testing.assert_allclose(final_rho, target_rho)
+    qibo.set_backend(original_backend)
+
+
 @pytest.mark.parametrize("backend", _BACKENDS)
 def test_entanglement_entropy(backend):
     """Check that entanglement entropy calculation works for density matrices."""

--- a/src/qibo/tests/test_density_matrix.py
+++ b/src/qibo/tests/test_density_matrix.py
@@ -725,6 +725,7 @@ def test_thermal_relaxation_channel(backend, t1, t2, time, excpop):
         matrix = np.diag([1 - p1, p0, p1, 1 - p0])
         matrix[0, -1], matrix[-1, 0] = exp, exp
         matrix = matrix.reshape(4 * (2,))
+        # Apply matrix using Eq. (3.28) from arXiv:1111.6950
         target_rho = np.copy(initial_rho).reshape(6 * (2,))
         target_rho = np.einsum("abcd,aJKcjk->bJKdjk", matrix, target_rho)
         target_rho = target_rho.reshape(initial_rho.shape)

--- a/src/qibo/tests/test_density_matrix.py
+++ b/src/qibo/tests/test_density_matrix.py
@@ -667,7 +667,7 @@ def test_collapse_gate(backend, nqubits, targets, results):
     qibo.set_backend(original_backend)
 
 
-@pytest.mark.parametrize("backend", ["custom"])
+@pytest.mark.parametrize("backend", _BACKENDS)
 def test_reset_channel(backend):
     """Check ``gates.ResetChannel`` on a 3-qubit random density matrix."""
     original_backend = qibo.get_backend()

--- a/src/qibo/tests/test_density_matrix.py
+++ b/src/qibo/tests/test_density_matrix.py
@@ -714,8 +714,9 @@ def test_thermal_relaxation_channel(backend, t1, t2, time, excpop):
     qibo.set_backend(backend)
     initial_rho = utils.random_density_matrix(3)
     c = models.Circuit(3, density_matrix=True)
-    c.add(gates.ThermalRelaxationChannel(0, t1, t2, time=time,
-                                         excited_population=excpop))
+    gate = gates.ThermalRelaxationChannel(0, t1, t2, time=time,
+        excited_population=excpop)
+    c.add(gate)
     final_rho = c(np.copy(initial_rho))
 
     exp, p0, p1 = gates.ThermalRelaxationChannel._calculate_probs(
@@ -745,6 +746,10 @@ def test_thermal_relaxation_channel(backend, t1, t2, time, excpop):
         target_rho = (pi * initial_rho + pz * z_rho + p0 * collapsed_rho +
                       p1 * flipped_rho)
     np.testing.assert_allclose(final_rho, target_rho)
+    # Try to apply to state vector if t1 < t2
+    if t1 < t2:
+        with pytest.raises(ValueError):
+            target_rho = gate._state_vector_call(initial_rho)
     qibo.set_backend(original_backend)
 
 

--- a/src/qibo/tests/test_density_matrix.py
+++ b/src/qibo/tests/test_density_matrix.py
@@ -691,7 +691,7 @@ def test_reset_channel(backend):
     qibo.set_backend(original_backend)
 
 
-@pytest.mark.parametrize("backend", ["custom"])
+@pytest.mark.parametrize("backend", _BACKENDS)
 def test_thermal_relaxation_channel(backend):
     """Check ``gates.ThermalRelaxationChannel`` on a 3-qubit random density matrix."""
     original_backend = qibo.get_backend()

--- a/src/qibo/tests/test_gates.py
+++ b/src/qibo/tests/test_gates.py
@@ -1412,7 +1412,7 @@ def test_noise_channel_repeated(backend):
     qibo.set_backend(original_backend)
 
 
-@pytest.mark.parametrize("backend", ["custom"])
+@pytest.mark.parametrize("backend", _BACKENDS)
 def test_reset_channel_repeated(backend):
     original_backend = qibo.get_backend()
     qibo.set_backend(backend)
@@ -1436,7 +1436,7 @@ def test_reset_channel_repeated(backend):
     qibo.set_backend(original_backend)
 
 
-@pytest.mark.parametrize("backend", ["custom"])
+@pytest.mark.parametrize("backend", _BACKENDS)
 def test_thermal_relaxation_channel_repeated(backend):
     original_backend = qibo.get_backend()
     qibo.set_backend(backend)

--- a/src/qibo/tests/test_gates.py
+++ b/src/qibo/tests/test_gates.py
@@ -1434,3 +1434,32 @@ def test_reset_channel_repeated(backend):
         target_state.append(noiseless_c(np.copy(initial_state)).numpy())
     np.testing.assert_allclose(final_state, target_state)
     qibo.set_backend(original_backend)
+
+
+@pytest.mark.parametrize("backend", ["custom"])
+def test_thermal_relaxation_channel_repeated(backend):
+    original_backend = qibo.get_backend()
+    qibo.set_backend(backend)
+
+    initial_state = utils.random_numpy_state(5)
+    c = Circuit(5)
+    c.add(gates.ThermalRelaxationChannel(4, t1=1.0, t2=0.6, time=0.8,
+                                         excited_population=0.8, seed=123))
+    final_state = c(np.copy(initial_state), nshots=30).numpy()
+
+    pz, p0, p1 = gates.ThermalRelaxationChannel._calculate_probs(
+        1.0, 0.6, 0.8, 0.8)
+    np.random.seed(123)
+    target_state = []
+    for _ in range(30):
+        noiseless_c = Circuit(5)
+        if np.random.random() < pz:
+            noiseless_c.add(gates.Z(4))
+        if np.random.random() < p0:
+            noiseless_c.add(gates.Collapse(4))
+        if np.random.random() < p1:
+            noiseless_c.add(gates.Collapse(4))
+            noiseless_c.add(gates.X(4))
+        target_state.append(noiseless_c(np.copy(initial_state)).numpy())
+    np.testing.assert_allclose(final_state, target_state)
+    qibo.set_backend(original_backend)

--- a/src/qibo/tests/test_gates.py
+++ b/src/qibo/tests/test_gates.py
@@ -1410,3 +1410,27 @@ def test_noise_channel_repeated(backend):
     target_state = noiseless_c().numpy()
     np.testing.assert_allclose(final_state, target_state)
     qibo.set_backend(original_backend)
+
+
+@pytest.mark.parametrize("backend", ["custom"])
+def test_reset_channel_repeated(backend):
+    original_backend = qibo.get_backend()
+    qibo.set_backend(backend)
+
+    initial_state = utils.random_numpy_state(5)
+    c = Circuit(5)
+    c.add(gates.ResetChannel(2, p0=0.3, p1=0.3, seed=123))
+    final_state = c(np.copy(initial_state), nshots=30).numpy()
+
+    np.random.seed(123)
+    target_state = []
+    for _ in range(30):
+        noiseless_c = Circuit(5)
+        if np.random.random() < 0.3:
+            noiseless_c.add(gates.Collapse(2))
+        if np.random.random() < 0.3:
+            noiseless_c.add(gates.Collapse(2))
+            noiseless_c.add(gates.X(2))
+        target_state.append(noiseless_c(np.copy(initial_state)).numpy())
+    np.testing.assert_allclose(final_state, target_state)
+    qibo.set_backend(original_backend)


### PR DESCRIPTION
This implements two new channels: `ResetChannel` and `ThermalRelaxationChannel`, both following the corresponding [Qiskit implementation](https://qiskit.org/documentation/_modules/qiskit/providers/aer/noise/errors/standard_errors.html#thermal_relaxation_error). Note that the thermal relaxation channel, at least as it is implemented in Qiskit, is different depending on which of T1, T2 is larger. Specifically:

* If T1 >= T2 (which I think is the common case experimentally), the channel is a probabilistic mixture of unitaries and collapse gate so it can be implemented as a special case of `UnitaryChannel`. This case can also be simulated with state vectors and sampling.

* If T1 < T2 the channel is general (not a unitary mixture) and can only be used with density matrices. Qiskit uses the Choi matrix representation to define the channel in this case but since we don't have an implementation of this, I just worked out the transformation on paper and coded the functions that implement it both for the custom and tf backends.

All transformation equations are written in detail in our docs. If @AdrianPerezSalinas agrees, this PR together with #278 (already merged) should close #63.