### PR TITLE
Trainable flag for parametrized gates

### DIFF
--- a/doc/source/advancedexamples.rst
+++ b/doc/source/advancedexamples.rst
@@ -318,10 +318,31 @@ The following gates support parameter setting:
     # rotations and five additional RX rotations are added afterwards.
 
 Note that a ``np.ndarray`` or a ``tf.Tensor`` may also be used in the place of
-a flat list.
+a flat list. Using :meth:`qibo.base.circuit.BaseCircuit.set_parameters` is more
+efficient than recreating a new circuit with new parameter values. The inverse
+method :meth:`qibo.base.circuit.BaseCircuit.get_parameters` is also available
+and returns a list, dictionary or flat list with the current parameter values
+of all parametrized gates in the circuit.
 
-Using :meth:`qibo.base.circuit.BaseCircuit.set_parameters` is more efficient than
-recreating a new circuit with new parameter values.
+It is possible to hide a parametrized gate from the action of
+:meth:`qibo.base.circuit.BaseCircuit.get_parameters` and
+:meth:`qibo.base.circuit.BaseCircuit.set_parameters` by setting
+the ``trainable=False`` during gate creation. For example:
+
+.. code-block::  python
+
+    c = Circuit(3)
+    c.add(gates.RX(0, theta=0.123))
+    c.add(gates.RY(1, theta=0.456, trainable=False))
+    c.add(gates.fSim(0, 2, theta=0.789, phi=0.567))
+
+    print(c.get_parameters())
+    # prints [0.123, (0.789, 0.567)] ignoring the parameters of the RY gate
+
+
+This is useful when the user wants to freeze the parameters of specific
+gates during optimization.
+Note that ``trainable`` defaults to ``True`` for all parametrized gates.
 
 
 How to invert a circuit?

--- a/src/qibo/base/abstract_gates.py
+++ b/src/qibo/base/abstract_gates.py
@@ -248,10 +248,11 @@ class ParametrizedGate(Gate):
     Implements the basic functionality of parameter setters and getters.
     """
 
-    def __init__(self):
+    def __init__(self, trainable=True):
         super(ParametrizedGate, self).__init__()
         self.parameter_names = "theta"
         self.nparams = 1
+        self.trainable = trainable
         self._parameters = None
 
     @property

--- a/src/qibo/base/circuit.py
+++ b/src/qibo/base/circuit.py
@@ -42,7 +42,7 @@ class _Queue(list):
         self.moments = [nqubits * [None]]
         self.moment_index = nqubits * [0]
 
-    def append(self, gate: gates.ParametrizedGate):
+    def append(self, gate: gates.Gate):
         super(_Queue, self).append(gate)
         # Calculate moment index for this gate
         if gate.qubits:
@@ -123,7 +123,7 @@ class BaseCircuit(ABC):
         # Add gates from `self` to `newcircuit` (including measurements)
         for gate in self.queue:
             newcircuit.queue.append(gate)
-            if isinstance(gate, gates.ParametrizedGate):
+            if isinstance(gate, gates.ParametrizedGate) and gate.trainable:
                 newcircuit.parametrized_gates.append(gate)
         newcircuit.measurement_gate = self.measurement_gate
         newcircuit.measurement_tuples = self.measurement_tuples
@@ -131,7 +131,7 @@ class BaseCircuit(ABC):
         for gate in circuit.queue:
             newcircuit.check_measured(gate.qubits)
             newcircuit.queue.append(gate)
-            if isinstance(gate, gates.ParametrizedGate):
+            if isinstance(gate, gates.ParametrizedGate) and gate.trainable:
                 newcircuit.parametrized_gates.append(gate)
 
         if newcircuit.measurement_gate is None:
@@ -193,7 +193,7 @@ class BaseCircuit(ABC):
             for gate in self.queue:
                 new_gate = copy.copy(gate)
                 new_circuit.queue.append(new_gate)
-                if isinstance(gate, gates.ParametrizedGate):
+                if isinstance(gate, gates.ParametrizedGate) and gate.trainable:
                     new_circuit.parametrized_gates.append(new_gate)
             new_circuit.measurement_gate = copy.copy(self.measurement_gate)
             if self.fusion_groups: # pragma: no cover
@@ -236,7 +236,7 @@ class BaseCircuit(ABC):
         import copy
         new_circuit = self.__class__(**self.init_kwargs)
         for gate in self.queue:
-            if isinstance(gate, gates.ParametrizedGate):
+            if isinstance(gate, gates.ParametrizedGate) and gate.trainable:
                 new_gate = copy.copy(gate)
                 new_circuit.queue.append(new_gate)
                 new_circuit.parametrized_gates.append(new_gate)
@@ -440,7 +440,7 @@ class BaseCircuit(ABC):
             self.queue.append(gate)
             if isinstance(gate, gates.UnitaryChannel):
                 self.repeated_execution = not self.density_matrix
-        if isinstance(gate, gates.ParametrizedGate):
+        if isinstance(gate, gates.ParametrizedGate) and gate.trainable:
             self.parametrized_gates.append(gate)
 
     def set_nqubits(self, gate: gates.Gate):

--- a/src/qibo/base/circuit.py
+++ b/src/qibo/base/circuit.py
@@ -595,11 +595,13 @@ class BaseCircuit(ABC):
             if self.fusion_groups:
                 raise_error(TypeError, "Cannot accept new parameters as dictionary "
                                        "for fused circuits. Use list, tuple or array.")
-            if set(parameters.keys()) != self.parametrized_gates.set:
-                raise_error(ValueError, "Dictionary with gate parameters does not "
-                                        "agree with the circuit gates.")
-            for gate in self.parametrized_gates:
-                gate.parameters = parameters[gate]
+            diff = set(parameters.keys()) - self.parametrized_gates.set
+            if diff:
+                raise_error(KeyError, "Dictionary contains gates {} which are "
+                                      "not on the list of parametrized gates "
+                                      "of the circuit.".format(diff))
+            for gate, params in parameters.items():
+                gate.parameters = params
         else:
             raise_error(TypeError, "Invalid type of parameters {}."
                                    "".format(type(parameters)))

--- a/src/qibo/base/gates.py
+++ b/src/qibo/base/gates.py
@@ -305,6 +305,9 @@ class _Rn_(ParametrizedGate):
     Args:
         q (int): the qubit id number.
         theta (float): the rotation angle.
+        trainable (bool): whether gate parameters can be updated using
+            :meth:`qibo.base.circuit.BaseCircuit.set_parameters`
+            (default is ``True``).
     """
     axis = "n"
 
@@ -347,6 +350,9 @@ class RX(_Rn_):
     Args:
         q (int): the qubit id number.
         theta (float): the rotation angle.
+        trainable (bool): whether gate parameters can be updated using
+            :meth:`qibo.base.circuit.BaseCircuit.set_parameters`
+            (default is ``True``).
     """
     axis = "x"
 
@@ -367,6 +373,9 @@ class RY(_Rn_):
     Args:
         q (int): the qubit id number.
         theta (float): the rotation angle.
+        trainable (bool): whether gate parameters can be updated using
+            :meth:`qibo.base.circuit.BaseCircuit.set_parameters`
+            (default is ``True``).
     """
     axis = "y"
 
@@ -385,6 +394,9 @@ class RZ(_Rn_):
     Args:
         q (int): the qubit id number.
         theta (float): the rotation angle.
