### PR TITLE
Create base callbacks

### DIFF
--- a/doc/source/advancedexamples.rst
+++ b/doc/source/advancedexamples.rst
@@ -176,7 +176,7 @@ How to use callbacks?
 Callbacks allow the user to apply additional functions on the state vector
 during circuit execution. An example use case of this is the calculation of
 entanglement entropy as the state propagates through a circuit. This can be
-implemented easily using :class:`qibo.tensorflow.callbacks.EntanglementEntropy`
+implemented easily using :class:`qibo.base.callbacks.EntanglementEntropy`
 and the :class:`qibo.base.gates.CallbackGate` gate. For example:
 
 .. code-block::  python
@@ -1049,7 +1049,7 @@ of the ``AdiabaticEvolution`` model. In this case the default initial state is
 |++...+> (full superposition in the computational basis).
 
 Callbacks may also be used as in the previous example. An additional callback
-(:class:`qibo.tensorflow.callbacks.Gap`) is available for calculating the
+(:class:`qibo.base.callbacks.Gap`) is available for calculating the
 energies and the gap of the adiabatic evolution Hamiltonian. Its usage is
 similar to other callbacks:
 

--- a/doc/source/qibo.rst
+++ b/doc/source/qibo.rst
@@ -282,13 +282,13 @@ Callbacks
 Callbacks provide a way to calculate quantities on the state vector as it
 propagates through the circuit. Example of such quantity is the entanglement
 entropy, which is currently the only callback implemented in
-:class:`qibo.tensorflow.callbacks.EntanglementEntropy`.
+:class:`qibo.base.callbacks.EntanglementEntropy`.
 The user can create custom callbacks by inheriting the
-:class:`qibo.tensorflow.callbacks.Callback` class. The point each callback is
+:class:`qibo.base.callbacks.Callback` class. The point each callback is
 calculated inside the circuit is defined by adding a :class:`qibo.base.gates.CallbackGate`.
 This can be added similarly to a standard gate and does not affect the state vector.
 
-.. automodule:: qibo.tensorflow.callbacks
+.. automodule:: qibo.base.callbacks
    :members:
    :member-order: bysource
 

