### PR TITLE
custom initial_state

### DIFF
--- a/src/qibo/tensorflow/circuit.py
+++ b/src/qibo/tensorflow/circuit.py
@@ -4,7 +4,7 @@ import numpy as np
 import tensorflow as tf
 from tensorflow.python.framework import errors_impl # pylint: disable=no-name-in-module
 from qibo.base import circuit
-from qibo.config import DTYPES, DEVICES, BACKEND, raise_error
+from qibo.config import DTYPES, DEVICES, BACKEND, raise_error, get_threads
 from qibo.tensorflow import measurements
 from qibo.tensorflow import custom_operators as op
 from typing import List, Optional, Tuple, Union
@@ -211,9 +211,7 @@ class TensorflowCircuit(circuit.BaseCircuit):
 
     def _default_initial_state(self) -> tf.Tensor:
         """Creates the |000...0> state for default initialization."""
-        zeros = tf.zeros(self.shapes.get('TF_FLAT'), dtype=DTYPES.get('DTYPECPX'))
-        state = op.initial_state(zeros)
-        return state
+        return op.initial_state(self.shapes.get('TF_FLAT'), DTYPES.get('DTYPECPX'), get_threads())
 
     def get_initial_state(self, state: Optional[InitStateType] = None
                            ) -> tf.Tensor:

--- a/src/qibo/tensorflow/custom_operators/cc/kernels/initial_state.h
+++ b/src/qibo/tensorflow/custom_operators/cc/kernels/initial_state.h
@@ -1,13 +1,15 @@
 #ifndef KERNEL_INITIAL_STATE_H_
 #define KERNEL_INITIAL_STATE_H_
 
