### PR TITLE
adding scipy requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 # Runtime requirements for qibo
 
 # numpy (included in tf)
-# scipy (included in tf)
 tensorflow>=2.2,<=2.3.1
+scipy
 sympy
 cma
 joblib


### PR DESCRIPTION
Scipy is not a requirement of tf>=2.2 so we have to include it to the requirements list.
This issue is already visible in Qibo 0.1.1, however we didn't catch it because sphinx requires scipy.