+        trainable (bool): whether gate parameters can be updated using
+            :meth:`qibo.base.circuit.BaseCircuit.set_parameters`
+            (default is ``True``).
     """
     axis = "z"
 
@@ -394,6 +406,9 @@ class _Un_(ParametrizedGate):
 
     Args:
         q (int): the qubit id number.
+        trainable (bool): whether gate parameters can be updated using
+            :meth:`qibo.base.circuit.BaseCircuit.set_parameters`
+            (default is ``True``).
     """
     order = 0
 
@@ -429,6 +444,9 @@ class U1(_Un_):
     Args:
         q (int): the qubit id number.
         theta (float): the rotation angle.
+        trainable (bool): whether gate parameters can be updated using
+            :meth:`qibo.base.circuit.BaseCircuit.set_parameters`
+            (default is ``True``).
     """
     order = 1
 
@@ -458,6 +476,9 @@ class U2(_Un_):
         q (int): the qubit id number.
         phi (float): first rotation angle.
         lamb (float): second rotation angle.
+        trainable (bool): whether gate parameters can be updated using
+            :meth:`qibo.base.circuit.BaseCircuit.set_parameters`
+            (default is ``True``).
     """
     order = 2
 
@@ -492,6 +513,9 @@ class U3(_Un_):
         theta (float): first rotation angle.
         phi (float): second rotation angle.
         lamb (float): third rotation angle.
+        trainable (bool): whether gate parameters can be updated using
+            :meth:`qibo.base.circuit.BaseCircuit.set_parameters`
+            (default is ``True``).
     """
     order = 3
 
@@ -524,6 +548,9 @@ class ZPow(Gate): # pragma: no cover
     Args:
         q (int): the qubit id number.
         theta (float): the rotation angle.
+        trainable (bool): whether gate parameters can be updated using
+            :meth:`qibo.base.circuit.BaseCircuit.set_parameters`
+            (default is ``True``).
     """
     # This class exists only for documentation purposes.
     def __new__(cls, q, theta, trainable=True):
@@ -593,6 +620,9 @@ class _CRn_(ParametrizedGate):
         q0 (int): the control qubit id number.
         q1 (int): the target qubit id number.
         theta (float): the rotation angle.
+        trainable (bool): whether gate parameters can be updated using
+            :meth:`qibo.base.circuit.BaseCircuit.set_parameters`
+            (default is ``True``).
     """
     axis = "n"
 
@@ -630,6 +660,9 @@ class CRX(_CRn_):
         q0 (int): the control qubit id number.
         q1 (int): the target qubit id number.
         theta (float): the rotation angle.
+        trainable (bool): whether gate parameters can be updated using
+            :meth:`qibo.base.circuit.BaseCircuit.set_parameters`
+            (default is ``True``).
     """
     axis = "x"
 
@@ -653,6 +686,9 @@ class CRY(_CRn_):
         q0 (int): the control qubit id number.
         q1 (int): the target qubit id number.
         theta (float): the rotation angle.
+        trainable (bool): whether gate parameters can be updated using
+            :meth:`qibo.base.circuit.BaseCircuit.set_parameters`
+            (default is ``True``).
     """
     axis = "y"
 
@@ -674,6 +710,9 @@ class CRZ(_CRn_):
         q0 (int): the control qubit id number.
         q1 (int): the target qubit id number.
         theta (float): the rotation angle.
+        trainable (bool): whether gate parameters can be updated using
+            :meth:`qibo.base.circuit.BaseCircuit.set_parameters`
+            (default is ``True``).
     """
     axis = "z"
 
@@ -684,6 +723,9 @@ class _CUn_(ParametrizedGate):
     Args:
         q0 (int): the control qubit id number.
         q1 (int): the target qubit id number.
+        trainable (bool): whether gate parameters can be updated using
+            :meth:`qibo.base.circuit.BaseCircuit.set_parameters`
+            (default is ``True``).
     """
     order = 0
 
@@ -716,6 +758,9 @@ class CU1(_CUn_):
         q0 (int): the control qubit id number.
         q1 (int): the target qubit id number.
         theta (float): the rotation angle.
+        trainable (bool): whether gate parameters can be updated using
+            :meth:`qibo.base.circuit.BaseCircuit.set_parameters`
+            (default is ``True``).
     """
     order = 1
 
@@ -750,6 +795,9 @@ class CU2(_CUn_):
         q1 (int): the target qubit id number.
         phi (float): first rotation angle.
         lamb (float): second rotation angle.
+        trainable (bool): whether gate parameters can be updated using
+            :meth:`qibo.base.circuit.BaseCircuit.set_parameters`
+            (default is ``True``).
     """
     order = 2
 
@@ -789,6 +837,9 @@ class CU3(_CUn_):
         theta (float): first rotation angle.
         phi (float): second rotation angle.
         lamb (float): third rotation angle.
+        trainable (bool): whether gate parameters can be updated using
+            :meth:`qibo.base.circuit.BaseCircuit.set_parameters`
+            (default is ``True``).
     """
     order = 3
 
@@ -826,6 +877,9 @@ class CZPow(Gate): # pragma: no cover
         q0 (int): the control qubit id number.
         q1 (int): the target qubit id number.
         theta (float): the rotation angle.
+        trainable (bool): whether gate parameters can be updated using
+            :meth:`qibo.base.circuit.BaseCircuit.set_parameters`
+            (default is ``True``).
     """
     def __new__(cls, q0, q1, theta, trainable=True): # pragma: no cover
         # code is not tested as it is substituted in `tensorflow` gates
@@ -875,6 +929,9 @@ class fSim(ParametrizedGate):
         q1 (int): the second qubit to be swapped id number.
         theta (float): Angle for the one-qubit rotation.
         phi (float): Angle for the |11> phase.
+        trainable (bool): whether gate parameters can be updated using
+            :meth:`qibo.base.circuit.BaseCircuit.set_parameters`
+            (default is ``True``).
     """
     # TODO: Check how this works with QASM.
 
@@ -914,6 +971,9 @@ class GeneralizedfSim(ParametrizedGate):
         q1 (int): the second qubit to be swapped id number.
         unitary (np.ndarray): Unitary that corresponds to the one-qubit rotation.
         phi (float): Angle for the |11> phase.
+        trainable (bool): whether gate parameters can be updated using
+            :meth:`qibo.base.circuit.BaseCircuit.set_parameters`
+            (default is ``True``).
     """
 
     def __init__(self, q0, q1, unitary, phi, trainable=True):
@@ -1004,6 +1064,9 @@ class Unitary(ParametrizedGate):
             Note that there is no check that the matrix passed is actually
             unitary. This allows the user to create non-unitary gates.
         *q (int): Qubit id numbers that the gate acts on.
+        trainable (bool): whether gate parameters can be updated using
+            :meth:`qibo.base.circuit.BaseCircuit.set_parameters`
+            (default is ``True``).
         name (str): Optional name for the gate.
     """
 
@@ -1065,6 +1128,9 @@ class VariationalLayer(ParametrizedGate):
         params2 (list): Variational parameters of one-qubit gates as a list that
             has the same length as ``qubits``. These gates act after the layer
             of entangling gates.
+        trainable (bool): whether gate parameters can be updated using
+            :meth:`qibo.base.circuit.BaseCircuit.set_parameters`
+            (default is ``True``).
         name (str): Optional name for the gate.
             If ``None`` the name ``"VariationalLayer"`` will be used.
 

--- a/src/qibo/base/gates.py
+++ b/src/qibo/base/gates.py
@@ -435,7 +435,7 @@ class U1(_Un_):
     def __init__(self, q, theta, trainable=True):
         super(U1, self).__init__(q, trainable=trainable)
         self.parameters = theta
