### PR TITLE
Replacing ThreadPool with OpenMP

### DIFF
--- a/.github/workflows/rules.yml
+++ b/.github/workflows/rules.yml
@@ -17,9 +17,9 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install OS requirements
-        uses: mstksg/get-package@v1
-        with:
-          brew: gcc@9 libomp
+      uses: mstksg/get-package@v1
+      with:
+        brew: gcc@9 libomp
     - name: Install package
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/rules.yml
+++ b/.github/workflows/rules.yml
@@ -16,10 +16,6 @@ jobs:
       uses: actions/setup-python@v1
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Install OS requirements
-      uses: mstksg/get-package@v1
-      with:
-        brew: gcc@9 libomp
     - name: Install package
       run: |
         python -m pip install --upgrade pip
@@ -27,6 +23,8 @@ jobs:
         pip install pytest-cov
         pip install -r requirements.txt
         pip install .[docs,tests]
+      env:
+        CXX: g++-9 # use for both os
     - name: Test with pylint
       run: |
         pylint src -E -d E1123,E1120

--- a/.github/workflows/rules.yml
+++ b/.github/workflows/rules.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-latest] #, macos-latest]
+        os: [ubuntu-latest, macos-latest]
         python-version: [3.6, 3.7, 3.8]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/rules.yml
+++ b/.github/workflows/rules.yml
@@ -16,6 +16,10 @@ jobs:
       uses: actions/setup-python@v1
       with:
         python-version: ${{ matrix.python-version }}
+    - name: Install OS requirements
+        uses: mstksg/get-package@v1
+        with:
+          brew: gcc@9 libomp
     - name: Install package
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/rules.yml
+++ b/.github/workflows/rules.yml
@@ -16,6 +16,10 @@ jobs:
       uses: actions/setup-python@v1
       with:
         python-version: ${{ matrix.python-version }}
+    - name: Install OS requirements
+      uses: mstksg/get-package@v1
+      with:
+        brew: libomp
     - name: Install package
       run: |
         python -m pip install --upgrade pip
@@ -23,8 +27,6 @@ jobs:
         pip install pytest-cov
         pip install -r requirements.txt
         pip install .[docs,tests]
-      env:
-        CXX: g++-9 # use for both os
     - name: Test with pylint
       run: |
         pylint src -E -d E1123,E1120

--- a/.github/workflows/rules.yml
+++ b/.github/workflows/rules.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest] #, macos-latest]
         python-version: [3.6, 3.7, 3.8]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -22,6 +22,10 @@ jobs:
       uses: actions/setup-python@v1
       with:
         python-version: ${{ matrix.python-version }}
+    - name: Install OS requirements
+      uses: mstksg/get-package@v1
+      with:
+        brew: libomp
     - name: Patch requirements
       run: |
         TFSTRING=`grep "tensorflow" requirements.txt`

--- a/doc/source/advancedexamples.rst
+++ b/doc/source/advancedexamples.rst
@@ -64,9 +64,25 @@ raised prompting the user to switch the default device using ``qibo.set_device``
 Setting the number of CPU threads
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Qibo inherits Tensorflow's defaults for CPU thread configuration and in most cases
-will utilize all available CPU threads. For small circuits the parallelization
-overhead may decrease performance making single thread execution preferrable.
+Qibo by default uses the ``"custom"`` operators backend. This backend uses
+OpenMP instructions for the parallelization. In most cases will utilize all
+available CPU threads. For small circuits the parallelization overhead may
+decrease performance making single thread execution preferrable.
+
+You can restrict the number of threads by exporting the ``OMP_NUM_THREADS``
+environment variable with the requested number of threads before launching Qibo,
+or programmatically, during runtime, as follows:
+
+.. code-block::  python
+
+    import qibo
+    # set the number of threads to 1
+    qibo.set_threads(1)
+    # retrieve the current number of threads
+    current_threads = qibo.get_threads()
+
+On the other hand, when using the ``"matmuleinsum"`` or ``"defaulteinsum"``
+backends Qibo inherits Tensorflow's defaults for CPU thread configuration.
 Tensorflow allows restricting the number of threads as follows:
 
 .. code-block::  python

--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -56,10 +56,12 @@ then proceed with the installation of requirements with:
       pip install -r requirements.txt
 
 Make sure your system has a GNU ``g++ >= 6`` compiler. If you are working on
