### PR TITLE
custom initial_state GPU

### DIFF
--- a/src/qibo/tensorflow/circuit.py
+++ b/src/qibo/tensorflow/circuit.py
@@ -211,7 +211,10 @@ class TensorflowCircuit(circuit.BaseCircuit):
 
     def _default_initial_state(self) -> tf.Tensor:
         """Creates the |000...0> state for default initialization."""
-        return op.initial_state(self.shapes.get('TF_FLAT'), DTYPES.get('DTYPECPX'), get_threads())
+        return op.initial_state(nqubits=self.nqubits,
+                                dtype=DTYPES.get('DTYPECPX'),
+                                is_matrix=self.density_matrix,
+                                omp_num_threads=get_threads())
 
     def get_initial_state(self, state: Optional[InitStateType] = None
                            ) -> tf.Tensor:

--- a/src/qibo/tensorflow/custom_operators/cc/kernels/initial_state.h
+++ b/src/qibo/tensorflow/custom_operators/cc/kernels/initial_state.h
@@ -9,7 +9,7 @@ namespace functor {
 
 template <typename Device, typename T>
 struct InitialStateFunctor {
-  void operator()(const Device &d, T *in, int64 shape, int nthreads);
+  void operator()(const Device &d, T *in, int64 shape);
 };
 
 }  // namespace functor

--- a/src/qibo/tensorflow/custom_operators/cc/kernels/initial_state_kernels.cc
+++ b/src/qibo/tensorflow/custom_operators/cc/kernels/initial_state_kernels.cc
@@ -18,10 +18,9 @@ struct InitialStateFunctor<CPUDevice, T> {
   void operator()(const CPUDevice &d, T *out, int64 shape, int nthreads)
   {
     #pragma omp parallel for num_threads(nthreads)
-    for (size_t i = 0; i < (size_t) shape; i++)
+    for (size_t i = 1; i < (size_t) shape; i++)
       out[i] = T(0, 0);
-    if (shape > 0)
-      out[0] = T(1, 0);
+    out[0] = T(1, 0);
   }
 };
 