-        self.init_kwargs = {"theta": theta}
+        self.init_kwargs = {"theta": theta, "trainable": trainable}
 
     def _dagger(self) -> "Gate":
         """"""
@@ -464,7 +464,7 @@ class U2(_Un_):
     def __init__(self, q, phi, lam, trainable=True):
         super(U2, self).__init__(q, trainable=trainable)
         self._phi, self._lam = None, None
-        self.init_kwargs = {"phi": phi, "lam": lam}
+        self.init_kwargs = {"phi": phi, "lam": lam, "trainable": trainable}
         self.parameter_names = ["phi", "lam"]
         self.parameters = phi, lam
 
@@ -498,7 +498,8 @@ class U3(_Un_):
     def __init__(self, q, theta, phi, lam, trainable=True):
         super(U3, self).__init__(q, trainable=trainable)
         self._theta, self._phi, self._lam = None, None, None
-        self.init_kwargs = {"theta": theta, "phi": phi, "lam": lam}
+        self.init_kwargs = {"theta": theta, "phi": phi, "lam": lam,
+                            "trainable": trainable}
         self.parameter_names = ["theta", "phi", "lam"]
         self.parameters = theta, phi, lam
 
@@ -603,7 +604,7 @@ class _CRn_(ParametrizedGate):
         self.parameters = theta
 
         self.init_args = [q0, q1]
-        self.init_kwargs = {"theta": theta}
+        self.init_kwargs = {"theta": theta, "trainable": trainable}
 
     def _dagger(self) -> "Gate":
         """"""
@@ -693,6 +694,7 @@ class _CUn_(ParametrizedGate):
         self.control_qubits = (q0,)
         self.target_qubits = (q1,)
         self.init_args = [q0, q1]
+        self.init_kwargs = {"trainable": trainable}
 
 
 class CU1(_CUn_):
@@ -720,7 +722,7 @@ class CU1(_CUn_):
     def __init__(self, q0, q1, theta, trainable=True):
         super(CU1, self).__init__(q0, q1, trainable=trainable)
         self.parameters = theta
-        self.init_kwargs = {"theta": theta}
+        self.init_kwargs = {"theta": theta, "trainable": trainable}
 
     def _dagger(self) -> "Gate":
         """"""
@@ -753,7 +755,7 @@ class CU2(_CUn_):
 
     def __init__(self, q0, q1, phi, lam, trainable=True):
         super(CU2, self).__init__(q0, q1, trainable=trainable)
-        self.init_kwargs = {"phi": phi, "lam": lam}
+        self.init_kwargs = {"phi": phi, "lam": lam, "trainable": trainable}
 
         self.parameter_names = ["phi", "lam"]
         self.parameters = phi, lam
@@ -793,7 +795,8 @@ class CU3(_CUn_):
     def __init__(self, q0, q1, theta, phi, lam, trainable=True):
         super(CU3, self).__init__(q0, q1, trainable=trainable)
         self._theta, self._phi, self._lam = None, None, None
-        self.init_kwargs = {"theta": theta, "phi": phi, "lam": lam}
+        self.init_kwargs = {"theta": theta, "phi": phi, "lam": lam,
+                            "trainable": trainable}
         self.parameter_names = ["theta", "phi", "lam"]
         self.parameters = theta, phi, lam
 
@@ -885,7 +888,7 @@ class fSim(ParametrizedGate):
         self.nparams = 2
 
         self.init_args = [q0, q1]
-        self.init_kwargs = {"theta": theta, "phi": phi}
+        self.init_kwargs = {"theta": theta, "phi": phi, "trainable": trainable}
 
     def _dagger(self) -> "Gate":
         """"""
@@ -923,7 +926,8 @@ class GeneralizedfSim(ParametrizedGate):
         self.nparams = 5
 
         self.init_args = [q0, q1]
-        self.init_kwargs = {"unitary": unitary, "phi": phi}
+        self.init_kwargs = {"unitary": unitary, "phi": phi,
+                            "trainable": trainable}
 
     @abstractmethod
     def _dagger(self) -> "Gate": # pragma: no cover
@@ -1013,7 +1017,7 @@ class Unitary(ParametrizedGate):
         self.nparams = 4 ** len(self.target_qubits)
 
         self.init_args = [unitary] + list(q)
-        self.init_kwargs = {"name": name}
+        self.init_kwargs = {"name": name, "trainable": trainable}
 
     @property
     def rank(self) -> int:
@@ -1093,7 +1097,8 @@ class VariationalLayer(ParametrizedGate):
                  name: Optional[str] = None):
         super(VariationalLayer, self).__init__(trainable)
         self.init_args = [qubits, pairs, one_qubit_gate, two_qubit_gate]
-        self.init_kwargs = {"params": params, "params2": params2, "name": name}
+        self.init_kwargs = {"params": params, "params2": params2,
+                            "trainable": trainable, "name": name}
         self.name = "VariationalLayer" if name is None else name
 
         self.target_qubits = tuple(qubits)

--- a/src/qibo/base/gates.py
+++ b/src/qibo/base/gates.py
@@ -308,14 +308,14 @@ class _Rn_(ParametrizedGate):
     """
     axis = "n"
 
-    def __init__(self, q, theta):
-        super(_Rn_, self).__init__()
+    def __init__(self, q, theta, trainable=True):
+        super(_Rn_, self).__init__(trainable)
         self.name = "r{}".format(self.axis)
         self.target_qubits = (q,)
 
         self.parameters = theta
         self.init_args = [q]
-        self.init_kwargs = {"theta": theta}
+        self.init_kwargs = {"theta": theta, "trainable": trainable}
 
     def _dagger(self) -> "Gate":
         """"""
@@ -397,12 +397,13 @@ class _Un_(ParametrizedGate):
     """
     order = 0
 
-    def __init__(self, q):
-        super(_Un_, self).__init__()
+    def __init__(self, q, trainable=True):
+        super(_Un_, self).__init__(trainable)
         self.name = "u{}".format(self.order)
         self.nparams = self.order
         self.target_qubits = (q,)
         self.init_args = [q]
+        self.init_kwargs = {"trainable": trainable}
 
     def controlled_by(self, *q):
         """Fall back to CUn if there is only one control."""
@@ -431,8 +432,8 @@ class U1(_Un_):
     """
     order = 1
 
-    def __init__(self, q, theta):
-        super(U1, self).__init__(q)
+    def __init__(self, q, theta, trainable=True):
+        super(U1, self).__init__(q, trainable=trainable)
         self.parameters = theta
         self.init_kwargs = {"theta": theta}
 
@@ -460,8 +461,8 @@ class U2(_Un_):
     """
     order = 2
 
-    def __init__(self, q, phi, lam):
-        super(U2, self).__init__(q)
+    def __init__(self, q, phi, lam, trainable=True):
+        super(U2, self).__init__(q, trainable=trainable)
         self._phi, self._lam = None, None
         self.init_kwargs = {"phi": phi, "lam": lam}
         self.parameter_names = ["phi", "lam"]
@@ -494,8 +495,8 @@ class U3(_Un_):
     """
     order = 3
 
-    def __init__(self, q, theta, phi, lam):
-        super(U3, self).__init__(q)
+    def __init__(self, q, theta, phi, lam, trainable=True):
+        super(U3, self).__init__(q, trainable=trainable)
         self._theta, self._phi, self._lam = None, None, None
         self.init_kwargs = {"theta": theta, "phi": phi, "lam": lam}
         self.parameter_names = ["theta", "phi", "lam"]
@@ -524,8 +525,8 @@ class ZPow(Gate): # pragma: no cover
         theta (float): the rotation angle.
     """
     # This class exists only for documentation purposes.