-macosx make sure the command ``g++`` is the official GNU compiler instead of an
-alias to the ``clang`` compiler. Optionally, you can use the ``CXX`` environment
-variable to set then compiler path. Similarly, the ``PYTHON`` environment
-variable sets the python interpreter path.
+macosx make sure the command ``c++`` is ``clang >= 11`` and install the libomp
+library with ``brew install libomp`` command.
+
+Optionally, you can use the ``CXX`` environment variable to set then compiler
+path. Similarly, the ``PYTHON`` environment variable sets the python interpreter
+path.
 
 .. note::
       If your system has a NVIDIA GPU, make sure TensorFlow is installed

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ cma
 joblib
 matplotlib
 blessings
+psutil

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 # Runtime requirements for qibo
 
 # numpy (included in tf)
+# psutil already included
 tensorflow>=2.2,<=2.3.1
 scipy
 sympy
@@ -8,4 +9,3 @@ cma
 joblib
 matplotlib
 blessings
-psutil

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 # Runtime requirements for qibo
 
 # numpy (included in tf)
-# psutil already included
 tensorflow>=2.2,<=2.3.1
 scipy
 sympy
@@ -9,3 +8,4 @@ cma
 joblib
 matplotlib
 blessings
+psutil

--- a/src/qibo/__init__.py
+++ b/src/qibo/__init__.py
@@ -1,5 +1,5 @@
 __version__ = "0.1.2-dev"
-from qibo.config import set_precision, set_backend, set_device, get_backend, get_precision, get_device, matrices, K
+from qibo.config import set_precision, set_backend, set_device, get_threads,get_backend, get_precision, get_device, matrices, K
 from qibo import callbacks
 from qibo import evolution
 from qibo import models

--- a/src/qibo/__init__.py
+++ b/src/qibo/__init__.py
@@ -1,5 +1,5 @@
 __version__ = "0.1.2-dev"
-from qibo.config import set_precision, set_backend, set_device, get_threads,get_backend, get_precision, get_device, matrices, K
+from qibo.config import set_precision, set_backend, set_device, set_threads, get_threads, get_backend, get_precision, get_device, matrices, K
 from qibo import callbacks
 from qibo import evolution
 from qibo import models

--- a/src/qibo/config.py
+++ b/src/qibo/config.py
@@ -42,15 +42,31 @@ if BACKEND_NAME == "tensorflow":
     K = tf
 
     # Set the number of threads from the environment variable
-    if "OMP_NUM_THREADS" not in os.environ: # pragma: no cover
+    OMP_NUM_THREADS = None
+    if "OMP_NUM_THREADS" not in os.environ:
         import psutil
         # using physical cores by default
         cores = psutil.cpu_count(logical=False)
-        os.environ["OMP_NUM_THREADS"] = str(cores)
+        OMP_NUM_THREADS = cores
+    else: # pragma: no cover
+        OMP_NUM_THREADS = int(os.environ.get("OMP_NUM_THREADS"))
 
-    def get_threads(): # pragma: no cover
+    def get_threads():
         """Returns number of threads."""