+#include "tensorflow/core/framework/op_kernel.h"
+
 namespace tensorflow {
 
 namespace functor {
 
 template <typename Device, typename T>
 struct InitialStateFunctor {
-  void operator()(const Device &d, T *in);
+  void operator()(const Device &d, T *in, int64 shape, int nthreads);
 };
 
 }  // namespace functor

--- a/src/qibo/tensorflow/custom_operators/cc/kernels/initial_state.h
+++ b/src/qibo/tensorflow/custom_operators/cc/kernels/initial_state.h
@@ -9,7 +9,7 @@ namespace functor {
 
 template <typename Device, typename T>
 struct InitialStateFunctor {
-  void operator()(const Device &d, T *in, int64 shape);
+  void operator()(const Device &d, T *in, int64 size);
 };
 
 }  // namespace functor

--- a/src/qibo/tensorflow/custom_operators/cc/kernels/initial_state_kernels.cc
+++ b/src/qibo/tensorflow/custom_operators/cc/kernels/initial_state_kernels.cc
@@ -15,24 +15,39 @@ namespace functor {
 // CPU specialization
 template <typename T>
 struct InitialStateFunctor<CPUDevice, T> {
-  void operator()(const CPUDevice &d, T *inout) { inout[0] = T(1, 0); }
+  void operator()(const CPUDevice &d, T *out, int64 shape, int nthreads)
+  {
+    #pragma omp parallel for num_threads(nthreads)
+    for (size_t i = 0; i < (size_t) shape; i++)
+      out[i] = T(0, 0);
+    if (shape > 0)
+      out[0] = T(1, 0);
+  }
 };
 
 template <typename Device, typename T>
 class InitialStateOp : public OpKernel {
  public:
-  explicit InitialStateOp(OpKernelConstruction *context) : OpKernel(context) {}
+  explicit InitialStateOp(OpKernelConstruction *context) : OpKernel(context) {
+    OP_REQUIRES_OK(context, context->GetAttr("omp_num_threads", &threads_));
+  }
 
   void Compute(OpKernelContext *context) override {
     // grabe the input tensor
-    Tensor input_tensor = context->input(0);
+    const Tensor &input_tensor = context->input(0);
+
+    Tensor* output_tensor = NULL;
+    OP_REQUIRES_OK(context, context->allocate_output(0, TensorShape{input_tensor.flat<int64>()}, &output_tensor));
 
     // call the implementation
     InitialStateFunctor<Device, T>()(context->eigen_device<Device>(),
-                                     input_tensor.flat<T>().data());
-
-    context->set_output(0, input_tensor);
+                                     output_tensor->flat<T>().data(),
+                                     output_tensor->flat<T>().size(),
+                                     threads_);
   }
+
+ private:
+  int threads_;
 };
 
 // Register the CPU kernels.

--- a/src/qibo/tensorflow/custom_operators/cc/ops/custom_ops.cc
+++ b/src/qibo/tensorflow/custom_operators/cc/ops/custom_ops.cc
@@ -5,10 +5,10 @@ using namespace tensorflow;
 
 // Register op that generates initial state
 REGISTER_OP("InitialState")
+    .Input("in: int64")
     .Attr("T: {complex64, complex128}")
-    .Input("in: T")
-    .Output("out: T")
-    .SetShapeFn(::tensorflow::shape_inference::UnchangedShape);
+    .Attr("omp_num_threads: int")
+    .Output("out: T");
 
 
 // Register op that changes qubit order for multi-GPU

--- a/src/qibo/tensorflow/distcircuit.py
+++ b/src/qibo/tensorflow/distcircuit.py
@@ -136,7 +136,7 @@ class TensorflowDistributedCircuit(circuit.TensorflowCircuit):
             for i in ids:
                 with tf.device(device):
                     piece = self._device_job(state.pieces[i], queues[i])
-                    state.pieces[i].assign(piece)
+                    state.pieces[i] = piece
                     del(piece)
 
         pool = joblib.Parallel(n_jobs=len(self.calc_devices),
@@ -167,8 +167,7 @@ class TensorflowDistributedCircuit(circuit.TensorflowCircuit):
             for piece in state.pieces:
                 total_norm += tf.reduce_sum(tf.math.square(tf.abs(piece)))
             total_norm = tf.cast(tf.math.sqrt(total_norm), dtype=state.dtype)
-            for piece in state.pieces:
-                piece.assign(piece / total_norm)
+            state.pieces /= total_norm
 
     def _revert_swaps(self, state: utils.DistributedState, swap_pairs: List[Tuple[int, int]]):
         for q1, q2 in swap_pairs:

--- a/src/qibo/tensorflow/distutils.py
+++ b/src/qibo/tensorflow/distutils.py
@@ -404,7 +404,7 @@ class DistributedState(DistributedBase):
       """Creates the |000...0> state for default initialization."""
       state = cls(circuit)
       with tf.device(state.device):
-          op.initial_state(state.pieces[0])
+          state.pieces[0] = op.initial_state(state.pieces[0].shape, state.pieces[0].dtype, get_threads())
       return state
 
     @classmethod
@@ -439,7 +439,7 @@ class DistributedState(DistributedBase):
                                            self.qubits.transpose_order,
                                            get_threads())
             for i in range(self.ndevices):
-                self.pieces[i].assign(new_state[i])
+                self.pieces[i] = new_state[i]
 
     @property
     def vector(self) -> tf.Tensor:

--- a/src/qibo/tests/test_custom_operators.py
+++ b/src/qibo/tests/test_custom_operators.py
@@ -25,8 +25,7 @@ def test_initial_state(dtype, compile):
   """Check that initial_state updates first element properly."""
   def apply_operator(dtype):
     """Apply the initial_state operator"""
-    a = tf.zeros(10, dtype=dtype)
-    return op.initial_state(a)
+    return op.initial_state(10, dtype, get_threads())
 
   func = apply_operator
   if compile:


### PR DESCRIPTION
Following the discussion in #304 here I replace the tf.zeros with a full custom operator which builds our desired input state.
Interesting to note that we are faster than tf for small number of qubits while tf (eigen) wins for larger numbers.

Even if this PR solves the issue identified by @stavros11 for nqubits > 15, I have observed issues with the multiprocessing start method and openmp/tf-threadpool if we try to run code in parallel using more than 1 thread. For example, when setting `set_threads(2)` the multiprocessing run gets stuck silently. I have the suspicious that this is related to how the `fork` mode works, limiting the thread creation. 

I prefer to not merge this PR until I understand if the code can run in `spawn` mode. My only concern is about performance, the fork mode is fast on single-thread simulation, thanks to the light initialization method, while spawn will presumably take longer to initialize and thus the benefit of parallel simulation with small number of qubits will disappear.

@stavros11 please let me know your opinion.