-    def __new__(cls, q, theta):
-        return U1(q, theta)
+    def __new__(cls, q, theta, trainable=True):
+        return U1(q, theta, trainable=trainable)
 
 
 class CNOT(Gate):
@@ -594,8 +595,8 @@ class _CRn_(ParametrizedGate):
     """
     axis = "n"
 
-    def __init__(self, q0, q1, theta):
-        super(_CRn_, self).__init__()
+    def __init__(self, q0, q1, theta, trainable=True):
+        super(_CRn_, self).__init__(trainable)
         self.name = "cr{}".format(self.axis)
         self.control_qubits = (q0,)
         self.target_qubits = (q1,)
@@ -685,8 +686,8 @@ class _CUn_(ParametrizedGate):
     """
     order = 0
 
-    def __init__(self, q0, q1):
-        super(_CUn_, self).__init__()
+    def __init__(self, q0, q1, trainable=True):
+        super(_CUn_, self).__init__(trainable)
         self.name = "cu{}".format(self.order)
         self.nparams = self.order
         self.control_qubits = (q0,)
@@ -716,8 +717,8 @@ class CU1(_CUn_):
     """
     order = 1
 
-    def __init__(self, q0, q1, theta):
-        super(CU1, self).__init__(q0, q1)
+    def __init__(self, q0, q1, theta, trainable=True):
+        super(CU1, self).__init__(q0, q1, trainable=trainable)
         self.parameters = theta
         self.init_kwargs = {"theta": theta}
 
@@ -750,8 +751,8 @@ class CU2(_CUn_):
     """
     order = 2
 
-    def __init__(self, q0, q1, phi, lam):
-        super(CU2, self).__init__(q0, q1)
+    def __init__(self, q0, q1, phi, lam, trainable=True):
+        super(CU2, self).__init__(q0, q1, trainable=trainable)
         self.init_kwargs = {"phi": phi, "lam": lam}
 
         self.parameter_names = ["phi", "lam"]
@@ -789,8 +790,8 @@ class CU3(_CUn_):
     """
     order = 3
 
-    def __init__(self, q0, q1, theta, phi, lam):
-        super(CU3, self).__init__(q0, q1)
+    def __init__(self, q0, q1, theta, phi, lam, trainable=True):
+        super(CU3, self).__init__(q0, q1, trainable=trainable)
         self._theta, self._phi, self._lam = None, None, None
         self.init_kwargs = {"theta": theta, "phi": phi, "lam": lam}
         self.parameter_names = ["theta", "phi", "lam"]
@@ -823,9 +824,9 @@ class CZPow(Gate): # pragma: no cover
         q1 (int): the target qubit id number.
         theta (float): the rotation angle.
     """
-    def __new__(cls, q0, q1, theta): # pragma: no cover
+    def __new__(cls, q0, q1, theta, trainable=True): # pragma: no cover
         # code is not tested as it is substituted in `tensorflow` gates
-        return CU1(q0, q1, theta)
+        return CU1(q0, q1, theta, trainable=trainable)
 
 
 class SWAP(Gate):
@@ -874,8 +875,8 @@ class fSim(ParametrizedGate):
     """
     # TODO: Check how this works with QASM.
 
-    def __init__(self, q0, q1, theta, phi):
-        super(fSim, self).__init__()
+    def __init__(self, q0, q1, theta, phi, trainable=True):
+        super(fSim, self).__init__(trainable)
         self.name = "fsim"
         self.target_qubits = (q0, q1)
 
@@ -912,8 +913,8 @@ class GeneralizedfSim(ParametrizedGate):
         phi (float): Angle for the |11> phase.
     """
 
-    def __init__(self, q0, q1, unitary, phi):
-        super(GeneralizedfSim, self).__init__()
+    def __init__(self, q0, q1, unitary, phi, trainable=True):
+        super(GeneralizedfSim, self).__init__(trainable)
         self.name = "generalizedfsim"
         self.target_qubits = (q0, q1)
 
