### PR TITLE
Fix issues with Collapse gate

### DIFF
--- a/src/qibo/base/gates.py
+++ b/src/qibo/base/gates.py
@@ -552,7 +552,7 @@ class Collapse(Gate):
 
     @result.setter
     def result(self, res):
-        res = self._result_to_list(res)
+        res = self._result_to_list(res) # pylint: disable=E1111
         if len(self.target_qubits) != len(res):
             raise_error(ValueError, "Collapse gate was created on {} qubits "
                                     "but {} result values were given."

--- a/src/qibo/base/gates.py
+++ b/src/qibo/base/gates.py
@@ -546,8 +546,7 @@ class Collapse(Gate):
         """Returns the result list in proper order after sorting the qubits."""
         return self._result
 
-    @staticmethod
-    def _result_to_list(res): # pragma: no cover
+    def _result_to_list(self, res): # pragma: no cover
         # abstract method
         raise_error(NotImplementedError)
 

--- a/src/qibo/config.py
+++ b/src/qibo/config.py
@@ -40,6 +40,12 @@ if BACKEND_NAME == "tensorflow":
     # Backend access
     K = tf
 
+    # Numpy and Tensorflow numeric and array types
+    NUMERIC_TYPES = (np.int, np.float, np.complex,
+                     np.int32, np.int64, np.float32,
+                     np.float64, np.complex64, np.complex128)
+    ARRAY_TYPES = (tf.Tensor, np.ndarray)
+
     # characters used in einsum strings
     EINSUM_CHARS = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
 

--- a/src/qibo/tensorflow/cgates.py
+++ b/src/qibo/tensorflow/cgates.py
@@ -3,7 +3,7 @@
 import numpy as np
 import tensorflow as tf
 from qibo.base import gates as base_gates
-from qibo.config import BACKEND, DTYPES, DEVICES, raise_error
+from qibo.config import BACKEND, DTYPES, DEVICES, NUMERIC_TYPES, raise_error
 from qibo.tensorflow import custom_operators as op
 from typing import Dict, List, Optional, Sequence, Tuple
 
@@ -193,12 +193,13 @@ class Collapse(TensorflowGate, base_gates.Collapse):
         self.result_tensor = None
         self.gate_op = op.collapse_state
 
-    @staticmethod
-    def _result_to_list(res):
+    def _result_to_list(self, res):
         if isinstance(res, np.ndarray):
             return list(res.astype(np.int))
         if isinstance(res, tf.Tensor):
             return list(res.numpy().astype(np.int))
+        if isinstance(res, int) or isinstance(res, NUMERIC_TYPES):
+            return len(self.target_qubits) * [res]
         return list(res)
 
     def _prepare(self):

--- a/src/qibo/tensorflow/custom_operators/cc/kernels/apply_gate_kernels.cc
+++ b/src/qibo/tensorflow/custom_operators/cc/kernels/apply_gate_kernels.cc
@@ -265,9 +265,9 @@ struct CollapseStateFunctor<CPUDevice, T, NormType> {
     };
 
     // Define vector that holds norms during parallel calculation
-    int nnorms = ncores + 1;
-    if (nreps > 0 && nstates / nreps > nnorms) {
-      nnorms = nstates / nreps;
+    int nnorms = 1;
+    if (nreps > 0) {
+      nnorms = ((int64)nstates / nreps) + 1;
     }
     Eigen::Matrix<NormType, Eigen::Dynamic, 1> norms(nnorms);
     norms.setZero();

--- a/src/qibo/tensorflow/gates.py
+++ b/src/qibo/tensorflow/gates.py
@@ -186,9 +186,8 @@ class Collapse(TensorflowGate, base_gates.Collapse):
         self.ids = None
         self.density_matrix_result = None
 
-    @staticmethod
-    def _result_to_list(res):
-        return cgates.Collapse._result_to_list(res)
+    def _result_to_list(self, res):
+        return cgates.Collapse._result_to_list(self, res)
 
     def _prepare(self):
         self.order = list(self.sorted_qubits)

--- a/src/qibo/tensorflow/hamiltonians.py
+++ b/src/qibo/tensorflow/hamiltonians.py
@@ -1,14 +1,8 @@
 import itertools
 import numpy as np
 import tensorflow as tf
-from qibo.config import raise_error, EINSUM_CHARS
+from qibo.config import raise_error, EINSUM_CHARS, NUMERIC_TYPES, ARRAY_TYPES
 from qibo.base import hamiltonians
-
-
-NUMERIC_TYPES = (np.int, np.float, np.complex,
-                 np.int32, np.int64, np.float32,
-                 np.float64, np.complex64, np.complex128)
-ARRAY_TYPES = (tf.Tensor, np.ndarray)
 
 
 class TensorflowHamiltonian(hamiltonians.Hamiltonian):

--- a/src/qibo/tests/test_gates.py
+++ b/src/qibo/tests/test_gates.py
@@ -1289,8 +1289,10 @@ def test_variational_layer_dagger(backend, nqubits):
                           (3, [1], 0, True),
                           (4, [1, 3], [0, 1], True),
                           (5, [0, 3, 4], [1, 1, 0], False),
-                          (6, [1, 3], np.ones(2, dtype=np.int), True)])
+                          (6, [1, 3], np.ones(2, dtype=np.int), True),
+                          (4, [0, 2], np.zeros(2, dtype=np.int32)[0], True)])
 def test_collapse_gate(backend, nqubits, targets, results, oncircuit):
+    from qibo.config import NUMERIC_TYPES
     original_backend = qibo.get_backend()
     qibo.set_backend(backend)
 
@@ -1309,7 +1311,7 @@ def test_collapse_gate(backend, nqubits, targets, results, oncircuit):
             final_state = collapse(np.copy(initial_state).reshape(new_shape))
             final_state = final_state.numpy().reshape(original_shape)
 
-    if isinstance(results, int):
+    if isinstance(results, int) or isinstance(results, NUMERIC_TYPES):
         results = nqubits * [results]
     slicer = nqubits * [slice(None)]
     for t, r in zip(targets, results):


### PR DESCRIPTION
Fixes some Collapse gate issues that I found while playing with the Shor example. Particularly the two following issues:

* Constructing the collapse gate fails when `result` is a `numpy` integer (eg. `np.int32`, `np.int64`) instead of pure Python `int`. I fixed this using the `NUMERIC_TYPES` we had in the Hamiltonians and added a relevant test.
* The C++ norm calculation is not working on a particular configuration of number of qubits and number of threads. For example using the collapse on 10 qubits on >35 threads is failing. This is because of a missing `+ 1` in the `nnorms` definition for the CPU custom operator. Things like that are a bit harder to capture in tests because most common machines and presumably the ones used by CI do not have that many threads.