-        return int(os.environ.get("OMP_NUM_THREADS"))
+        return OMP_NUM_THREADS
+
+    def set_threads(num_threads):
+        """Set number of OpenMP threads.
+
+        Args:
+            num_threads (int): number of threads.
+        """
+        if not isinstance(num_threads, int): # pragma: no cover
+            raise_error(RuntimeError, "Number of threads must be integer.")
+        if num_threads < 1: # pragma: no cover
+            raise_error(RuntimeError, "Number of threads must be positive.")
+        global OMP_NUM_THREADS
+        OMP_NUM_THREADS = num_threads
 
     # Numpy and Tensorflow numeric and array types
     NUMERIC_TYPES = (np.int, np.float, np.complex,

--- a/src/qibo/config.py
+++ b/src/qibo/config.py
@@ -41,23 +41,23 @@ if BACKEND_NAME == "tensorflow":
     # Backend access
     K = tf
 
-    # Set the intra number of threads to the environment flag
-    if "QIBO_NUM_THREADS" in os.environ: # pragma: no cover
-        nthreads = int(os.environ["QIBO_NUM_THREADS"])
-        tf.config.threading.set_intra_op_parallelism_threads(nthreads)
+    # Set the number of threads from the environment variable
+    if "OMP_NUM_THREADS" not in os.environ: # pragma: no cover
+        import psutil
+        # using physical cores by default
+        cores = psutil.cpu_count(logical=False)
+        os.environ["OMP_NUM_THREADS"] = str(cores)
 
-
-    THREADS = {
-        'inter': tf.config.threading.get_inter_op_parallelism_threads(),
-        'intra': tf.config.threading.get_intra_op_parallelism_threads()
-    }
+    def get_threads(): # pragma: no cover
+        """Returns number of threads."""
+        return int(os.environ.get("OMP_NUM_THREADS"))
 
     # Numpy and Tensorflow numeric and array types
     NUMERIC_TYPES = (np.int, np.float, np.complex,
                      np.int32, np.int64, np.float32,
                      np.float64, np.complex64, np.complex128)
     ARRAY_TYPES = (tf.Tensor, np.ndarray)
-    
+
     # characters used in einsum strings
     EINSUM_CHARS = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
 

--- a/src/qibo/optimizers.py
+++ b/src/qibo/optimizers.py
@@ -62,12 +62,9 @@ def newtonian(loss, initial_parameters, method='Powell', options=None, processes
         args (tuple): optional arguments for the loss function.
     """
     if method == 'parallel_L-BFGS-B': # pragma: no cover
-        from qibo.config import raise_error, get_backend, get_device, THREADS
+        from qibo.config import raise_error, get_device
         if "GPU" in get_device():
             raise_error(RuntimeError, "Parallel L-BFGS-B cannot be used with GPU.")
-        if get_backend() == 'custom' and THREADS.get("intra") != 1:
-            raise_error(RuntimeError, "Parallel L-BFGS-B runs on only on single-threaded multi-processes"
-                                      " please set the QIBO_NUM_THREADS=1 environment variable before launching Qibo.")
         o = ParallelBFGS(loss, args=args, options=options, processes=processes)
         m = o.run(initial_parameters)
     else:

--- a/src/qibo/optimizers.py
+++ b/src/qibo/optimizers.py
@@ -61,9 +61,9 @@ def newtonian(loss, initial_parameters, method='Powell', options=None, processes
         processes (int): number of processes when using the paralle BFGS method.
         args (tuple): optional arguments for the loss function.
     """
-    if method == 'parallel_L-BFGS-B': # pragma: no cover
+    if method == 'parallel_L-BFGS-B':
         from qibo.config import raise_error, get_device
-        if "GPU" in get_device():
+        if "GPU" in get_device(): # pragma: no cover
             raise_error(RuntimeError, "Parallel L-BFGS-B cannot be used with GPU.")
         o = ParallelBFGS(loss, args=args, options=options, processes=processes)
         m = o.run(initial_parameters)

--- a/src/qibo/tensorflow/cgates.py
+++ b/src/qibo/tensorflow/cgates.py
@@ -3,7 +3,7 @@
 import numpy as np
 import tensorflow as tf
 from qibo.base import gates as base_gates
-from qibo.config import BACKEND, DTYPES, DEVICES, NUMERIC_TYPES, raise_error
+from qibo.config import BACKEND, DTYPES, DEVICES, NUMERIC_TYPES, raise_error, get_threads
 from qibo.tensorflow import custom_operators as op
 from typing import Dict, List, Optional, Sequence, Tuple
 
@@ -80,13 +80,13 @@ class TensorflowGate(base_gates.Gate):
 
     def _state_vector_call(self, state: tf.Tensor) -> tf.Tensor:
         return self.gate_op(state, self.qubits_tensor, self.nqubits,
-                            *self.target_qubits)
+                            *self.target_qubits, get_threads())
 
     def _density_matrix_call(self, state: tf.Tensor) -> tf.Tensor:
         state = self.gate_op(state, self.qubits_tensor_dm, 2 * self.nqubits,
-                             *self.target_qubits)
+                             *self.target_qubits, get_threads())
         state = self.gate_op(state, self.qubits_tensor, 2 * self.nqubits,
-                             *self.target_qubits_dm)
+                             *self.target_qubits_dm, get_threads())
         return state
 
     def __call__(self, state: tf.Tensor) -> tf.Tensor:
@@ -113,14 +113,14 @@ class MatrixGate(TensorflowGate):
 
     def _state_vector_call(self, state: tf.Tensor) -> tf.Tensor:
        return self.gate_op(state, self.matrix, self.qubits_tensor,
-                           self.nqubits, *self.target_qubits)
+                           self.nqubits, *self.target_qubits, get_threads())
 
     def _density_matrix_call(self, state: tf.Tensor) -> tf.Tensor:
         state = self.gate_op(state, self.matrix, self.qubits_tensor_dm,
-                             2 * self.nqubits, *self.target_qubits)
+                             2 * self.nqubits, *self.target_qubits, get_threads())
         adjmatrix = tf.math.conj(self.matrix)
         state = self.gate_op(state, adjmatrix, self.qubits_tensor,
-                             2 * self.nqubits, *self.target_qubits_dm)
+                             2 * self.nqubits, *self.target_qubits_dm, get_threads())
         return state
 
 