@@ -1002,8 +1003,8 @@ class Unitary(ParametrizedGate):
         name (str): Optional name for the gate.
     """
 
-    def __init__(self, unitary, *q, name: Optional[str] = None):
-        super(Unitary, self).__init__()
+    def __init__(self, unitary, *q, trainable=True, name=None):
+        super(Unitary, self).__init__(trainable)
         self.name = "Unitary" if name is None else name
         self.target_qubits = tuple(q)
 
@@ -1088,8 +1089,9 @@ class VariationalLayer(ParametrizedGate):
     def __init__(self, qubits: List[int], pairs: List[Tuple[int, int]],
                  one_qubit_gate, two_qubit_gate,
                  params: List[float], params2: Optional[List[float]] = None,
+                 trainable: bool = True,
                  name: Optional[str] = None):
-        super(VariationalLayer, self).__init__()
+        super(VariationalLayer, self).__init__(trainable)
         self.init_args = [qubits, pairs, one_qubit_gate, two_qubit_gate]
         self.init_kwargs = {"params": params, "params2": params2, "name": name}
         self.name = "VariationalLayer" if name is None else name

--- a/src/qibo/tensorflow/cgates.py
+++ b/src/qibo/tensorflow/cgates.py
@@ -320,9 +320,9 @@ class M(TensorflowGate, gates.M):
 
 class RX(MatrixGate, gates.RX):
 
-    def __init__(self, q, theta):
+    def __init__(self, q, theta, trainable=True):
         MatrixGate.__init__(self)
-        gates.RX.__init__(self, q, theta)
+        gates.RX.__init__(self, q, theta, trainable)
 
     def construct_unitary(self) -> np.ndarray:
         theta = self.parameters
@@ -332,9 +332,9 @@ class RX(MatrixGate, gates.RX):
 
 class RY(MatrixGate, gates.RY):
 
-    def __init__(self, q, theta):
+    def __init__(self, q, theta, trainable=True):
         MatrixGate.__init__(self)
-        gates.RY.__init__(self, q, theta)
+        gates.RY.__init__(self, q, theta, trainable)
 
     def construct_unitary(self) -> np.ndarray:
         theta = self.parameters
@@ -344,9 +344,9 @@ class RY(MatrixGate, gates.RY):
 
 class RZ(MatrixGate, gates.RZ):
 
-    def __init__(self, q, theta):
+    def __init__(self, q, theta, trainable=True):
         MatrixGate.__init__(self)
-        gates.RZ.__init__(self, q, theta)
+        gates.RZ.__init__(self, q, theta, trainable)
 
     def construct_unitary(self) -> np.ndarray:
         phase = np.exp(1j * self.parameters / 2.0)
@@ -355,9 +355,9 @@ class RZ(MatrixGate, gates.RZ):
 
 class U1(MatrixGate, gates.U1):
 
-    def __init__(self, q, theta):
+    def __init__(self, q, theta, trainable=True):
         MatrixGate.__init__(self)
-        gates.U1.__init__(self, q, theta)
+        gates.U1.__init__(self, q, theta, trainable)
         self.gate_op = op.apply_z_pow
 
     def reprepare(self):
@@ -372,9 +372,9 @@ class U1(MatrixGate, gates.U1):
 
 class U2(MatrixGate, gates.U2):
 
-    def __init__(self, q, phi, lam):
+    def __init__(self, q, phi, lam, trainable=True):
         MatrixGate.__init__(self)
-        gates.U2.__init__(self, q, phi, lam)
+        gates.U2.__init__(self, q, phi, lam, trainable)
 
     def construct_unitary(self) -> np.ndarray:
         phi, lam = self.parameters
@@ -386,9 +386,9 @@ class U2(MatrixGate, gates.U2):
 
 class U3(MatrixGate, gates.U3):
 
-    def __init__(self, q, theta, phi, lam):
+    def __init__(self, q, theta, phi, lam, trainable=True):
         MatrixGate.__init__(self)
-        gates.U3.__init__(self, q, theta, phi, lam)
+        gates.U3.__init__(self, q, theta, phi, lam, trainable)
 
     def construct_unitary(self) -> np.ndarray:
         theta, phi, lam = self.parameters
@@ -403,12 +403,12 @@ class U3(MatrixGate, gates.U3):
 
 class ZPow(gates.ZPow):
 
-  def __new__(cls, q, theta):
+  def __new__(cls, q, theta, trainable=True):
       if BACKEND.get('GATES') == 'custom':
-          return U1(q, theta)
+          return U1(q, theta, trainable)
       else:
           from qibo.tensorflow import gates
-          return gates.U1(q, theta)
+          return gates.U1(q, theta, trainable)
 
 
 class CNOT(TensorflowGate, gates.CNOT):
@@ -455,29 +455,29 @@ class _CUn_(MatrixGate):
 class CRX(_CUn_, gates.CRX):
     base = RX
 
-    def __init__(self, q0, q1, theta):
-        _CUn_.__init__(self, q0, q1, theta=theta)
+    def __init__(self, q0, q1, theta, trainable=True):
+        _CUn_.__init__(self, q0, q1, theta=theta, trainable=trainable)
 
 
 class CRY(_CUn_, gates.CRY):
     base = RY
 
-    def __init__(self, q0, q1, theta):
-        _CUn_.__init__(self, q0, q1, theta=theta)
+    def __init__(self, q0, q1, theta, trainable=True):
+        _CUn_.__init__(self, q0, q1, theta=theta, trainable=trainable)
 
 
 class CRZ(_CUn_, gates.CRZ):
     base = RZ
 
-    def __init__(self, q0, q1, theta):
-        _CUn_.__init__(self, q0, q1, theta=theta)
+    def __init__(self, q0, q1, theta, trainable=True):
+        _CUn_.__init__(self, q0, q1, theta=theta, trainable=trainable)
 
 
 class CU1(_CUn_, gates.CU1):
     base = U1
 
-    def __init__(self, q0, q1, theta):
-        _CUn_.__init__(self, q0, q1, theta=theta)
+    def __init__(self, q0, q1, theta, trainable=True):
+        _CUn_.__init__(self, q0, q1, theta=theta, trainable=trainable)
         self.gate_op = op.apply_z_pow
 
     def reprepare(self):
@@ -487,25 +487,26 @@ class CU1(_CUn_, gates.CU1):
 class CU2(_CUn_, gates.CU2):
     base = U2
 
-    def __init__(self, q0, q1, phi, lam):
-        _CUn_.__init__(self, q0, q1, phi=phi, lam=lam)
+    def __init__(self, q0, q1, phi, lam, trainable=True):
+        _CUn_.__init__(self, q0, q1, phi=phi, lam=lam, trainable=trainable)
 
 
 class CU3(_CUn_, gates.CU3):
     base = U3
 
-    def __init__(self, q0, q1, theta, phi, lam):
-        _CUn_.__init__(self, q0, q1, theta=theta, phi=phi, lam=lam)
+    def __init__(self, q0, q1, theta, phi, lam, trainable=True):
+        _CUn_.__init__(self, q0, q1, theta=theta, phi=phi, lam=lam,
+                       trainable=trainable)
 
 
 class CZPow(gates.CZPow):
 
-  def __new__(cls, q0, q1, theta):
+  def __new__(cls, q0, q1, theta, trainable=True):
       if BACKEND.get('GATES') == 'custom':
-          return CU1(q0, q1, theta)
+          return CU1(q0, q1, theta, trainable)
       else:
           from qibo.tensorflow import gates
-          return gates.CU1(q0, q1, theta)
+          return gates.CU1(q0, q1, theta, trainable)
 
 
 class SWAP(TensorflowGate, gates.SWAP):
@@ -523,9 +524,9 @@ class SWAP(TensorflowGate, gates.SWAP):
 
 class fSim(MatrixGate, gates.fSim):
 
-    def __init__(self, q0, q1, theta, phi):
+    def __init__(self, q0, q1, theta, phi, trainable=True):
         MatrixGate.__init__(self)
-        gates.fSim.__init__(self, q0, q1, theta, phi)
+        gates.fSim.__init__(self, q0, q1, theta, phi, trainable)
         self.gate_op = op.apply_fsim
 
     def reprepare(self):
@@ -549,9 +550,9 @@ class fSim(MatrixGate, gates.fSim):
 
 class GeneralizedfSim(MatrixGate, gates.GeneralizedfSim):
 
-    def __init__(self, q0, q1, unitary, phi):
+    def __init__(self, q0, q1, unitary, phi, trainable=True):
         TensorflowGate.__init__(self)
-        gates.GeneralizedfSim.__init__(self, q0, q1, unitary, phi)
+        gates.GeneralizedfSim.__init__(self, q0, q1, unitary, phi, trainable)
         self.gate_op = op.apply_fsim
 
     def reprepare(self):
@@ -601,12 +602,12 @@ class TOFFOLI(TensorflowGate, gates.TOFFOLI):
 
 class Unitary(MatrixGate, gates.Unitary):
 
-    def __init__(self, unitary, *q, name: Optional[str] = None):
+    def __init__(self, unitary, *q, trainable=True, name: Optional[str] = None):
         if not isinstance(unitary, (np.ndarray, tf.Tensor)):
             raise_error(TypeError, "Unknown type {} of unitary matrix."
                                    "".format(type(unitary)))
         MatrixGate.__init__(self)
-        gates.Unitary.__init__(self, unitary, *q, name=name)
+        gates.Unitary.__init__(self, unitary, *q, trainable=trainable, name=name)
         rank = self.rank
         if rank == 1:
             self.gate_op = op.apply_gate
@@ -669,11 +670,13 @@ class VariationalLayer(TensorflowGate, gates.VariationalLayer):
     def __init__(self, qubits: List[int], pairs: List[Tuple[int, int]],
                  one_qubit_gate, two_qubit_gate,
                  params: List[float], params2: Optional[List[float]] = None,
+                 trainable: bool = True,
                  name: Optional[str] = None):
         self.module.TensorflowGate.__init__(self)
         gates.VariationalLayer.__init__(self, qubits, pairs,
                                         one_qubit_gate, two_qubit_gate,
-                                        params, params2, name=name)
+                                        params, params2,
+                                        trainable=trainable, name=name)
 
         matrices, additional_matrix = self._calculate_unitaries()
         self.unitaries = []

--- a/src/qibo/tensorflow/gates.py
+++ b/src/qibo/tensorflow/gates.py
@@ -220,9 +220,9 @@ class Collapse(TensorflowGate, gates.Collapse):
 
 class RX(TensorflowGate, gates.RX):
 
-    def __init__(self, q, theta):
+    def __init__(self, q, theta, trainable=True):
         TensorflowGate.__init__(self)
-        gates.RX.__init__(self, q, theta)
+        gates.RX.__init__(self, q, theta, trainable)
 
     def construct_unitary(self) -> tf.Tensor:
         t = tf.cast(self.parameters, dtype=DTYPES.get('DTYPECPX'))
@@ -231,9 +231,9 @@ class RX(TensorflowGate, gates.RX):
 
 class RY(TensorflowGate, gates.RY):
 
-    def __init__(self, q, theta):
+    def __init__(self, q, theta, trainable=True):
         TensorflowGate.__init__(self)
-        gates.RY.__init__(self, q, theta)
+        gates.RY.__init__(self, q, theta, trainable)
 
     def construct_unitary(self) -> tf.Tensor:
         t = tf.cast(self.parameters, dtype=DTYPES.get('DTYPECPX'))
@@ -242,9 +242,9 @@ class RY(TensorflowGate, gates.RY):
 
 class RZ(TensorflowGate, gates.RZ):
 
-    def __init__(self, q, theta):
+    def __init__(self, q, theta, trainable=True):
         TensorflowGate.__init__(self)
-        gates.RZ.__init__(self, q, theta)
+        gates.RZ.__init__(self, q, theta, trainable)
 
     def construct_unitary(self) -> tf.Tensor:
         t = tf.cast(self.parameters, dtype=DTYPES.get('DTYPECPX'))
@@ -255,9 +255,9 @@ class RZ(TensorflowGate, gates.RZ):
 
 class U1(TensorflowGate, gates.U1):
 
-    def __init__(self, q, theta):
+    def __init__(self, q, theta, trainable=True):
         TensorflowGate.__init__(self)
-        gates.U1.__init__(self, q, theta)
+        gates.U1.__init__(self, q, theta, trainable)
 
     def construct_unitary(self) -> tf.Tensor:
         t = tf.cast(self.parameters, dtype=DTYPES.get('DTYPECPX'))
@@ -267,9 +267,9 @@ class U1(TensorflowGate, gates.U1):
 
 class U2(TensorflowGate, gates.U2):
 
-    def __init__(self, q, phi, lam):
+    def __init__(self, q, phi, lam, trainable=True):
         TensorflowGate.__init__(self)
-        gates.U2.__init__(self, q, phi, lam)
+        gates.U2.__init__(self, q, phi, lam, trainable)
 
     def construct_unitary(self):
         return cgates.U2.construct_unitary(self)
@@ -277,9 +277,9 @@ class U2(TensorflowGate, gates.U2):
 
 class U3(TensorflowGate, gates.U3):
 
-    def __init__(self, q, theta, phi, lam):
+    def __init__(self, q, theta, phi, lam, trainable=True):
         TensorflowGate.__init__(self)
-        gates.U3.__init__(self, q, theta, phi, lam)
+        gates.U3.__init__(self, q, theta, phi, lam, trainable=trainable)
 
     def construct_unitary(self):
         return cgates.U3.construct_unitary(self)
@@ -322,43 +322,44 @@ class _CUn_(TensorflowGate):
 class CRX(_CUn_, gates.CRX):
     base = RX
 
-    def __init__(self, q0, q1, theta):
-        _CUn_.__init__(self, q0, q1, theta=theta)
+    def __init__(self, q0, q1, theta, trainable=True):
+        _CUn_.__init__(self, q0, q1, theta=theta, trainable=trainable)
 
 
 class CRY(_CUn_, gates.CRY):
     base = RY
 
-    def __init__(self, q0, q1, theta):
-        _CUn_.__init__(self, q0, q1, theta=theta)
+    def __init__(self, q0, q1, theta, trainable=True):
+        _CUn_.__init__(self, q0, q1, theta=theta, trainable=trainable)
 
 
 class CRZ(_CUn_, gates.CRZ):
     base = RZ
 
-    def __init__(self, q0, q1, theta):
-        _CUn_.__init__(self, q0, q1, theta=theta)
+    def __init__(self, q0, q1, theta, trainable=True):
+        _CUn_.__init__(self, q0, q1, theta=theta, trainable=trainable)
 
 
 class CU1(_CUn_, gates.CU1):
     base = U1
 
-    def __init__(self, q0, q1, theta):
-        _CUn_.__init__(self, q0, q1, theta=theta)
+    def __init__(self, q0, q1, theta, trainable=True):
+        _CUn_.__init__(self, q0, q1, theta=theta, trainable=trainable)
 
 
 class CU2(_CUn_, gates.CU2):
     base = U2
 
-    def __init__(self, q0, q1, phi, lam):
-        _CUn_.__init__(self, q0, q1, phi=phi, lam=lam)
+    def __init__(self, q0, q1, phi, lam, trainable=True):
+        _CUn_.__init__(self, q0, q1, phi=phi, lam=lam, trainable=trainable)
 
 
 class CU3(_CUn_, gates.CU3):
     base = U3
 
-    def __init__(self, q0, q1, theta, phi, lam):
-        _CUn_.__init__(self, q0, q1, theta=theta, phi=phi, lam=lam)
+    def __init__(self, q0, q1, theta, phi, lam, trainable=True):
+        _CUn_.__init__(self, q0, q1, theta=theta, phi=phi, lam=lam,
+                       trainable=trainable)
 
 
 class SWAP(TensorflowGate, gates.SWAP):
@@ -375,9 +376,9 @@ class SWAP(TensorflowGate, gates.SWAP):
 
 class fSim(TensorflowGate, gates.fSim):
 
-    def __init__(self, q0, q1, theta, phi):
+    def __init__(self, q0, q1, theta, phi, trainable=True):
         TensorflowGate.__init__(self)
-        gates.fSim.__init__(self, q0, q1, theta, phi)
+        gates.fSim.__init__(self, q0, q1, theta, phi, trainable)
 
     def construct_unitary(self):
         return cgates.fSim.construct_unitary(self)
@@ -385,9 +386,9 @@ class fSim(TensorflowGate, gates.fSim):
 
 class GeneralizedfSim(TensorflowGate, gates.GeneralizedfSim):
 
-    def __init__(self, q0, q1, unitary, phi):
+    def __init__(self, q0, q1, unitary, phi, trainable=True):
         TensorflowGate.__init__(self)
-        gates.GeneralizedfSim.__init__(self, q0, q1, unitary, phi)
+        gates.GeneralizedfSim.__init__(self, q0, q1, unitary, phi, trainable)
 
     def construct_unitary(self):
         return cgates.GeneralizedfSim.construct_unitary(self)
@@ -414,12 +415,12 @@ class TOFFOLI(TensorflowGate, gates.TOFFOLI):
 
 class Unitary(TensorflowGate, gates.Unitary):
 
-    def __init__(self, unitary, *q, name: Optional[str] = None):
+    def __init__(self, unitary, *q, trainable=True, name: Optional[str] = None):
         if not isinstance(unitary, (np.ndarray, tf.Tensor)):
             raise_error(TypeError, "Unknown type {} of unitary matrix."
                                    "".format(type(unitary)))
         TensorflowGate.__init__(self)
-        gates.Unitary.__init__(self, unitary, *q, name=name)
+        gates.Unitary.__init__(self, unitary, *q, trainable=trainable, name=name)
 
     def construct_unitary(self):
         unitary = self.parameters
@@ -474,10 +475,12 @@ class VariationalLayer(TensorflowGate, gates.VariationalLayer):
                  one_qubit_gate, two_qubit_gate,
                  params: List[float],
                  params2: Optional[List[float]] = None,
+                 trainable: bool = True,
                  name: Optional[str] = None):
         cgates.VariationalLayer.__init__(self, qubits, pairs,
                                          one_qubit_gate, two_qubit_gate,
-                                         params, params2, name=name)
+                                         params, params2,
+                                         trainable=trainable, name=name)
 
     def _dagger(self):
         return cgates.VariationalLayer._dagger(self)

--- a/src/qibo/tests/test_parametrized.py
+++ b/src/qibo/tests/test_parametrized.py
@@ -35,38 +35,51 @@ def test_rx_parameter_setter(backend):
     qibo.set_backend(original_backend)
 
 
-def test_get_parameters():
+@pytest.mark.parametrize("trainable", [True, False])
+def test_get_parameters(trainable):
     c = Circuit(3)
     c.add(gates.RX(0, theta=0.123))
-    c.add(gates.RY(1, theta=0.456))
+    c.add(gates.RY(1, theta=0.456, trainable=trainable))
     c.add(gates.CZ(1, 2))
-    c.add(gates.fSim(0, 2, theta=0.789, phi=0.987))
+    c.add(gates.fSim(0, 2, theta=0.789, phi=0.987, trainable=trainable))
     c.add(gates.H(2))
     unitary = np.array([[0.123, 0.123], [0.123, 0.123]])
     c.add(gates.Unitary(unitary, 1))
 
-    params = [0.123, 0.456, (0.789, 0.987), unitary]
-    assert params == c.get_parameters()
-    params = [0.123, 0.456, (0.789, 0.987), unitary]
-    assert params == c.get_parameters()
-    params = {c.queue[0]: 0.123, c.queue[1]: 0.456,
-              c.queue[3]: (0.789, 0.987), c.queue[5]: unitary}
-    assert params == c.get_parameters("dict")
-    params = [0.123, 0.456, 0.789, 0.987]
-    params.extend(unitary.ravel())
-    assert params == c.get_parameters("flatlist")
+    if trainable:
+        params = {
+            "list": [0.123, 0.456, (0.789, 0.987), unitary],
+            "dict": {c.queue[0]: 0.123, c.queue[1]: 0.456,
+                     c.queue[3]: (0.789, 0.987), c.queue[5]: unitary},
+            "flatlist": [0.123, 0.456, 0.789, 0.987]
+            }
+    else:
+        params = {
+            "list": [0.123, unitary],
+            "dict": {c.queue[0]: 0.123, c.queue[5]: unitary},
+            "flatlist": [0.123]
+            }
+    params["flatlist"].extend(unitary.ravel())
+    for fmt, prm in params.items():
+        assert c.get_parameters(fmt) == prm
+
     with pytest.raises(ValueError):
         c.get_parameters("test")
 
 
 @pytest.mark.parametrize(("backend", "accelerators"), _DEVICE_BACKENDS)
-def test_circuit_set_parameters_with_list(backend, accelerators):
+@pytest.mark.parametrize("trainable", [True, False])
+def test_circuit_set_parameters_with_list(backend, accelerators, trainable):
     """Check updating parameters of circuit with list."""
     original_backend = qibo.get_backend()
     qibo.set_backend(backend)
+    params = [0.123, 0.456, (0.789, 0.321)]
 
     c = Circuit(3, accelerators)
-    c.add(gates.RX(0, theta=0))
+    if trainable:
+        c.add(gates.RX(0, theta=0, trainable=trainable))
+    else:
+        c.add(gates.RX(0, theta=params[0], trainable=trainable))
     c.add(gates.RY(1, theta=0))
     c.add(gates.CZ(1, 2))
     c.add(gates.fSim(0, 2, theta=0, phi=0))
@@ -74,7 +87,6 @@ def test_circuit_set_parameters_with_list(backend, accelerators):
     # execute once
     final_state = c()
 
-    params = [0.123, 0.456, (0.789, 0.321)]
     target_c = Circuit(3)
     target_c.add(gates.RX(0, theta=params[0]))
     target_c.add(gates.RY(1, theta=params[1]))
@@ -82,35 +94,54 @@ def test_circuit_set_parameters_with_list(backend, accelerators):
     target_c.add(gates.fSim(0, 2, theta=params[2][0], phi=params[2][1]))
     target_c.add(gates.H(2))
 
-    c.set_parameters(params)
+    if trainable:
+        c.set_parameters(params)
+    else:
+        c.set_parameters(params[1:])
     np.testing.assert_allclose(c(), target_c())
 
     # Attempt using a flat np.ndarray/list
     for new_params in (np.random.random(4), list(np.random.random(4))):
-        params = [new_params[0], new_params[1], (new_params[2], new_params[3])]
-        target_c.set_parameters(params)
-        c.set_parameters(new_params)
+        if trainable:
+            c.set_parameters(new_params)
+        else:
+            new_params[0] = params[0]
+            c.set_parameters(new_params[1:])
+        target_params = [new_params[0], new_params[1], (new_params[2], new_params[3])]
+        target_c.set_parameters(target_params)
         np.testing.assert_allclose(c(), target_c())
     qibo.set_backend(original_backend)
 
 
 @pytest.mark.parametrize(("backend", "accelerators"), _DEVICE_BACKENDS)
-def test_circuit_set_parameters_ungates(backend, accelerators):
+@pytest.mark.parametrize("trainable", [True, False])
+def test_circuit_set_parameters_ungates(backend, accelerators, trainable):
     """Check updating parameters of circuit with list."""
     original_backend = qibo.get_backend()
     qibo.set_backend(backend)
 
+    params = [0.1, 0.2, 0.3, (0.4, 0.5), (0.6, 0.7, 0.8)]
+    if trainable:
+        trainable_params = list(params)
+    else:
+        trainable_params = [0.1, 0.3, (0.4, 0.5)]
+
     c = Circuit(3, accelerators)
     c.add(gates.RX(0, theta=0))
-    c.add(gates.CRY(0, 1, theta=0))
+    if trainable:
+        c.add(gates.CRY(0, 1, theta=0, trainable=trainable))
+    else:
+        c.add(gates.CRY(0, 1, theta=params[1], trainable=trainable))
     c.add(gates.CZ(1, 2))
     c.add(gates.U1(2, theta=0))
     c.add(gates.CU2(0, 2, phi=0, lam=0))
-    c.add(gates.U3(1, theta=0, phi=0, lam=0))
+    if trainable:
+        c.add(gates.U3(1, theta=0, phi=0, lam=0, trainable=trainable))
+    else:
+        c.add(gates.U3(1, *params[4], trainable=trainable))
     # execute once
     final_state = c()
 
-    params = [0.1, 0.2, 0.3, (0.4, 0.5), (0.6, 0.7, 0.8)]
     target_c = Circuit(3)
     target_c.add(gates.RX(0, theta=params[0]))
     target_c.add(gates.CRY(0, 1, theta=params[1]))
@@ -118,19 +149,25 @@ def test_circuit_set_parameters_ungates(backend, accelerators):
     target_c.add(gates.U1(2, theta=params[2]))
     target_c.add(gates.CU2(0, 2, *params[3]))
     target_c.add(gates.U3(1, *params[4]))
-    c.set_parameters(params)
+    c.set_parameters(trainable_params)
     np.testing.assert_allclose(c(), target_c())
 
     # Attempt using a flat list
-    params = np.random.random(8)
+    npparams = np.random.random(8)
+    if trainable:
+        trainable_params = np.copy(npparams)
+    else:
+        npparams[1] = params[1]
+        npparams[5:] = params[4]
+        trainable_params = np.delete(npparams, [1, 5, 6, 7])
     target_c = Circuit(3)
-    target_c.add(gates.RX(0, theta=params[0]))
-    target_c.add(gates.CRY(0, 1, theta=params[1]))
+    target_c.add(gates.RX(0, theta=npparams[0]))
+    target_c.add(gates.CRY(0, 1, theta=npparams[1]))
     target_c.add(gates.CZ(1, 2))
-    target_c.add(gates.U1(2, theta=params[2]))
-    target_c.add(gates.CU2(0, 2, *params[3:5]))
-    target_c.add(gates.U3(1, *params[5:]))
-    c.set_parameters(params)
+    target_c.add(gates.U1(2, theta=npparams[2]))
+    target_c.add(gates.CU2(0, 2, *npparams[3:5]))
+    target_c.add(gates.U3(1, *npparams[5:]))
+    c.set_parameters(trainable_params)
     np.testing.assert_allclose(c(), target_c())
     qibo.set_backend(original_backend)
 
@@ -165,23 +202,31 @@ def test_circuit_set_parameters_with_unitary(backend, accelerators):
 
 
 @pytest.mark.parametrize(("backend", "accelerators"), _DEVICE_BACKENDS)
-def test_circuit_set_parameters_with_dictionary(backend, accelerators):
+@pytest.mark.parametrize("trainable", [True, False])
+def test_circuit_set_parameters_with_dictionary(backend, accelerators, trainable):
     """Check updating parameters of circuit with list."""
     original_backend = qibo.get_backend()
     qibo.set_backend(backend)
 
+    params = [0.123, 0.456, 0.789, np.random.random((2, 2))]
+
     c = Circuit(3, accelerators)
     c.add(gates.X(0))
     c.add(gates.X(2))
-    c.add(gates.U1(0, theta=0))
+    if trainable:
+        c.add(gates.U1(0, theta=0, trainable=trainable))
+    else:
+        c.add(gates.U1(0, theta=params[0], trainable=trainable))
     c.add(gates.RZ(1, theta=0))
     c.add(gates.CZ(1, 2))
     c.add(gates.CU1(0, 2, theta=0))
     c.add(gates.H(2))
-    c.add(gates.Unitary(np.eye(2), 1))
+    if trainable:
+        c.add(gates.Unitary(np.eye(2), 1, trainable=trainable))
+    else:
+        c.add(gates.Unitary(params[3], 1, trainable=trainable))
     final_state = c()
 
-    params = [0.123, 0.456, 0.789, np.random.random((2, 2))]
     target_c = Circuit(3, accelerators)
     target_c.add(gates.X(0))
     target_c.add(gates.X(2))
@@ -192,8 +237,11 @@ def test_circuit_set_parameters_with_dictionary(backend, accelerators):
     target_c.add(gates.H(2))
     target_c.add(gates.Unitary(params[3], 1))
 
-    param_dict = {c.queue[i]: p for i, p in zip([2, 3, 5, 7], params)}
-    c.set_parameters(param_dict)
+    if trainable:
+        params_dict = {c.queue[i]: p for i, p in zip([2, 3, 5, 7], params)}
+    else:
+        params_dict = {c.queue[3]: params[1], c.queue[5]: params[2]}
+    c.set_parameters(params_dict)
     np.testing.assert_allclose(c(), target_c())
     qibo.set_backend(original_backend)
 
@@ -258,7 +306,9 @@ def test_set_parameters_with_variationallayer(backend, accelerators, nqubits):
 
 @pytest.mark.parametrize(("backend", "accelerators"), _DEVICE_BACKENDS)
 @pytest.mark.parametrize("nqubits", [4, 5])
-def test_set_parameters_with_double_variationallayer(backend, accelerators, nqubits):
+@pytest.mark.parametrize("trainable", [True, False])
+def test_set_parameters_with_double_variationallayer(backend, accelerators,
+                                                     nqubits, trainable):
     """Check updating parameters of variational layer."""
     original_backend = qibo.get_backend()
     qibo.set_backend(backend)
@@ -268,7 +318,8 @@ def test_set_parameters_with_double_variationallayer(backend, accelerators, nqub
     pairs = [(i, i + 1) for i in range(0, nqubits - 1, 2)]
     c.add(gates.VariationalLayer(range(nqubits), pairs,
                                  gates.RY, gates.CZ,
-                                 theta[0], theta[1]))
+                                 theta[0], theta[1],
+                                 trainable=trainable))
     c.add((gates.RX(i, theta[2, i]) for i in range(nqubits)))
 
     target_c = Circuit(nqubits)
@@ -279,38 +330,50 @@ def test_set_parameters_with_double_variationallayer(backend, accelerators, nqub
     np.testing.assert_allclose(c(), target_c())
 
     new_theta = np.random.random(3 * nqubits)
-    c.set_parameters(np.copy(new_theta))
+    if trainable:
+        c.set_parameters(np.copy(new_theta))
+    else:
+        c.set_parameters(np.copy(new_theta[2 * nqubits:]))
+        new_theta[:2 * nqubits] = theta[:2].ravel()
     target_c.set_parameters(np.copy(new_theta))
     np.testing.assert_allclose(c(), target_c())
-
     qibo.set_backend(original_backend)
 
 
 @pytest.mark.parametrize(("backend", "accelerators"), _DEVICE_BACKENDS)
-def test_set_parameters_with_gate_fusion(backend, accelerators):
+@pytest.mark.parametrize("trainable", [True, False])
+def test_set_parameters_with_gate_fusion(backend, accelerators, trainable):
     """Check updating parameters of fused circuit."""
     original_backend = qibo.get_backend()
     qibo.set_backend(backend)
 
     params = np.random.random(9)
     c = Circuit(5, accelerators)
-    c.add(gates.RX(0, theta=params[0]))
+    c.add(gates.RX(0, theta=params[0], trainable=trainable))
     c.add(gates.RY(1, theta=params[1]))
     c.add(gates.CZ(0, 1))
     c.add(gates.RX(2, theta=params[2]))
-    c.add(gates.RY(3, theta=params[3]))
+    c.add(gates.RY(3, theta=params[3], trainable=trainable))
     c.add(gates.fSim(2, 3, theta=params[4], phi=params[5]))
     c.add(gates.RX(4, theta=params[6]))
-    c.add(gates.RZ(0, theta=params[7]))
+    c.add(gates.RZ(0, theta=params[7], trainable=trainable))
     c.add(gates.RZ(1, theta=params[8]))
 
     fused_c = c.fuse()
     np.testing.assert_allclose(c(), fused_c())
 
-    new_params = np.random.random(9)
-    new_params_list = list(new_params[:4])
-    new_params_list.append((new_params[4], new_params[5]))
-    new_params_list.extend(new_params[6:])
+    if trainable:
+        new_params = np.random.random(9)
+        new_params_list = list(new_params[:4])
+        new_params_list.append((new_params[4], new_params[5]))
+        new_params_list.extend(new_params[6:])
+    else:
+        new_params = np.random.random(9)
+        new_params_list = list(new_params[1:3])
+        new_params_list.append((new_params[4], new_params[5]))
+        new_params_list.append(new_params[6])
+        new_params_list.append(new_params[8])
+
     c.set_parameters(new_params_list)
     fused_c.set_parameters(new_params_list)
     np.testing.assert_allclose(c(), fused_c())


### PR DESCRIPTION
This PR adds the `trainable` flag in all parametrized gates which allows the user to hide them from `circuit.get_parameters()` and `circuit.set_parameters()`. For example
```Python
c = Circuit(3)
c.add(gates.RX(0, theta=0))
c.add(gates.RY(1, theta=0.5, trainable=False))
c.add(gates.RZ(2, theta=0.8))

print(c.get_parameters()) 
# will print [0, 0.8] ignoring the RY

c.set_parameters([0.2, 0.4])
# will set RX(0.2) and RZ(0.4) and ignore RY
```

@scarrazza, @igres26 I used the name `trainable` for this flag following Tensorflow/Keras but I am open to alternative suggestions.