--- a/src/qibo/base/callbacks.py
+++ b/src/qibo/base/callbacks.py
@@ -1,0 +1,269 @@
+from abc import ABC, abstractmethod
+from qibo.config import raise_error
+from typing import List, Optional, Union
+
+
+class Callback(ABC):
+    """Base callback class.
+
+    Callbacks should inherit this class and implement its `__call__` method.
+
+    Results of a callback can be accessed by indexing the corresponding object.
+    """
+    from qibo.config import K
+
+    def __init__(self):
+        self._results = []
+        self._nqubits = None
+
+    @property
+    def nqubits(self): # pragma: no cover
+        """Total number of qubits in the circuit that the callback was added in."""
+        # abstract method
+        return self._nqubits
+
+    @nqubits.setter
+    def nqubits(self, n: int): # pragma: no cover
+        # abstract method
+        self._nqubits = n
+
+    def __getitem__(self, k):
+        if isinstance(k, int):
+            if k >= len(self._results):
+                raise_error(IndexError, "Attempting to access callbacks {} run but "
+                                        "the callback has been used in {} executions."
+                                        "".format(k, len(self._results)))
+            return self._results[k]
+        if isinstance(k, slice) or isinstance(k, list) or isinstance(k, tuple):
+            return self.K.stack(self._results[k])
+        raise_error(IndexError, "Unrecognized type for index {}.".format(k))
+
+    def append(self, x):
+        self._results.append(x)
+
+    def extend(self, x):
+        self._results.extend(x)
+
+    @abstractmethod
+    def __call__(self, state, is_density_matrix=False): # pragma: no cover
+        raise_error(NotImplementedError)
+
+
+class PartialTrace(Callback):
+    """Calculates reduced density matrix of a state.
+
+    This is used by the :class:`qibo.tensorflow.callbacks.EntanglementEntropy`
+    callback. It can also be used as a standalone callback in order to access
+    a reduced density matrix in the middle of a circuit execution.
+
+    Args:
+        partition (list): List with qubit ids that defines the first subsystem.
+            If `partition` is not given then the first subsystem is the first
+            half of the qubits.
+    """
+
+    def __init__(self, partition: Optional[List[int]] = None):
+        super().__init__()
+        self.partition = partition
+        self.rho_dim = None
+        self._traceout = None
+
+    @property
+    def nqubits(self) -> int:
+        return self._nqubits
+
+    @nqubits.setter
+    def nqubits(self, n: int):
+        self._nqubits = n
+        if self.partition is None: # pragma: no cover
+            self.partition = list(range(n // 2 + n % 2))
+
+        if len(self.partition) < n // 2:
+            # Revert parition so that we diagonalize a smaller matrix
+            self.partition = [i for i in range(n)
+                              if i not in set(self.partition)]
+        self.rho_dim = 2 ** (n - len(self.partition))
+        self._traceout = None
+
+    def traceout(self):
+        """Einsum string used to trace out when state is density matrix."""
+        if self._traceout is None:
+            from qibo.tensorflow.einsum import DefaultEinsum
+            partition = set(self.partition)
+            self._traceout = DefaultEinsum.partialtrace_str(partition, self.nqubits)
+        return self._traceout
+
+
+class EntanglementEntropy(PartialTrace):
+    """Von Neumann entanglement entropy callback.
+
+    .. math::
+        S = \\mathrm{Tr} \\left ( \\rho \\log _2 \\rho \\right )
+
+    Args:
+        partition (list): List with qubit ids that defines the first subsystem
+            for the entropy calculation.
+            If `partition` is not given then the first subsystem is the first
+            half of the qubits.
+        compute_spectrum (bool): Compute the entanglement spectrum. Default is False.
+
+    Example:
+        ::
+
+            from qibo import models, gates, callbacks
+            # create entropy callback where qubit 0 is the first subsystem
+            entropy = callbacks.EntanglementEntropy([0], compute_spectrum=True)
+            # initialize circuit with 2 qubits and add gates
+            c = models.Circuit(2)
+            # add callback gates between normal gates
+            c.add(gates.CallbackGate(entropy))
+            c.add(gates.H(0))
+            c.add(gates.CallbackGate(entropy))
+            c.add(gates.CNOT(0, 1))
+            c.add(gates.CallbackGate(entropy))
+            # execute the circuit
+            final_state = c()
+            print(entropy[:])
+            # Should print [0, 0, 1] which is the entanglement entropy
+            # after every gate in the calculation.
+            print(entropy.spectrum)
+            # Print the entanglement spectrum.
+    """
+
+    def __init__(self, partition: Optional[List[int]] = None,
+                 compute_spectrum: bool = False):
+        self.compute_spectrum = compute_spectrum
+        self.spectrum = list()
+        super().__init__(partition)
+
+
+class Norm(Callback):
+    """State norm callback.
+
+    .. math::
+        \\mathrm{Norm} = \\left \\langle \\Psi | \\Psi \\right \\rangle
+        = \\mathrm{Tr} (\\rho )
+    """
+    pass
+
+
+class Overlap(Callback):
+    """State overlap callback.
+
+    Calculates the overlap between the circuit state and a given target state:
+
+    .. math::
+        \\mathrm{Overlap} = |\\left \\langle \\Phi | \\Psi \\right \\rangle |
+
+    Args:
+        state (np.ndarray): Target state to calculate overlap with.
+        normalize (bool): If ``True`` the states are normalized for the overlap
+            calculation.
+    """
+    pass
+
+
+class Energy(Callback):
+    """Energy expectation value callback.
+
+    Calculates the expectation value of a given Hamiltonian as:
+
+    .. math::
+        \\left \\langle H \\right \\rangle =
+        \\left \\langle \\Psi | H | \\Psi \\right \\rangle
+        = \\mathrm{Tr} (\\rho H)
+
+    assuming that the state is normalized.
+
+    Args:
+        hamiltonian (:class:`qibo.hamiltonians.Hamiltonian`): Hamiltonian
+            object to calculate its expectation value.
+    """
+
+    def __init__(self, hamiltonian: "hamiltonians.Hamiltonian"):
+        super().__init__()
+        self.hamiltonian = hamiltonian
+
+    def __call__(self, state, is_density_matrix=False):
+        return self.hamiltonian.expectation(state)
+
+
+class Gap(Callback):
+    """Callback for calculating the gap of adiabatic evolution Hamiltonians.
+
+    Can also be used to calculate the Hamiltonian eigenvalues at each time step
+    during the evolution.
+    Note that this callback can only be added in
+    :class:`qibo.evolution.AdiabaticEvolution` models.
+
+    Args:
+        mode (str/int): Defines which quantity this callback calculates.
+            If ``mode == 'gap'`` then the difference between ground state and
+            first excited state energy (gap) is calculated.
+            If ``mode`` is an integer, then the energy of the corresponding
+            eigenstate is calculated.
+
+    Example:
+        ::
+
+            from qibo import models, callbacks
+            # define easy and hard Hamiltonians for adiabatic evolution
+            h0 = hamiltonians.X(3)
+            h1 = hamiltonians.TFIM(3, h=1.0)
+            # define callbacks for logging the ground state, first excited
+            # and gap energy
+            ground = callbacks.Gap(0)
+            excited = callbacks.Gap(1)
+            gap = callbacks.Gap()
+            # define and execute the ``AdiabaticEvolution`` model
+            evolution = AdiabaticEvolution(h0, h1, lambda t: t, dt=1e-1,
+                                           callbacks=[gap, ground, excited])
+            final_state = evolution(final_time=1.0)
+            # print results
+            print(ground[:])
+            print(excited[:])
+            print(gap[:])
+    """
+
+    def __init__(self, mode: Union[str, int] = "gap"):
+        super(Gap, self).__init__()
+        if isinstance(mode, str):
+            if mode != "gap":
+                raise_error(ValueError, "Unsupported mode {} for gap callback."
+                                        "".format(mode))
+        elif not isinstance(mode, int):
+            raise_error(TypeError, "Gap callback mode should be integer or "
+                                   "string but is {}.".format(type(mode)))
+        self._evolution = None
+        self.mode = mode
+
+    @property
+    def evolution(self):
+        """:class:`qibo.evolution.AdiabaticEvolution` model used by the callback."""
+        return self._evolution
+
+    @evolution.setter
+    def evolution(self, ev: "models.AdiabaticEvolution"):
+        """Sets the :class:`qibo.evolution.AdiabaticEvolution` model."""
+        from qibo.models import AdiabaticEvolution
+        if not isinstance(ev, AdiabaticEvolution):
+            t = type(ev)
+            raise_error(TypeError, "Cannot add gap callback to {}.".format(t))
+        self._evolution = ev
+
+    def __call__(self, state, is_density_matrix=False):
+        if self.evolution is None:
+            raise_error(ValueError, "Gap callback can only be used in "
+                                    "adiabatic evolution models.")
+        if is_density_matrix:
+            raise_error(NotImplementedError, "Adiabatic evolution gap callback "
+                                             "is not implemented for density "
+                                             "matrices.")
+        hamiltonian = self.evolution.hamiltonian()
+        # Call the eigenvectors so that they are cached for the ``exp`` call
+        hamiltonian.eigenvectors()
+        if isinstance(self.mode, int):
+            return self.K.math.real(hamiltonian.eigenvalues()[self.mode])
+        # case: self.mode == "gap"
+        return self.K.math.real(hamiltonian.eigenvalues()[1] -
+                                hamiltonian.eigenvalues()[0])

--- a/src/qibo/tensorflow/callbacks.py
+++ b/src/qibo/tensorflow/callbacks.py
@@ -5,7 +5,7 @@ from qibo.config import DTYPES, EIGVAL_CUTOFF, raise_error
 from typing import Union
 
 
-class PartialTrace(callbacks.Callback):
+class PartialTrace(callbacks.PartialTrace):
 
     def __call__(self, state: tf.Tensor, is_density_matrix: bool = False
                  ) -> tf.Tensor:

--- a/src/qibo/tensorflow/callbacks.py
+++ b/src/qibo/tensorflow/callbacks.py
@@ -7,35 +7,31 @@ from typing import Union
 
 class PartialTrace(callbacks.PartialTrace):
 
-    def __call__(self, state: tf.Tensor, is_density_matrix: bool = False
-                 ) -> tf.Tensor:
-        """Calculates reduced density matrix.
-
-        Traces out all qubits contained in `self.partition`.
-        """
-        # Cast state in the proper shape
+    def set_nqubits(self, state):
         if not (isinstance(state, np.ndarray) or isinstance(state, tf.Tensor)):
             raise_error(TypeError, "State of unknown type {} was given in callback "
                                    "calculation.".format(type(state)))
         if self._nqubits is None:
             self.nqubits = int(np.log2(tuple(state.shape)[0]))
 
-        shape = (1 + int(is_density_matrix)) * self.nqubits * (2,)
-        state = tf.reshape(state, shape)
+    def state_vector_call(self, state):
+        self.set_nqubits(state)
+        state = tf.reshape(state, self.nqubits * (2,))
+        rho = tf.tensordot(state, tf.math.conj(state),
+                           axes=[self.partition, self.partition])
+        return tf.reshape(rho, (self.rho_dim, self.rho_dim))
 
-        if is_density_matrix:
-            rho = tf.einsum(self.traceout(), state)
-        else:
-            rho = tf.tensordot(state, tf.math.conj(state),
-                               axes=[self.partition, self.partition])
+    def density_matrix_call(self, state):
+        self.set_nqubits(state)
+        state = tf.reshape(state, 2 * self.nqubits * (2,))
+        rho = tf.einsum(self.traceout(), state)
         return tf.reshape(rho, (self.rho_dim, self.rho_dim))
 
 
 class EntanglementEntropy(callbacks.EntanglementEntropy):
     _log2 = tf.cast(tf.math.log(2.0), dtype=DTYPES.get('DTYPE'))
 
-    def _entropy(self, rho: tf.Tensor) -> tf.Tensor:
-        """Calculates entropy by diagonalizing the density matrix."""
+    def entropy(self, rho: tf.Tensor) -> tf.Tensor:
         # Diagonalize
         eigvals = tf.math.real(tf.linalg.eigvalsh(rho))
         # Treating zero and negative eigenvalues
@@ -46,26 +42,14 @@ class EntanglementEntropy(callbacks.EntanglementEntropy):
         entropy = tf.reduce_sum(masked_eigvals * spectrum)
         return entropy / self._log2
 
-    def __call__(self, state: tf.Tensor, is_density_matrix: bool = False
-                 ) -> tf.Tensor:
-        # Construct reduced density matrix
-        rho = PartialTrace.__call__(self, state, is_density_matrix)
-        # Calculate entropy of reduced density matrix
-        return self._entropy(rho)
-
 
 class Norm(callbacks.Norm):
 
-    @staticmethod
-    def norm(state: tf.Tensor, is_density_matrix: bool = False) -> tf.Tensor:
-        """"""
-        if is_density_matrix:
-            return tf.linalg.trace(state)
+    def state_vector_call(self, state):
         return tf.sqrt(tf.reduce_sum(tf.square(tf.abs(state))))
 
-    def __call__(self, state: tf.Tensor, is_density_matrix: bool = False
-                 ) -> tf.Tensor:
-        return self.norm(state, is_density_matrix)
+    def density_matrix_call(self, state):
+        return tf.linalg.trace(state)
 
 
 class Overlap(callbacks.Overlap):
@@ -74,22 +58,18 @@ class Overlap(callbacks.Overlap):
         super().__init__()
         self.statec = tf.math.conj(tf.cast(state, dtype=DTYPES.get('DTYPECPX')))
 
-    def __call__(self, state: tf.Tensor, is_density_matrix: bool = False
-                 ) -> tf.Tensor:
-        if is_density_matrix:
-            raise_error(NotImplementedError, "Overlap callback is not implemented "
-                                             "for density matrices.")
+    def state_vector_call(self, state):
         return tf.abs(tf.reduce_sum(self.statec * state))
+
+    def density_matrix_call(self, state):
+        raise_error(NotImplementedError, "Overlap callback is not implemented "
+                                          "for density matrices.")
 
 
 class Energy(callbacks.Energy):
 
-    def __call__(self, state: tf.Tensor, is_density_matrix: bool = False
-                 ) -> tf.Tensor:
-        if is_density_matrix:
-            return tf.linalg.trace(tf.matmul(self.hamiltonian.matrix,
-                                             state))
-        return self.hamiltonian.expectation(state)
+    def density_matrix_call(self, state):
+        return tf.linalg.trace(tf.matmul(self.hamiltonian.matrix, state))
 
 
 class Gap(callbacks.Gap):

--- a/src/qibo/tensorflow/callbacks.py
+++ b/src/qibo/tensorflow/callbacks.py
@@ -1,99 +1,11 @@
 import numpy as np
 import tensorflow as tf
+from qibo.base import callbacks
 from qibo.config import DTYPES, EIGVAL_CUTOFF, raise_error
-from typing import List, Optional, Union
+from typing import Union
 
 
-class Callback:
-    """Base callback class.
-
-    All Tensorflow callbacks should inherit this class and implement its
-    `__call__` method.
-
-    Results of a callback can be accessed by indexing the corresponding object.
-    """
-
-    def __init__(self):
-        self._results = []
-        self._nqubits = None
-
-    @property
-    def nqubits(self) -> int: # pragma: no cover
-        """Total number of qubits in the circuit that the callback was added in."""
-        # abstract method
-        return self._nqubits
-
-    @nqubits.setter
-    def nqubits(self, n: int): # pragma: no cover
-        # abstract method
-        self._nqubits = n
-
-    def __getitem__(self, k) -> tf.Tensor:
-        if isinstance(k, int):
-            if k >= len(self._results):
-                raise_error(IndexError, "Attempting to access callbacks {} run but "
-                                        "the callback has been used in {} executions."
-                                        "".format(k, len(self._results)))
-            return self._results[k]
-        if isinstance(k, slice) or isinstance(k, list) or isinstance(k, tuple):
-            return tf.stack(self._results[k])
-        raise_error(IndexError, "Unrecognized type for index {}.".format(k))
-
-    def __call__(self, state: tf.Tensor) -> tf.Tensor: # pragma: no cover
-        # abstract method
-        raise_error(NotImplementedError)
-
-    def append(self, result: tf.Tensor):
-        self._results.append(result)
-
-    def extend(self, result: tf.Tensor):
-        self._results.extend(result)
-
-
-class PartialTrace(Callback):
-    """Calculates reduced density matrix of a state.
-
-    This is used by the :class:`qibo.tensorflow.callbacks.EntanglementEntropy`
-    callback. It can also be used as a standalone callback in order to access
-    a reduced density matrix in the middle of a circuit execution.
-
-    Args:
-        partition (list): List with qubit ids that defines the first subsystem.
-            If `partition` is not given then the first subsystem is the first
-            half of the qubits.
-    """
-
-    def __init__(self, partition: Optional[List[int]] = None):
-        super(PartialTrace, self).__init__()
-        self.partition = partition
-        self.rho_dim = None
-        self._traceout = None
-
-    @property
-    def nqubits(self) -> int:
-        return self._nqubits
-
-    @nqubits.setter
-    def nqubits(self, n: int):
-        self._nqubits = n
-        if self.partition is None: # pragma: no cover
-            self.partition = list(range(n // 2 + n % 2))
-
-        if len(self.partition) < n // 2:
-            # Revert parition so that we diagonalize a smaller matrix
-            self.partition = [i for i in range(n)
-                              if i not in set(self.partition)]
-        self.rho_dim = 2 ** (n - len(self.partition))
-        self._traceout = None
-
-    @property
-    def _traceout_str(self):
-        """Einsum string used to trace out when state is density matrix."""
-        if self._traceout is None:
-            from qibo.tensorflow.einsum import DefaultEinsum
-            partition = set(self.partition)
-            self._traceout = DefaultEinsum.partialtrace_str(partition, self.nqubits)
-        return self._traceout
+class PartialTrace(callbacks.Callback):
 
     def __call__(self, state: tf.Tensor, is_density_matrix: bool = False
                  ) -> tf.Tensor:
@@ -112,54 +24,15 @@ class PartialTrace(Callback):
         state = tf.reshape(state, shape)
 
         if is_density_matrix:
-            rho = tf.einsum(self._traceout_str, state)
+            rho = tf.einsum(self.traceout(), state)
         else:
             rho = tf.tensordot(state, tf.math.conj(state),
                                axes=[self.partition, self.partition])
         return tf.reshape(rho, (self.rho_dim, self.rho_dim))
 
 
-class EntanglementEntropy(PartialTrace):
-    """Von Neumann entanglement entropy callback.
-
-    .. math::
-        S = \\mathrm{Tr} \\left ( \\rho \\log _2 \\rho \\right )
-
-    Args:
-        partition (list): List with qubit ids that defines the first subsystem
-            for the entropy calculation.
-            If `partition` is not given then the first subsystem is the first
-            half of the qubits.
-        compute_spectrum (bool): Compute the entanglement spectrum. Default is False.
-
-    Example:
-        ::
-
-            from qibo import models, gates, callbacks
-            # create entropy callback where qubit 0 is the first subsystem
-            entropy = callbacks.EntanglementEntropy([0], compute_spectrum=True)
-            # initialize circuit with 2 qubits and add gates
-            c = models.Circuit(2)
-            # add callback gates between normal gates
-            c.add(gates.CallbackGate(entropy))
-            c.add(gates.H(0))
-            c.add(gates.CallbackGate(entropy))
-            c.add(gates.CNOT(0, 1))
-            c.add(gates.CallbackGate(entropy))
-            # execute the circuit
-            final_state = c()
-            print(entropy[:])
-            # Should print [0, 0, 1] which is the entanglement entropy
-            # after every gate in the calculation.
-            print(entropy.spectrum)
-            # Print the entanglement spectrum.
-    """
+class EntanglementEntropy(callbacks.EntanglementEntropy):
     _log2 = tf.cast(tf.math.log(2.0), dtype=DTYPES.get('DTYPE'))
-
-    def __init__(self, partition: Optional[List[int]] = None, compute_spectrum: bool = False):
-        self.compute_spectrum = compute_spectrum
-        self.spectrum = list()
-        super(EntanglementEntropy, self).__init__(partition)
 
     def _entropy(self, rho: tf.Tensor) -> tf.Tensor:
         """Calculates entropy by diagonalizing the density matrix."""
@@ -176,18 +49,12 @@ class EntanglementEntropy(PartialTrace):
     def __call__(self, state: tf.Tensor, is_density_matrix: bool = False
                  ) -> tf.Tensor:
         # Construct reduced density matrix
-        rho = super(EntanglementEntropy, self).__call__(state, is_density_matrix)
+        rho = PartialTrace.__call__(self, state, is_density_matrix)
         # Calculate entropy of reduced density matrix
         return self._entropy(rho)
 
 
-class Norm(Callback):
-    """State norm callback.
-
-    .. math::
-        \\mathrm{Norm} = \\left \\langle \\Psi | \\Psi \\right \\rangle
-        = \\mathrm{Tr} (\\rho )
-    """
+class Norm(callbacks.Norm):
 
     @staticmethod
     def norm(state: tf.Tensor, is_density_matrix: bool = False) -> tf.Tensor:
@@ -201,22 +68,10 @@ class Norm(Callback):
         return self.norm(state, is_density_matrix)
 
 
-class Overlap(Callback):
-    """State overlap callback.
-
-    Calculates the overlap between the circuit state and a given target state:
-
-    .. math::
-        \\mathrm{Overlap} = |\\left \\langle \\Phi | \\Psi \\right \\rangle |
-
-    Args:
-        state (np.ndarray): Target state to calculate overlap with.
-        normalize (bool): If ``True`` the states are normalized for the overlap
-            calculation.
-    """
+class Overlap(callbacks.Overlap):
 
     def __init__(self, state: Union[np.ndarray, tf.Tensor]):
-        super(Overlap, self).__init__()
+        super().__init__()
         self.statec = tf.math.conj(tf.cast(state, dtype=DTYPES.get('DTYPECPX')))
 
     def __call__(self, state: tf.Tensor, is_density_matrix: bool = False
@@ -224,30 +79,10 @@ class Overlap(Callback):
         if is_density_matrix:
             raise_error(NotImplementedError, "Overlap callback is not implemented "
                                              "for density matrices.")
-
         return tf.abs(tf.reduce_sum(self.statec * state))
 
 
-class Energy(Callback):
-    """Energy expectation value callback.
-
-    Calculates the expectation value of a given Hamiltonian as:
-
-    .. math::
-        \\left \\langle H \\right \\rangle =
-        \\left \\langle \\Psi | H | \\Psi \\right \\rangle
-        = \\mathrm{Tr} (\\rho H)
-
-    assuming that the state is normalized.
-
-    Args:
-        hamiltonian (:class:`qibo.hamiltonians.Hamiltonian`): Hamiltonian
-            object to calculate its expectation value.
-    """
-
-    def __init__(self, hamiltonian: "hamiltonians.Hamiltonian"):
-        super(Energy, self).__init__()
-        self.hamiltonian = hamiltonian
+class Energy(callbacks.Energy):
 
     def __call__(self, state: tf.Tensor, is_density_matrix: bool = False
                  ) -> tf.Tensor:
@@ -257,83 +92,5 @@ class Energy(Callback):
         return self.hamiltonian.expectation(state)
 
 
-class Gap(Callback):
-    """Callback for calculating the gap of adiabatic evolution Hamiltonians.
-
-    Can also be used to calculate the Hamiltonian eigenvalues at each time step
-    during the evolution.
-    Note that this callback can only be added in
-    :class:`qibo.evolution.AdiabaticEvolution` models.
-
-    Args:
-        mode (str/int): Defines which quantity this callback calculates.
-            If ``mode == 'gap'`` then the difference between ground state and
-            first excited state energy (gap) is calculated.
-            If ``mode`` is an integer, then the energy of the corresponding
-            eigenstate is calculated.
-
-    Example:
-        ::
-
-            from qibo import models, callbacks
-            # define easy and hard Hamiltonians for adiabatic evolution
-            h0 = hamiltonians.X(3)
-            h1 = hamiltonians.TFIM(3, h=1.0)
-            # define callbacks for logging the ground state, first excited
-            # and gap energy
-            ground = callbacks.Gap(0)
-            excited = callbacks.Gap(1)
-            gap = callbacks.Gap()
-            # define and execute the ``AdiabaticEvolution`` model
-            evolution = AdiabaticEvolution(h0, h1, lambda t: t, dt=1e-1,
-                                           callbacks=[gap, ground, excited])
-            final_state = evolution(final_time=1.0)
-            # print results
-            print(ground[:])
-            print(excited[:])
-            print(gap[:])
-    """
-
-    def __init__(self, mode: Union[str, int] = "gap"):
-        super(Gap, self).__init__()
-        if isinstance(mode, str):
-            if mode != "gap":
-                raise_error(ValueError, "Unsupported mode {} for gap callback."
-                                        "".format(mode))
-        elif not isinstance(mode, int):
-            raise_error(TypeError, "Gap callback mode should be integer or "
-                                   "string but is {}.".format(type(mode)))
-        self._evolution = None
-        self.mode = mode
-
-    @property
-    def evolution(self):
-        """:class:`qibo.evolution.AdiabaticEvolution` model used by the callback."""
-        return self._evolution
-
-    @evolution.setter
-    def evolution(self, ev: "models.AdiabaticEvolution"):
-        """Sets the :class:`qibo.evolution.AdiabaticEvolution` model."""
-        from qibo.models import AdiabaticEvolution
-        if not isinstance(ev, AdiabaticEvolution):
-            t = type(ev)
-            raise_error(TypeError, "Cannot add gap callback to {}.".format(t))
-        self._evolution = ev
-
-    def __call__(self, state: tf.Tensor, is_density_matrix: bool = False
-                 ) -> tf.Tensor:
-        if self.evolution is None:
-            raise_error(ValueError, "Gap callback can only be used in "
-                                    "adiabatic evolution models.")
-        if is_density_matrix:
-            raise_error(NotImplementedError, "Adiabatic evolution gap callback "
-                                             "is not implemented for density "
-                                             "matrices.")
-        hamiltonian = self.evolution.hamiltonian()
-        # Call the eigenvectors so that they are cached for the ``exp`` call
-        hamiltonian.eigenvectors()
-        if isinstance(self.mode, int):
-            return tf.math.real(hamiltonian.eigenvalues()[self.mode])
-        # case: self.mode == "gap"
-        return tf.math.real(hamiltonian.eigenvalues()[1] -
-                            hamiltonian.eigenvalues()[0])
+class Gap(callbacks.Gap):
+    pass

--- a/src/qibo/tensorflow/cgates.py
+++ b/src/qibo/tensorflow/cgates.py
@@ -757,12 +757,17 @@ class CallbackGate(TensorflowGate, gates.CallbackGate):
         gates.CallbackGate.__init__(self, callback)
         self.swap_reset = []
 
+    @BackendGate.density_matrix.setter
+    def density_matrix(self, x):
+        BackendGate.density_matrix.fset(self, x) # pylint: disable=no-member
+        self.callback.density_matrix = x
+
     def construct_unitary(self):
         raise_error(ValueError, "Unitary gate does not have unitary "
                                  "representation.")
 
     def state_vector_call(self, state: tf.Tensor) -> tf.Tensor:
-        self.callback.append(self.callback(state, self.density_matrix))
+        self.callback.append(self.callback(state))
         return state
 
     def density_matrix_call(self, state: tf.Tensor) -> tf.Tensor:

--- a/src/qibo/tensorflow/cgates.py
+++ b/src/qibo/tensorflow/cgates.py
@@ -250,10 +250,9 @@ class M(TensorflowGate, gates.M):
         self.reduced_target_qubits = list(
             reduced_target_qubits[i] for i in self.target_qubits)
         if self.density_matrix:
-            from qibo.tensorflow.einsum import DefaultEinsum
+            from qibo.base.callbacks import PartialTrace
             qubits = set(self.unmeasured_qubits)
-            # TODO: Remove ``DefaultEinsum`` dependence here
-            self.traceout = DefaultEinsum.partialtrace_str(
+            self.traceout = PartialTrace.einsum_string(
                 qubits, self.nqubits, measuring=True)
 
     def _get_cpu(self): # pragma: no cover

--- a/src/qibo/tensorflow/einsum.py
+++ b/src/qibo/tensorflow/einsum.py
@@ -31,7 +31,6 @@ class DefaultEinsum:
     The user should switch to :class:`qibo.tensorflow.einsum.MatmulEinsum`
     if automatic differentiation is required.
     """
-    from qibo.config import EINSUM_CHARS as _chars
 
     def __call__(self, cache: str, state: tf.Tensor, gate: tf.Tensor) -> tf.Tensor:
       return tf.einsum(cache, state, gate)
@@ -40,46 +39,6 @@ class DefaultEinsum:
     def create_cache(qubits: Sequence[int], nqubits: int,
                      ncontrol: Optional[int] = None) -> cache.DefaultEinsumCache:
         return cache.DefaultEinsumCache(qubits, nqubits, ncontrol)
-
-    @classmethod
-    def partialtrace_str(cls, qubits: Set[int], nqubits: int,
-                         measuring: bool = False) -> str:
-        """Generates einsum strings for partial trace of density matrices.
-
-        Helper method used when measuring or calculating entanglement entropies
-        on density matrices.
-
-        Args:
-            qubits (list): Set of qubit ids that are traced out.
-            nqubits (int): Total number of qubits in the state.
-            measuring (bool): If True non-traced-out indices are multiplied and
-                the output has shape (nqubits - len(qubits),).
-                If False the output has shape 2 * (nqubits - len(qubits),).
-
-        Returns:
-            String to use in einsum for performing partial density of a
-            density matrix.
-        """
-        if (2 - int(measuring)) * nqubits > len(cls._chars): # pragma: no cover
-            # case not tested because it requires large instance
-            raise_error(NotImplementedError, "Not enough einsum characters.")
-
-        left_in, right_in, left_out, right_out = [], [], [], []
-        for i in range(nqubits):
-            left_in.append(cls._chars[i])
-            if i in qubits:
-                right_in.append(cls._chars[i])
-            else:
-                left_out.append(cls._chars[i])
-                if measuring:
-                    right_in.append(cls._chars[i])
-                else:
-                    right_in.append(cls._chars[i + nqubits])
-                    right_out.append(cls._chars[i + nqubits])
-
-        left_in, left_out = "".join(left_in), "".join(left_out)
-        right_in, right_out = "".join(right_in), "".join(right_out)
-        return f"{left_in}{right_in}->{left_out}{right_out}"
 
 
 class MatmulEinsum:

--- a/src/qibo/tensorflow/einsum.py
+++ b/src/qibo/tensorflow/einsum.py
@@ -20,7 +20,7 @@ examples.
 import tensorflow as tf
 from qibo.base import cache
 from qibo.config import raise_error
-from typing import Dict, Optional, Sequence, Set
+from typing import Dict, Optional, Sequence
 
 
 class DefaultEinsum:

--- a/src/qibo/tests/test_callbacks.py
+++ b/src/qibo/tests/test_callbacks.py
@@ -47,7 +47,7 @@ def test_entropy_random_state():
     rho = u.dot(np.diag(s)).dot(u.conj().T)
 
     callback = callbacks.EntanglementEntropy(compute_spectrum=True)
-    result = callback._entropy(rho)
+    result = callback.entropy(rho)
     target = - (s * np.log2(s)).sum()
     np.testing.assert_allclose(result.numpy(), target)
 
@@ -86,7 +86,7 @@ def test_entropy_numerical():
                         1e-11, 1e-10, 1e-9, 1e-7, 1, 4, 10])
     rho = tf.convert_to_tensor(np.diag(eigvals), dtype=DTYPES.get('DTYPECPX'))
     callback = callbacks.EntanglementEntropy()
-    result = callback._entropy(rho).numpy()
+    result = callback.entropy(rho).numpy()
 
     mask = eigvals > 0
     target = - (eigvals[mask] * np.log2(eigvals[mask])).sum()
@@ -305,9 +305,10 @@ def test_norm():
     target_norm = np.sqrt((np.abs(state) ** 2).sum())
     np.testing.assert_allclose(norm(state), target_norm)
 
+    norm.density_matrix = True
     state = np.random.random((2, 2)) + 1j * np.random.random((2, 2))
     target_norm = np.trace(state)
-    np.testing.assert_allclose(norm(state, True), target_norm)
+    np.testing.assert_allclose(norm(state), target_norm)
 
 
 def test_overlap():
@@ -318,8 +319,9 @@ def test_overlap():
     target_overlap = np.abs((state0.conj() * state1).sum())
     np.testing.assert_allclose(overlap(state1), target_overlap)
 
+    overlap.density_matrix = True
     with pytest.raises(NotImplementedError):
-        overlap(state1, is_density_matrix=True)
+        overlap(state1)
 
 
 def test_energy():
@@ -333,9 +335,10 @@ def test_energy():
     target_energy = state.conj().dot(matrix.dot(state))
     np.testing.assert_allclose(energy(state), target_energy)
 
+    energy.density_matrix = True
     state = np.random.random((16, 16)) + 1j * np.random.random((16, 16))
     target_energy = np.trace(matrix.dot(state))
-    np.testing.assert_allclose(energy(state, True), target_energy)
+    np.testing.assert_allclose(energy(state), target_energy)
 
 
 @pytest.mark.parametrize("trotter", [False, True])
@@ -364,8 +367,9 @@ def test_gap(trotter):
     np.testing.assert_allclose(excited[:], targets["excited"])
     np.testing.assert_allclose(gap[:], targets["gap"])
     # check not implemented for density matrices
+    gap.density_matrix = True
     with pytest.raises(NotImplementedError):
-        gap(np.zeros(8), is_density_matrix=True)
+        gap(np.zeros(8))
 
 
 def test_gap_errors():

--- a/src/qibo/tests/test_callbacks.py
+++ b/src/qibo/tests/test_callbacks.py
@@ -370,6 +370,9 @@ def test_gap(trotter):
     gap.density_matrix = True
     with pytest.raises(NotImplementedError):
         gap(np.zeros(8))
+    # for coverage
+    _ = gap.density_matrix
+    gap.density_matrix = False
 
 
 def test_gap_errors():

--- a/src/qibo/tests/test_density_matrix.py
+++ b/src/qibo/tests/test_density_matrix.py
@@ -781,7 +781,8 @@ def test_entanglement_entropy(backend):
     # this is a positive rho
 
     entropy = callbacks.EntanglementEntropy([0, 2])
-    final_ent = entropy(rho, is_density_matrix=True)
+    entropy.density_matrix = True
+    final_ent = entropy(rho)
 
     rho = rho.reshape(8 * (2,))
     reduced_rho = np.einsum("abcdafch->bdfh", rho).reshape((4, 4))

--- a/src/qibo/tests/test_evolution.py
+++ b/src/qibo/tests/test_evolution.py
@@ -24,7 +24,7 @@ class TimeStepChecker(Callback):
     def state_vector_call(self, state):
         assert_states_equal(state, next(self.target_states), atol=self.atol)
 
-    def density_matrix_call(self, state):
+    def density_matrix_call(self, state): # pragma: no cover
         raise_error(NotImplementedError)
 
 

--- a/src/qibo/tests/test_evolution.py
+++ b/src/qibo/tests/test_evolution.py
@@ -2,6 +2,7 @@ import pytest
 import numpy as np
 from qibo import callbacks, hamiltonians, models
 from qibo.base.callbacks import Callback
+from qibo.config import raise_error
 from qibo.tests import utils
 from scipy.linalg import expm
 
@@ -20,8 +21,11 @@ class TimeStepChecker(Callback):
         self.target_states = iter(target_states)
         self.atol = atol
 
-    def __call__(self, state):
+    def state_vector_call(self, state):
         assert_states_equal(state, next(self.target_states), atol=self.atol)
+
+    def density_matrix_call(self, state):
+        raise_error(NotImplementedError)
 
 
 def test_initial_state():

--- a/src/qibo/tests/test_evolution.py
+++ b/src/qibo/tests/test_evolution.py
@@ -1,6 +1,7 @@
 import pytest
 import numpy as np
 from qibo import callbacks, hamiltonians, models
+from qibo.base.callbacks import Callback
 from qibo.tests import utils
 from scipy.linalg import expm
 
@@ -11,7 +12,7 @@ def assert_states_equal(state, target_state, atol=0):
     np.testing.assert_allclose(state, phase * target_state, atol=atol)
 
 
-class TimeStepChecker(callbacks.Callback):
+class TimeStepChecker(Callback):
     """Callback that checks each evolution time step."""
 
     def __init__(self, target_states, atol=0):


### PR DESCRIPTION
As part of the cleanup related to the backends this PR creates a `qibo.base.callbacks` module. So far we only had `qibo.tensorflow.callbacks` which was not consistent with the rest of the models. Also several methods from this file were independent of Tensorflow and thus can be moved to base.