@@ -209,13 +209,13 @@ class Collapse(TensorflowGate, base_gates.Collapse):
 
     def _state_vector_call(self, state: tf.Tensor) -> tf.Tensor:
         return self.gate_op(state, self.qubits_tensor, self.result_tensor,
-                            self.nqubits, self.normalize)
+                            self.nqubits, self.normalize, get_threads())
 
     def _density_matrix_call(self, state: tf.Tensor) -> tf.Tensor:
         state = self.gate_op(state, self.qubits_tensor_dm, self.result_tensor,
-                             2 * self.nqubits, False)
+                             2 * self.nqubits, False, get_threads())
         state = self.gate_op(state, self.qubits_tensor, self.result_tensor,
-                             2 * self.nqubits, False)
+                             2 * self.nqubits, False, get_threads())
         return state / tf.linalg.trace(state)
 
 
@@ -899,4 +899,4 @@ class _ThermalRelaxationChannelB(MatrixGate, base_gates._ThermalRelaxationChanne
 
     def _density_matrix_call(self, state: tf.Tensor) -> tf.Tensor:
         return self.gate_op(state, self.matrix, self.qubits_tensor,
-                            2 * self.nqubits, *self.target_qubits_dm)
+                            2 * self.nqubits, *self.target_qubits_dm, get_threads())

--- a/src/qibo/tensorflow/custom_operators/Makefile
+++ b/src/qibo/tensorflow/custom_operators/Makefile
@@ -6,6 +6,7 @@
 # Compilers
 NVCC := $(CUDA_PATH)/bin/nvcc
 PYTHON_BIN_PATH	:= python
+UNAME_S := $(shell uname -s)
 
 ifneq ($(PYTHON),)
 	PYTHON_BIN_PATH = $(PYTHON)
