### PR TITLE
testing wheels

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -41,13 +41,24 @@ jobs:
     - name: Build macos wheels
       if: startsWith(matrix.os, 'macos')
       run: |
+        python -m pip install --upgrade pip
         pip install -r requirements.txt
         python setup.py bdist_wheel
+        pip install delocate
+        cd dist
+        delocate-wheel -v `ls`
     - name: Store wheels as artifacts
       uses: actions/upload-artifact@v1
       with:
         name: wheels
         path: dist
+    - name: Test wheels
+      run: |
+        python -m pip install --upgrade pip
+        pip install pytest cirq ply sklearn
+        pip install -r requirements.txt
+        pip install qibo --no-index --find-links ./dist/
+        pytest --pyargs qibo
   deploy:
     runs-on: ubuntu-latest
     needs: build


### PR DESCRIPTION
This PR introduces a check for generated whl files. This also fixes the libomp dependency, now the user does not need to install libomp with homebrew before using Qibo.

There is an issue that has to be solved for linux https://github.com/pypa/manylinux/issues/836