@@ -29,15 +28,22 @@ template <typename Device, typename T>
 class InitialStateOp : public OpKernel {
  public:
   explicit InitialStateOp(OpKernelConstruction *context) : OpKernel(context) {
+    OP_REQUIRES_OK(context, context->GetAttr("nqubits", &nqubits_));
+    OP_REQUIRES_OK(context, context->GetAttr("is_matrix", &is_matrix_));
     OP_REQUIRES_OK(context, context->GetAttr("omp_num_threads", &threads_));
+    OP_REQUIRES(context, nqubits_ > 0, errors::InvalidArgument("nqubits must be positive"));
   }
 
   void Compute(OpKernelContext *context) override {
     // grabe the input tensor
-    const Tensor &input_tensor = context->input(0);
+    const int64 size = std::pow(2, nqubits_);
+
+    TensorShape shape{size};
+    if (is_matrix_)
+      shape = TensorShape{size, size};
 
     Tensor* output_tensor = NULL;
-    OP_REQUIRES_OK(context, context->allocate_output(0, TensorShape{input_tensor.flat<int64>()}, &output_tensor));
+    OP_REQUIRES_OK(context, context->allocate_output(0, shape, &output_tensor));
 
     // call the implementation
     InitialStateFunctor<Device, T>()(context->eigen_device<Device>(),
@@ -47,13 +53,15 @@ class InitialStateOp : public OpKernel {
   }
 
  private:
+  int nqubits_;
+  bool is_matrix_;
   int threads_;
 };
 
 // Register the CPU kernels.
 #define REGISTER_CPU(T)                                               \
   REGISTER_KERNEL_BUILDER(                                            \
-      Name("InitialState").Device(DEVICE_CPU).TypeConstraint<T>("T"), \
+      Name("InitialState").Device(DEVICE_CPU).TypeConstraint<T>("dtype"), \
       InitialStateOp<CPUDevice, T>);
 REGISTER_CPU(complex64);
 REGISTER_CPU(complex128);
@@ -63,7 +71,7 @@ REGISTER_CPU(complex128);
 #define REGISTER_GPU(T)                                               \
   extern template struct InitialStateFunctor<GPUDevice, T>;           \
   REGISTER_KERNEL_BUILDER(                                            \
-      Name("InitialState").Device(DEVICE_GPU).TypeConstraint<T>("T"), \
+      Name("InitialState").Device(DEVICE_GPU).TypeConstraint<T>("dtype"), \
       InitialStateOp<GPUDevice, T>);
 REGISTER_GPU(complex64);
 REGISTER_GPU(complex128);

--- a/src/qibo/tensorflow/custom_operators/cc/kernels/initial_state_kernels.cc
+++ b/src/qibo/tensorflow/custom_operators/cc/kernels/initial_state_kernels.cc
@@ -15,10 +15,10 @@ namespace functor {
 // CPU specialization
 template <typename T>
 struct InitialStateFunctor<CPUDevice, T> {
-  void operator()(const CPUDevice &d, T *out, int64 shape, int nthreads)
+  void operator()(const CPUDevice &d, T *out, int64 size)
   {
-    #pragma omp parallel for num_threads(nthreads)
-    for (size_t i = 1; i < (size_t) shape; i++)
+    #pragma omp parallel for
+    for (size_t i = 1; i < (size_t) size; i++)
       out[i] = T(0, 0);
     out[0] = T(1, 0);
   }
@@ -32,11 +32,12 @@ class InitialStateOp : public OpKernel {
     OP_REQUIRES_OK(context, context->GetAttr("is_matrix", &is_matrix_));
     OP_REQUIRES_OK(context, context->GetAttr("omp_num_threads", &threads_));
     OP_REQUIRES(context, nqubits_ > 0, errors::InvalidArgument("nqubits must be positive"));
+    omp_set_num_threads(threads_);
   }
 
   void Compute(OpKernelContext *context) override {
     // grabe the input tensor
-    const int64 size = std::pow(2, nqubits_);
+    const int64 size = pow(2, nqubits_);
 
     TensorShape shape{size};
     if (is_matrix_)
@@ -48,8 +49,7 @@ class InitialStateOp : public OpKernel {
     // call the implementation
     InitialStateFunctor<Device, T>()(context->eigen_device<Device>(),
                                      output_tensor->flat<T>().data(),
-                                     output_tensor->flat<T>().size(),
-                                     threads_);
+                                     output_tensor->flat<T>().size());
   }
 
  private:

--- a/src/qibo/tensorflow/custom_operators/cc/kernels/initial_state_kernels.cu.cc
+++ b/src/qibo/tensorflow/custom_operators/cc/kernels/initial_state_kernels.cu.cc
@@ -28,8 +28,8 @@ template <typename T>
 struct InitialStateFunctor<GPUDevice, T> {
   void operator()(const GPUDevice& d, T* out, int64 shape, int nthreads) {
 
-    int blockSize = DEFAULT_BLOCK_SIZE;
-    int numBlocks = (shape + blockSize - 1) / blockSize;
+    int64 blockSize = DEFAULT_BLOCK_SIZE;
+    int64 numBlocks = (shape + blockSize - 1) / blockSize;
     if (shape < blockSize) {
       numBlocks = 1;
       blockSize = shape;

--- a/src/qibo/tensorflow/custom_operators/cc/kernels/initial_state_kernels.cu.cc
+++ b/src/qibo/tensorflow/custom_operators/cc/kernels/initial_state_kernels.cu.cc
@@ -26,13 +26,13 @@ __global__ void InitializeToZero(T* out) {
 // Define the GPU implementation that launches the CUDA kernel.
 template <typename T>
 struct InitialStateFunctor<GPUDevice, T> {
-  void operator()(const GPUDevice& d, T* out, int64 shape, int nthreads) {
+  void operator()(const GPUDevice& d, T* out, int64 size) {
 
     int64 blockSize = DEFAULT_BLOCK_SIZE;
-    int64 numBlocks = (shape + blockSize - 1) / blockSize;
+    int64 numBlocks = (size + blockSize - 1) / blockSize;
     if (shape < blockSize) {
       numBlocks = 1;
-      blockSize = shape;
+      blockSize = size;
     }
 
     InitializeToZero<T><<<numBlocks, blockSize, 0, d.stream()>>>(out);

--- a/src/qibo/tensorflow/custom_operators/cc/kernels/initial_state_kernels.cu.cc
+++ b/src/qibo/tensorflow/custom_operators/cc/kernels/initial_state_kernels.cu.cc
@@ -30,7 +30,7 @@ struct InitialStateFunctor<GPUDevice, T> {
 
     int64 blockSize = DEFAULT_BLOCK_SIZE;
     int64 numBlocks = (size + blockSize - 1) / blockSize;
-    if (shape < blockSize) {
+    if (size < blockSize) {
       numBlocks = 1;
       blockSize = size;
     }

--- a/src/qibo/tensorflow/custom_operators/cc/ops/custom_ops.cc
+++ b/src/qibo/tensorflow/custom_operators/cc/ops/custom_ops.cc
@@ -5,10 +5,11 @@ using namespace tensorflow;
 
 // Register op that generates initial state
 REGISTER_OP("InitialState")
-    .Input("in: int64")
-    .Attr("T: {complex64, complex128}")
+    .Attr("nqubits: int")
+    .Attr("dtype: {complex64, complex128}")
+    .Attr("is_matrix: bool")
     .Attr("omp_num_threads: int")
-    .Output("out: T");
+    .Output("out: dtype");
 
 
 // Register op that changes qubit order for multi-GPU

--- a/src/qibo/tensorflow/distcircuit.py
+++ b/src/qibo/tensorflow/distcircuit.py
@@ -136,7 +136,7 @@ class TensorflowDistributedCircuit(circuit.TensorflowCircuit):
             for i in ids:
                 with tf.device(device):
                     piece = self._device_job(state.pieces[i], queues[i])
-                    state.pieces[i] = piece
+                    state.pieces[i].assign(piece)
                     del(piece)
 
         pool = joblib.Parallel(n_jobs=len(self.calc_devices),
@@ -167,7 +167,8 @@ class TensorflowDistributedCircuit(circuit.TensorflowCircuit):
             for piece in state.pieces:
                 total_norm += tf.reduce_sum(tf.math.square(tf.abs(piece)))
             total_norm = tf.cast(tf.math.sqrt(total_norm), dtype=state.dtype)
-            state.pieces /= total_norm
+            for piece in state.pieces:
+                piece.assign(piece / total_norm)
 
     def _revert_swaps(self, state: utils.DistributedState, swap_pairs: List[Tuple[int, int]]):
         for q1, q2 in swap_pairs:

--- a/src/qibo/tensorflow/distutils.py
+++ b/src/qibo/tensorflow/distutils.py
@@ -404,9 +404,10 @@ class DistributedState(DistributedBase):
       """Creates the |000...0> state for default initialization."""
       state = cls(circuit)
       with tf.device(state.device):
-          state.pieces[0] = op.initial_state(nqubits=state.nlocal,
-                                             dtype=DTYPES.get('DTYPECPX'),
-                                             is_matrix=False, omp_num_threads=get_threads())
+          piece = op.initial_state(nqubits=state.nlocal,
+                                   dtype=DTYPES.get('DTYPECPX'),
+                                   is_matrix=False, omp_num_threads=get_threads())
+          state.pieces[0] = tf.Variable(piece, dtype=piece.dtype)
       return state
 
     @classmethod
@@ -441,7 +442,7 @@ class DistributedState(DistributedBase):
                                            self.qubits.transpose_order,
                                            get_threads())
             for i in range(self.ndevices):
-                self.pieces[i] = new_state[i]
+                self.pieces[i].assign(new_state[i])
 
     @property
     def vector(self) -> tf.Tensor:

--- a/src/qibo/tensorflow/distutils.py
+++ b/src/qibo/tensorflow/distutils.py
@@ -404,7 +404,9 @@ class DistributedState(DistributedBase):
       """Creates the |000...0> state for default initialization."""
       state = cls(circuit)
       with tf.device(state.device):
-          state.pieces[0] = op.initial_state(state.pieces[0].shape, state.pieces[0].dtype, get_threads())
+          state.pieces[0] = op.initial_state(nqubits=state.nlocal,
+                                             dtype=DTYPES.get('DTYPECPX'),
+                                             is_matrix=False, omp_num_threads=get_threads())
       return state
 
     @classmethod

--- a/src/qibo/tests/test_custom_operators.py
+++ b/src/qibo/tests/test_custom_operators.py
@@ -25,13 +25,14 @@ def test_initial_state(dtype, compile):
   """Check that initial_state updates first element properly."""
   def apply_operator(dtype):
     """Apply the initial_state operator"""
-    return op.initial_state(10, dtype, get_threads())
+    return op.initial_state(nqubits=4, dtype=dtype,
+                            is_matrix=False, omp_num_threads=get_threads())
 
   func = apply_operator
   if compile:
       func = tf.function(apply_operator)
   final_state = func(dtype)
-  exact_state = np.array([1] + [0]*9, dtype=dtype)
+  exact_state = np.array([1] + [0]*15, dtype=dtype)
   np.testing.assert_allclose(final_state, exact_state)
 
 


### PR DESCRIPTION
I am opening this PR to complement the implementation in #305 for GPU.
Now the code compiles and passes several tests on GPU, however there is something wrong with some of distributed circuit tests.

@stavros11 could you please have a look? Looks like the local state vectors are not recovered from the devices after applying gates, this may be due to the replacement of `.assign` with `=`.