@@ -29,10 +30,10 @@ TF_CFLAGS := $(shell $(PYTHON_BIN_PATH) -c 'import tensorflow as tf; print(" ".j
 TF_LFLAGS := $(shell $(PYTHON_BIN_PATH) -c 'import tensorflow as tf; print(" ".join(tf.sysconfig.get_link_flags()))')
 
 CFLAGS = ${TF_CFLAGS} -fPIC -O2 -std=c++11
-ifeq ($(shell uname -s),Linux)
+ifeq ($(UNAME_S),Linux)
 	CFLAGS += -fopenmp
 endif
-ifeq ($(shell uname -s),Darwin)
+ifeq ($(UNAME_S),Darwin)
 	CFLAGS += -Xpreprocessor -fopenmp
 endif
 
@@ -40,7 +41,7 @@ CFLAGS_CUDA = $(CFLAGS) -D GOOGLE_CUDA=1 -I$(CUDA_PATH)/include
 CFLAGS_NVCC = ${TF_CFLAGS} -O2 -std=c++11 -D GOOGLE_CUDA=1 -x cu -Xcompiler -fPIC -DNDEBUG --expt-relaxed-constexpr
 
 LDFLAGS = -shared ${TF_LFLAGS}
-ifeq ($(shell uname -s),Darwin)
+ifeq ($(UNAME_S),Darwin)
 	LDFLAGS += -lomp
 endif
 

--- a/src/qibo/tensorflow/custom_operators/Makefile
+++ b/src/qibo/tensorflow/custom_operators/Makefile
@@ -28,7 +28,13 @@ SOURCES = $(filter-out $(CUDASRC), $(SRCS))
 TF_CFLAGS := $(shell $(PYTHON_BIN_PATH) -c 'import tensorflow as tf; print(" ".join(tf.sysconfig.get_compile_flags()))')
 TF_LFLAGS := $(shell $(PYTHON_BIN_PATH) -c 'import tensorflow as tf; print(" ".join(tf.sysconfig.get_link_flags()))')
 
-CFLAGS = ${TF_CFLAGS} -fPIC -O2 -std=c++11 -fopenmp
+CFLAGS = ${TF_CFLAGS} -fPIC -O2 -std=c++11
+ifneq ($(CXX),g++)
+	CFLAGS += -fopenmp
+else
+	CFLAGS += -Xpreprocessor -fopenmp
+endif
+
 CFLAGS_CUDA = $(CFLAGS) -D GOOGLE_CUDA=1 -I$(CUDA_PATH)/include
 CFLAGS_NVCC = ${TF_CFLAGS} -O2 -std=c++11 -D GOOGLE_CUDA=1 -x cu -Xcompiler -fPIC -DNDEBUG --expt-relaxed-constexpr
 

--- a/src/qibo/tensorflow/custom_operators/Makefile
+++ b/src/qibo/tensorflow/custom_operators/Makefile
@@ -28,7 +28,7 @@ SOURCES = $(filter-out $(CUDASRC), $(SRCS))
 TF_CFLAGS := $(shell $(PYTHON_BIN_PATH) -c 'import tensorflow as tf; print(" ".join(tf.sysconfig.get_compile_flags()))')
 TF_LFLAGS := $(shell $(PYTHON_BIN_PATH) -c 'import tensorflow as tf; print(" ".join(tf.sysconfig.get_link_flags()))')
 
-CFLAGS = ${TF_CFLAGS} -fPIC -O2 -std=c++11 -Xpreprocessor -fopenmp
+CFLAGS = ${TF_CFLAGS} -fPIC -O2 -std=c++11 -fopenmp
 CFLAGS_CUDA = $(CFLAGS) -D GOOGLE_CUDA=1 -I$(CUDA_PATH)/include
 CFLAGS_NVCC = ${TF_CFLAGS} -O2 -std=c++11 -D GOOGLE_CUDA=1 -x cu -Xcompiler -fPIC -DNDEBUG --expt-relaxed-constexpr
 

--- a/src/qibo/tensorflow/custom_operators/Makefile
+++ b/src/qibo/tensorflow/custom_operators/Makefile
@@ -28,7 +28,7 @@ SOURCES = $(filter-out $(CUDASRC), $(SRCS))
 TF_CFLAGS := $(shell $(PYTHON_BIN_PATH) -c 'import tensorflow as tf; print(" ".join(tf.sysconfig.get_compile_flags()))')
 TF_LFLAGS := $(shell $(PYTHON_BIN_PATH) -c 'import tensorflow as tf; print(" ".join(tf.sysconfig.get_link_flags()))')
 
-CFLAGS = ${TF_CFLAGS} -fPIC -O2 -std=c++11 -fopenmp
+CFLAGS = ${TF_CFLAGS} -fPIC -O2 -std=c++11 -Xpreprocessor -fopenmp
 CFLAGS_CUDA = $(CFLAGS) -D GOOGLE_CUDA=1 -I$(CUDA_PATH)/include
 CFLAGS_NVCC = ${TF_CFLAGS} -O2 -std=c++11 -D GOOGLE_CUDA=1 -x cu -Xcompiler -fPIC -DNDEBUG --expt-relaxed-constexpr
 

--- a/src/qibo/tensorflow/custom_operators/Makefile
+++ b/src/qibo/tensorflow/custom_operators/Makefile
@@ -29,9 +29,11 @@ TF_CFLAGS := $(shell $(PYTHON_BIN_PATH) -c 'import tensorflow as tf; print(" ".j
 TF_LFLAGS := $(shell $(PYTHON_BIN_PATH) -c 'import tensorflow as tf; print(" ".join(tf.sysconfig.get_link_flags()))')
 
 CFLAGS = ${TF_CFLAGS} -fPIC -O2 -std=c++11
-ifneq ($(CXX),g++)
+ifeq ($(shell uname -s),Linux)
 	CFLAGS += -fopenmp
-else
+endif
+
+ifeq ($(shell uname -s),Darwin)
 	CFLAGS += -Xpreprocessor -fopenmp
 endif
 

--- a/src/qibo/tensorflow/custom_operators/Makefile
+++ b/src/qibo/tensorflow/custom_operators/Makefile
@@ -28,7 +28,7 @@ SOURCES = $(filter-out $(CUDASRC), $(SRCS))
 TF_CFLAGS := $(shell $(PYTHON_BIN_PATH) -c 'import tensorflow as tf; print(" ".join(tf.sysconfig.get_compile_flags()))')
 TF_LFLAGS := $(shell $(PYTHON_BIN_PATH) -c 'import tensorflow as tf; print(" ".join(tf.sysconfig.get_link_flags()))')
 
-CFLAGS = ${TF_CFLAGS} -fPIC -O2 -std=c++11
+CFLAGS = ${TF_CFLAGS} -fPIC -O2 -std=c++11 -fopenmp
 CFLAGS_CUDA = $(CFLAGS) -D GOOGLE_CUDA=1 -I$(CUDA_PATH)/include
 CFLAGS_NVCC = ${TF_CFLAGS} -O2 -std=c++11 -D GOOGLE_CUDA=1 -x cu -Xcompiler -fPIC -DNDEBUG --expt-relaxed-constexpr
 

--- a/src/qibo/tensorflow/custom_operators/Makefile
+++ b/src/qibo/tensorflow/custom_operators/Makefile
@@ -32,7 +32,6 @@ CFLAGS = ${TF_CFLAGS} -fPIC -O2 -std=c++11
 ifeq ($(shell uname -s),Linux)
 	CFLAGS += -fopenmp
 endif
-
 ifeq ($(shell uname -s),Darwin)
 	CFLAGS += -Xpreprocessor -fopenmp
 endif
@@ -41,6 +40,10 @@ CFLAGS_CUDA = $(CFLAGS) -D GOOGLE_CUDA=1 -I$(CUDA_PATH)/include
 CFLAGS_NVCC = ${TF_CFLAGS} -O2 -std=c++11 -D GOOGLE_CUDA=1 -x cu -Xcompiler -fPIC -DNDEBUG --expt-relaxed-constexpr
 
 LDFLAGS = -shared ${TF_LFLAGS}
+ifeq ($(shell uname -s),Darwin)
+	LDFLAGS += -lomp
+endif
+
 LDFLAGS_CUDA = $(LDFLAGS) -L$(CUDA_PATH)/lib64 -lcudart
 
 OBJECT_SRCS = $(SOURCES:.cc=.o)

--- a/src/qibo/tensorflow/custom_operators/cc/kernels/apply_gate_kernels.cc
+++ b/src/qibo/tensorflow/custom_operators/cc/kernels/apply_gate_kernels.cc
@@ -248,6 +248,8 @@ class OneQubitGateOp : public OpKernel {
   explicit OneQubitGateOp(OpKernelConstruction* context) : OpKernel(context) {
     OP_REQUIRES_OK(context, context->GetAttr("nqubits", &nqubits_));
     OP_REQUIRES_OK(context, context->GetAttr("target", &target_));
+    OP_REQUIRES_OK(context, context->GetAttr("omp_num_threads", &threads_));
+    omp_set_num_threads(threads_);
   }
 
   void Compute(OpKernelContext* context) override {
@@ -278,6 +280,7 @@ class OneQubitGateOp : public OpKernel {
  private:
   int nqubits_;
   int target_;
+  int threads_;
 };
 
 template <typename Device, typename T, typename F, bool UseMatrix>
@@ -287,6 +290,8 @@ class TwoQubitGateOp : public OpKernel {
     OP_REQUIRES_OK(context, context->GetAttr("nqubits", &nqubits_));
     OP_REQUIRES_OK(context, context->GetAttr("target1", &target1_));
     OP_REQUIRES_OK(context, context->GetAttr("target2", &target2_));
+    OP_REQUIRES_OK(context, context->GetAttr("omp_num_threads", &threads_));
+    omp_set_num_threads(threads_);
   }
 
   void Compute(OpKernelContext* context) override {
@@ -317,6 +322,7 @@ class TwoQubitGateOp : public OpKernel {
  private:
   int nqubits_;
   int target1_, target2_;
+  int threads_;
 };
 
 template <typename Device, typename T, typename NormType>
@@ -325,6 +331,8 @@ class CollapseStateOp : public OpKernel {
   explicit CollapseStateOp(OpKernelConstruction* context) : OpKernel(context) {
     OP_REQUIRES_OK(context, context->GetAttr("nqubits", &nqubits_));
     OP_REQUIRES_OK(context, context->GetAttr("normalize", &normalize_));
+    OP_REQUIRES_OK(context, context->GetAttr("omp_num_threads", &threads_));
+    omp_set_num_threads(threads_);
   }
 
   void Compute(OpKernelContext* context) override {
@@ -342,7 +350,7 @@ class CollapseStateOp : public OpKernel {
   }
 
  private:
-   int nqubits_;
+   int nqubits_, threads_;
    bool normalize_;
 };
 

--- a/src/qibo/tensorflow/custom_operators/cc/kernels/transpose_state.cc
+++ b/src/qibo/tensorflow/custom_operators/cc/kernels/transpose_state.cc
@@ -56,6 +56,8 @@ class TransposeStateOp : public OpKernel {
     OP_REQUIRES_OK(context, context->GetAttr("nqubits", &nqubits_));
     OP_REQUIRES_OK(context, context->GetAttr("ndevices", &ndevices_));
     OP_REQUIRES_OK(context, context->GetAttr("qubit_order", &qubit_order_));
+    OP_REQUIRES_OK(context, context->GetAttr("omp_num_threads", &threads_));
+    omp_set_num_threads(threads_);
   }
 
   void Compute(OpKernelContext *context) override {
@@ -80,6 +82,7 @@ class TransposeStateOp : public OpKernel {
   private:
    int nqubits_;
    int ndevices_;
+   int threads_;
    std::vector<int> qubit_order_;
 };
 
@@ -90,6 +93,8 @@ class SwapPiecesOp : public OpKernel {
   explicit SwapPiecesOp(OpKernelConstruction *context) : OpKernel(context) {
     OP_REQUIRES_OK(context, context->GetAttr("nqubits", &nqubits_));
     OP_REQUIRES_OK(context, context->GetAttr("target", &target_));
+    OP_REQUIRES_OK(context, context->GetAttr("omp_num_threads", &threads_));
+    omp_set_num_threads(threads_);
   }
 
   void Compute(OpKernelContext *context) override {
@@ -112,7 +117,7 @@ class SwapPiecesOp : public OpKernel {
     context->set_output(1, piece1);
   }
   private:
-   int nqubits_, target_;
+   int nqubits_, target_, threads_;
 };
 
 

--- a/src/qibo/tensorflow/custom_operators/cc/ops/custom_ops.cc
+++ b/src/qibo/tensorflow/custom_operators/cc/ops/custom_ops.cc
@@ -19,6 +19,7 @@ REGISTER_OP("TransposeState")
     .Input("transposed_state: T")
     .Attr("nqubits: int")
     .Attr("qubit_order: list(int)")
+    .Attr("omp_num_threads: int")
     .Output("out: T")
     .SetShapeFn(::tensorflow::shape_inference::UnchangedShape);
 
@@ -30,6 +31,7 @@ REGISTER_OP("SwapPieces")
     .Input("piece1: T")
     .Attr("target: int")
     .Attr("nqubits: int")
+    .Attr("omp_num_threads: int")
     .Output("out0: T")
     .Output("out1: T")
     .SetShapeFn(::tensorflow::shape_inference::UnchangedShape);
@@ -43,6 +45,7 @@ REGISTER_OP("CollapseState")            \
     .Input("result: int64")             \
     .Attr("nqubits: int")               \
     .Attr("normalize: bool")            \
+    .Attr("omp_num_threads: int")       \
     .Output("out: T")                   \
     .SetShapeFn(::tensorflow::shape_inference::UnchangedShape);
 
@@ -56,6 +59,7 @@ REGISTER_OP("CollapseState")            \
       .Input("qubits: int32")             \
       .Attr("nqubits: int")               \
       .Attr("target: int")                \
+      .Attr("omp_num_threads: int")       \
       .Output("out: T")                   \
       .SetShapeFn(::tensorflow::shape_inference::UnchangedShape);
 
@@ -67,6 +71,7 @@ REGISTER_OP("CollapseState")            \
       .Input("qubits: int32")             \
       .Attr("nqubits: int")               \
       .Attr("target: int")                \
+      .Attr("omp_num_threads: int")       \
       .Output("out: T")                   \
       .SetShapeFn(::tensorflow::shape_inference::UnchangedShape);
 
@@ -80,6 +85,7 @@ REGISTER_OP("CollapseState")            \
       .Attr("nqubits: int")               \
       .Attr("target1: int")               \
       .Attr("target2: int")               \
+      .Attr("omp_num_threads: int")       \
       .Output("out: T")                   \
       .SetShapeFn(::tensorflow::shape_inference::UnchangedShape);
 
@@ -92,6 +98,7 @@ REGISTER_OP("CollapseState")            \
       .Attr("nqubits: int")               \
       .Attr("target1: int")               \
       .Attr("target2: int")               \
+      .Attr("omp_num_threads: int")       \
       .Output("out: T")                   \
       .SetShapeFn(::tensorflow::shape_inference::UnchangedShape);
 

--- a/src/qibo/tensorflow/custom_operators/python/ops/qibo_tf_custom_operators.py
+++ b/src/qibo/tensorflow/custom_operators/python/ops/qibo_tf_custom_operators.py
@@ -4,7 +4,7 @@ import tensorflow as tf
 import numpy as np
 from tensorflow.python.framework import load_library
 from tensorflow.python.platform import resource_loader
-from qibo.config import get_device
+from qibo.config import get_device, get_threads
 
 
 if tf.config.list_physical_devices("GPU"): # pragma: no cover
@@ -26,7 +26,7 @@ transpose_state = custom_module.transpose_state
 swap_pieces = custom_module.swap_pieces
 
 # apply_gate operator
-def apply_gate(state, gate, qubits, nqubits, target):
+def apply_gate(state, gate, qubits, nqubits, target, omp_num_threads=get_threads()):
     """Applies arbitrary one-qubit gate to a state vector.
 
     Modifies ``state`` in-place.
@@ -46,7 +46,7 @@ def apply_gate(state, gate, qubits, nqubits, target):
         state (tf.Tensor): State vector of shape ``(2 ** nqubits,)`` after
             ``gate`` is applied.
     """
-    return custom_module.apply_gate(state, gate, qubits, nqubits, target)
+    return custom_module.apply_gate(state, gate, qubits, nqubits, target, omp_num_threads)
 
 
 apply_two_qubit_gate = custom_module.apply_two_qubit_gate
@@ -64,5 +64,5 @@ apply_fsim = custom_module.apply_fsim
 
 apply_swap = custom_module.apply_swap
 
-def collapse_state(state, qubits, result, nqubits, normalize=True):
-    return custom_module.collapse_state(state, qubits, result, nqubits, normalize)
+def collapse_state(state, qubits, result, nqubits, normalize=True, omp_num_threads=get_threads()):
+    return custom_module.collapse_state(state, qubits, result, nqubits, normalize, omp_num_threads)

--- a/src/qibo/tensorflow/distcircuit.py
+++ b/src/qibo/tensorflow/distcircuit.py
@@ -3,7 +3,7 @@
 import numpy as np
 import tensorflow as tf
 import joblib
-from qibo.config import raise_error
+from qibo.config import raise_error, get_threads
 from qibo.base import gates
 from qibo import gates as gate_module
 from qibo.tensorflow import callbacks, circuit, measurements
@@ -157,7 +157,7 @@ class TensorflowDistributedCircuit(circuit.TensorflowCircuit):
             local_eff = self.queues.qubits.reduced_local[local_qubit]
             with tf.device(self.memory_device):
                 op.swap_pieces(state.pieces[i], state.pieces[i + t],
-                               local_eff, self.nlocal)
+                               local_eff, self.nlocal, get_threads())
 
     def _normalize(self, state: utils.DistributedState):
         """Normalizes state by summing the norms of each state piece.

--- a/src/qibo/tensorflow/distutils.py
+++ b/src/qibo/tensorflow/distutils.py
@@ -3,7 +3,7 @@ import numpy as np
 import tensorflow as tf
 from qibo.base import gates
 from qibo.tensorflow import custom_operators as op
-from qibo.config import DTYPES, raise_error
+from qibo.config import DTYPES, raise_error, get_threads
 from typing import Dict, List, Optional, Sequence, Tuple
 
 
@@ -434,7 +434,8 @@ class DistributedState(DistributedBase):
             pieces = [full_state[i] for i in range(self.ndevices)]
             new_state = tf.zeros(self.shapes["device"], dtype=self.dtype)
             new_state = op.transpose_state(pieces, new_state, self.nqubits,
-                                           self.qubits.transpose_order)
+                                           self.qubits.transpose_order,
+                                           get_threads())
             for i in range(self.ndevices):
                 self.pieces[i].assign(new_state[i])
 
@@ -457,7 +458,8 @@ class DistributedState(DistributedBase):
             with tf.device(self.device):
                 state = tf.zeros(self.shapes["full"], dtype=self.dtype)
                 state = op.transpose_state(self.pieces, state, self.nqubits,
-                                           self.qubits.reverse_transpose_order)
+                                           self.qubits.reverse_transpose_order,
+                                           get_threads())
         return state
 
     def __len__(self) -> int:

--- a/src/qibo/tests/test_vqe.py
+++ b/src/qibo/tests/test_vqe.py
@@ -3,6 +3,7 @@ Testing Variational Quantum Eigensolver.
 """
 import numpy as np
 import pytest
+from qibo.config import get_threads, set_threads
 from qibo import gates
 from qibo.models import Circuit, VQE
 from qibo.hamiltonians import XXZ
@@ -14,6 +15,8 @@ test_values = [("Powell", {'maxiter': 1}, True, 'vqe_powell.out'),
                ("Powell", {'maxiter': 1}, False, 'vqe_powell.out'),
                ("BFGS", {'maxiter': 1}, True, 'vqe_bfgs.out'),
                ("BFGS", {'maxiter': 1}, False, 'vqe_bfgs.out'),
+               ("parallel_L-BFGS-B", {'maxiter': 1}, True, None),
+               ("parallel_L-BFGS-B", {'maxiter': 1}, False, None),
                ("cma", {"maxfevals": 2}, False, None),
                ("sgd", {"nepochs": 5}, False, None),
                ("sgd", {"nepochs": 5}, True, None)]
@@ -26,6 +29,10 @@ def test_vqe(method, options, compile, filename):
         qibo.set_backend("matmuleinsum")
     else:
         qibo.set_backend("custom")
+
+    original_threads = get_threads()
+    if method == 'parallel_L-BFGS-B':
+        qibo.set_threads(1)
 
     nqubits = 6
     layers  = 4
@@ -57,6 +64,7 @@ def test_vqe(method, options, compile, filename):
     if filename is not None:
         utils.assert_regression_fixture(params, filename)
     qibo.set_backend(original_backend)
+    qibo.set_threads(original_threads)
 
 
 def test_vqe_custom_gates_errors():


### PR DESCRIPTION
This PR replace the TF thread pool mechanism with OpenMP.

This approach opens the possibility to:
- control the number of threads of each custom operator
- provides the `set_threads` and `get_threads` methods to set and get the number of threads. 
- by default we use the env variable OMP_NUM_THREADS, otherwise, if not set, we take the number of physical cores.
- adds a test for the parallel_L-BFGS-B optimizer