### PR TITLE
Detach custom operators

### DIFF
--- a/src/qibo/backends/__init__.py
+++ b/src/qibo/backends/__init__.py
@@ -41,10 +41,11 @@ else:
     try:
         os.environ["TF_CPP_MIN_LOG_LEVEL"] = str(config.LOG_LEVEL)
         import tensorflow as tf
-        try:
-            import qibo.tensorflow.custom_operators
-        except tf.errors.NotFoundError: # pragma: no cover
-            raise ModuleNotFoundError
+        import qibo.tensorflow.custom_operators as op
+        _CUSTOM_OPERATORS_LOADED = op._custom_operators_loaded
+        if not _CUSTOM_OPERATORS_LOADED:
+            log.warning("Removing custom operators from available backends.")
+            AVAILABLE_BACKENDS.remove("custom")
         K = TensorflowBackend()
     except ModuleNotFoundError: # pragma: no cover
         # case not tested because CI has tf installed
@@ -109,6 +110,11 @@ if _BACKEND_NAME != "tensorflow": # pragma: no cover
     log.warning("{} does not support Qibo custom operators and GPU. "
                 "Einsum will be used to apply gates on CPU."
                 "".format(_BACKEND_NAME))
+    set_backend("defaulteinsum")
+
+
+if _BACKEND_NAME == "tensorflow" and not _CUSTOM_OPERATORS_LOADED: # pragma: no cover
+    log.warning("Einsum will be used to apply gates with tensorflow.")
     set_backend("defaulteinsum")
 
 

--- a/src/qibo/backends/__init__.py
+++ b/src/qibo/backends/__init__.py
@@ -43,7 +43,7 @@ else:
         import tensorflow as tf
         import qibo.tensorflow.custom_operators as op
         _CUSTOM_OPERATORS_LOADED = op._custom_operators_loaded
-        if not _CUSTOM_OPERATORS_LOADED:
+        if not _CUSTOM_OPERATORS_LOADED: # pragma: no cover
             log.warning("Removing custom operators from available backends.")
             AVAILABLE_BACKENDS.remove("custom")
         K = TensorflowBackend()

--- a/src/qibo/backends/numpy.py
+++ b/src/qibo/backends/numpy.py
@@ -2,25 +2,6 @@ from qibo.backends import abstract
 from qibo.config import raise_error, log
 
 
-class DummyModule:
-
-    def __init__(self, *names):
-        self.names = set(names)
-
-    def __getattr__(self, name):
-        if name in self.names:
-            return None
-        else: # pragma: no cover
-            raise_error(ValueError, "{} is not available in the numpy backend."
-                                    "".format(name))
-
-    def __enter__(self, *args):
-        pass
-
-    def __exit__(self, *args):
-        pass
-
-
 class NumpyBackend(abstract.AbstractBackend):
 
     def __init__(self):
@@ -40,8 +21,8 @@ class NumpyBackend(abstract.AbstractBackend):
         self.random = np.random
         self.newaxis = np.newaxis
         self.oom_error = MemoryError
-        self.optimization = DummyModule()
-        self.op = DummyModule("apply_gate")
+        self.optimization = None
+        self.op = None
 
     def set_device(self, name):
         log.warning("Numpy does not support device placement. "
@@ -216,6 +197,14 @@ class NumpyBackend(abstract.AbstractBackend):
         return func
 
     def device(self, device_name):
+        class DummyModule:
+
+            def __enter__(self, *args):
+                pass
+
+            def __exit__(self, *args):
+                pass
+
         return DummyModule()
 
     def set_seed(self, seed):

--- a/src/qibo/backends/tensorflow.py
+++ b/src/qibo/backends/tensorflow.py
@@ -136,11 +136,12 @@ class TensorflowBackend(numpy.NumpyBackend):
 
     def initial_state(self, nqubits, is_matrix=False):
         if self.op is None:
-            state = self.backend.zeros(2 ** nqubits, dtype=self.dtypes('DTYPECPX'))
+            dim = 1 + is_matrix
+            shape = dim * (2 ** nqubits,)
+            idx = self.backend.constant([dim * [0]], dtype=self.dtypes('DTYPEINT'))
+            state = self.backend.zeros(shape, dtype=self.dtypes('DTYPECPX'))
             update = self.backend.constant([1], dtype=self.dtypes('DTYPECPX'))
-            state = self.backend.tensor_scatter_nd_update(state,
-                        self.backend.constant([[0]], dtype=self.dtypes('DTYPEINT')),
-                        update)
+            state = self.backend.tensor_scatter_nd_update(state, idx, update)
             return state
         else:
             from qibo.config import get_threads

--- a/src/qibo/backends/tensorflow.py
+++ b/src/qibo/backends/tensorflow.py
@@ -44,7 +44,10 @@ class TensorflowBackend(numpy.NumpyBackend):
         self.optimization = Optimization()
 
         from qibo.tensorflow import custom_operators as op
-        self.op = op
+        self.op = None
+        if op._custom_operators_loaded:
+            self.op = op
+
 
     def set_device(self, name):
         abstract.AbstractBackend.set_device(self, name)
@@ -132,10 +135,18 @@ class TensorflowBackend(numpy.NumpyBackend):
         return self.backend.gather_nd(x, indices)
 
     def initial_state(self, nqubits, is_matrix=False):
-        from qibo.config import get_threads
-        return self.op.initial_state(nqubits, self.dtypes('DTYPECPX'),
-                                     is_matrix=is_matrix,
-                                     omp_num_threads=get_threads())
+        if self.op is None:
+            state = self.backend.zeros(2 ** nqubits, dtype=self.dtypes('DTYPECPX'))
+            update = self.backend.constant([1], dtype=self.dtypes('DTYPECPX'))
+            state = self.backend.tensor_scatter_nd_update(state,
+                        self.backend.constant([[0]], dtype=self.dtypes('DTYPEINT')),
+                        update)
+            return state
+        else:
+            from qibo.config import get_threads
+            return self.op.initial_state(nqubits, self.dtypes('DTYPECPX'),
+                                        is_matrix=is_matrix,
+                                        omp_num_threads=get_threads())
 
     def random_uniform(self, shape, dtype='DTYPE'):
         return self.backend.random.uniform(shape, dtype=self.dtypes(dtype))

--- a/src/qibo/backends/tensorflow.py
+++ b/src/qibo/backends/tensorflow.py
@@ -135,7 +135,7 @@ class TensorflowBackend(numpy.NumpyBackend):
         return self.backend.gather_nd(x, indices)
 
     def initial_state(self, nqubits, is_matrix=False):
-        if self.op is None:
+        if self.op is None: # pragma: no cover
             dim = 1 + is_matrix
             shape = dim * (2 ** nqubits,)
             idx = self.backend.constant([dim * [0]], dtype=self.dtypes('DTYPEINT'))

--- a/src/qibo/core/cgates.py
+++ b/src/qibo/core/cgates.py
@@ -27,7 +27,8 @@ class BackendGate(BaseBackendGate):
                         "Custom operator gates should not be used in compiled "
                         "mode.")
         super().__init__()
-        self.gate_op = K.op.apply_gate
+        if K.op:
+            self.gate_op = K.op.apply_gate
         self.qubits_tensor = None
         self.qubits_tensor_dm = None
         self.target_qubits_dm = None
@@ -92,11 +93,11 @@ class MatrixGate(BackendGate):
         self.reprepare()
 
     def state_vector_call(self, state):
-        return self.gate_op(state, self.matrix, self.qubits_tensor,
+        return self.gate_op(state, self.matrix, self.qubits_tensor, # pylint: disable=E1121
                             self.nqubits, *self.target_qubits, get_threads())
 
     def density_matrix_call(self, state):
-        state = self.gate_op(state, self.matrix, self.qubits_tensor_dm,
+        state = self.gate_op(state, self.matrix, self.qubits_tensor_dm, # pylint: disable=E1121
                              2 * self.nqubits, *self.target_qubits, get_threads())
         adjmatrix = K.conj(self.matrix)
         state = self.gate_op(state, adjmatrix, self.qubits_tensor,

--- a/src/qibo/tensorflow/custom_operators/__init__.py
+++ b/src/qibo/tensorflow/custom_operators/__init__.py
@@ -20,7 +20,7 @@ try:
         # Import gradients
         from qibo.tensorflow.custom_operators.python.ops.qibo_tf_custom_operators_grads import _initial_state_grad
         _custom_operators_loaded = True
-    except tf.errors.NotFoundError:
+    except tf.errors.NotFoundError: # pragma: no cover
         log.warning("Custom operators not found, skipping custom operators load.")
 
 except ModuleNotFoundError: # pragma: no cover

--- a/src/qibo/tensorflow/custom_operators/__init__.py
+++ b/src/qibo/tensorflow/custom_operators/__init__.py
@@ -1,23 +1,27 @@
 """TensorFlow custom operator for Tensor initial state."""
 from qibo.config import log
 
-
+_custom_operators_loaded = False
 try:
     import tensorflow as tf
-    from qibo.tensorflow.custom_operators.python.ops.qibo_tf_custom_operators import initial_state
-    from qibo.tensorflow.custom_operators.python.ops.qibo_tf_custom_operators import transpose_state
-    from qibo.tensorflow.custom_operators.python.ops.qibo_tf_custom_operators import swap_pieces
-    from qibo.tensorflow.custom_operators.python.ops.qibo_tf_custom_operators import apply_gate
-    from qibo.tensorflow.custom_operators.python.ops.qibo_tf_custom_operators import apply_x
-    from qibo.tensorflow.custom_operators.python.ops.qibo_tf_custom_operators import apply_y
-    from qibo.tensorflow.custom_operators.python.ops.qibo_tf_custom_operators import apply_z
-    from qibo.tensorflow.custom_operators.python.ops.qibo_tf_custom_operators import apply_z_pow
-    from qibo.tensorflow.custom_operators.python.ops.qibo_tf_custom_operators import apply_two_qubit_gate
-    from qibo.tensorflow.custom_operators.python.ops.qibo_tf_custom_operators import apply_fsim
-    from qibo.tensorflow.custom_operators.python.ops.qibo_tf_custom_operators import apply_swap
-    from qibo.tensorflow.custom_operators.python.ops.qibo_tf_custom_operators import collapse_state
-    # Import gradients
-    from qibo.tensorflow.custom_operators.python.ops.qibo_tf_custom_operators_grads import _initial_state_grad
+    try:
+        from qibo.tensorflow.custom_operators.python.ops.qibo_tf_custom_operators import initial_state
+        from qibo.tensorflow.custom_operators.python.ops.qibo_tf_custom_operators import transpose_state
+        from qibo.tensorflow.custom_operators.python.ops.qibo_tf_custom_operators import swap_pieces
+        from qibo.tensorflow.custom_operators.python.ops.qibo_tf_custom_operators import apply_gate
+        from qibo.tensorflow.custom_operators.python.ops.qibo_tf_custom_operators import apply_x
+        from qibo.tensorflow.custom_operators.python.ops.qibo_tf_custom_operators import apply_y
+        from qibo.tensorflow.custom_operators.python.ops.qibo_tf_custom_operators import apply_z
+        from qibo.tensorflow.custom_operators.python.ops.qibo_tf_custom_operators import apply_z_pow
+        from qibo.tensorflow.custom_operators.python.ops.qibo_tf_custom_operators import apply_two_qubit_gate
+        from qibo.tensorflow.custom_operators.python.ops.qibo_tf_custom_operators import apply_fsim
+        from qibo.tensorflow.custom_operators.python.ops.qibo_tf_custom_operators import apply_swap
+        from qibo.tensorflow.custom_operators.python.ops.qibo_tf_custom_operators import collapse_state
+        # Import gradients
+        from qibo.tensorflow.custom_operators.python.ops.qibo_tf_custom_operators_grads import _initial_state_grad
+        _custom_operators_loaded = True
+    except tf.errors.NotFoundError:
+        log.warning("Custom operators not found, skipping custom operators load.")
 
 except ModuleNotFoundError: # pragma: no cover
     # case not tested because CI has tf installed

--- a/src/qibo/tests_new/conftest.py
+++ b/src/qibo/tests_new/conftest.py
@@ -12,7 +12,7 @@ try:
                 "numpy_defaulteinsum,numpy_matmuleinsum"
     _ENGINES = "numpy,tensorflow"
     import qibo.tensorflow.custom_operators as op
-    if not op._custom_operators_loaded:
+    if not op._custom_operators_loaded: # pragma: no cover
         _BACKENDS = "defaulteinsum,matmuleinsum,"\
                     "numpy_defaulteinsum,numpy_matmuleinsum"
     _ACCELERATORS = "2/GPU:0,1/GPU:0+1/GPU:1,2/GPU:0+1/GPU:1+1/GPU:2"
@@ -81,7 +81,7 @@ def pytest_generate_tests(metafunc):
             if x in backends:
                 backends.remove(x)
 
-    if "custom" not in backends:
+    if "custom" not in backends: # pragma: no cover
         # for `test_tensorflow_custom_operators.py`
         module_name = "qibo.tests_new.test_tensorflow_custom_operators"
         if metafunc.module.__name__ == module_name:

--- a/src/qibo/tests_new/conftest.py
+++ b/src/qibo/tests_new/conftest.py
@@ -8,13 +8,13 @@ import pytest
 
 try:
     import tensorflow as tf
-    try:
-        import qibo.tensorflow.custom_operators
-    except tf.errors.NotFoundError: # pragma: no cover
-        raise ModuleNotFoundError
     _BACKENDS = "custom,defaulteinsum,matmuleinsum,"\
                 "numpy_defaulteinsum,numpy_matmuleinsum"
     _ENGINES = "numpy,tensorflow"
+    import qibo.tensorflow.custom_operators as op
+    if not op._custom_operators_loaded:
+        _BACKENDS = "defaulteinsum,matmuleinsum,"\
+                    "numpy_defaulteinsum,numpy_matmuleinsum"
     _ACCELERATORS = "2/GPU:0,1/GPU:0+1/GPU:1,2/GPU:0+1/GPU:1+1/GPU:2"
 except ModuleNotFoundError: # pragma: no cover
     # workflows install Tensorflow automatically so this case is not covered
@@ -81,6 +81,7 @@ def pytest_generate_tests(metafunc):
             if x in backends:
                 backends.remove(x)
 
+    if "custom" not in backends:
         # for `test_tensorflow_custom_operators.py`
         module_name = "qibo.tests_new.test_tensorflow_custom_operators"
         if metafunc.module.__name__ == module_name:

--- a/src/qibo/tests_new/conftest.py
+++ b/src/qibo/tests_new/conftest.py
@@ -106,8 +106,10 @@ def pytest_generate_tests(metafunc):
                 metafunc.parametrize("accelerators", [None])
             else:
                 config = [(b, None) for b in backends]
-                config.extend([("custom", {dev[1:]: int(dev[0]) for dev in x.split("+")})
-                               for x in accelerators.split(",")])
+                if "custom" in backends:
+                    for x in accelerators.split(","):
+                        devdict = {dev[1:]: int(dev[0]) for dev in x.split("+")}
+                        config.append(("custom", devdict))
                 metafunc.parametrize("backend,accelerators", config)
         else:
             metafunc.parametrize("backend", backends)

--- a/src/qibo/tests_new/test_abstract_circuit_qasm.py
+++ b/src/qibo/tests_new/test_abstract_circuit_qasm.py
@@ -1,5 +1,6 @@
 """Tests creating abstract Qibo circuits from OpenQASM code."""
 import pytest
+import qibo
 from qibo import __version__
 from qibo.abstractions import gates
 from qibo.tests_new.test_abstract_circuit import Circuit
@@ -346,7 +347,9 @@ test q[2];
         c = Circuit.from_qasm(target)
 
 
-def test_from_qasm_measurements():
+def test_from_qasm_measurements(backend):
+    original_backend = qibo.get_backend()
+    qibo.set_backend(backend)
     target = """OPENQASM 2.0;
 include "qelib1.inc";
 qreg q[5];
@@ -363,9 +366,12 @@ measure q[3] -> b[1];"""
     assert isinstance(c.queue[0], gates.X)
     assert isinstance(c.measurement_gate, gates.M)
     assert c.measurement_tuples == {"a": (0, 2, 4), "b": (1, 3)}
+    qibo.set_backend(original_backend)
 
 
-def test_from_qasm_measurements_order():
+def test_from_qasm_measurements_order(backend):
+    original_backend = qibo.get_backend()
+    qibo.set_backend(backend)
     target = """OPENQASM 2.0;
 include "qelib1.inc";
 qreg q[5];
@@ -379,9 +385,12 @@ measure q[0] -> b[0];
 """
     c = Circuit.from_qasm(target)
     assert c.measurement_tuples == {"a": (4, 3, 1), "b": (0, 2)}
+    qibo.set_backend(original_backend)
 
 
-def test_from_qasm_invalid_measurements():
+def test_from_qasm_invalid_measurements(backend):
+    original_backend = qibo.get_backend()
+    qibo.set_backend(backend)
     # Undefined qubit
     target = """OPENQASM 2.0;
 qreg q[2];
@@ -434,6 +443,7 @@ creg a[2];
 measure q[0] -> a[1] -> a[0];"""
     with pytest.raises(ValueError):
         c = Circuit.from_qasm(target)
+    qibo.set_backend(original_backend)
 
 
 def test_from_qasm_invalid_parametrized_gates():
@@ -470,7 +480,9 @@ rx(0.123)(0.25)(0) q[0];
         c = Circuit.from_qasm(target)
 
 
-def test_from_qasm_empty_spaces():
+def test_from_qasm_empty_spaces(backend):
+    original_backend = qibo.get_backend()
+    qibo.set_backend(backend)
     target = """OPENQASM 2.0; qreg q[2];
 creg a[2]; h q[0];x q[1]; cx q[0], q[1];
 measure q[0] -> a[0];measure q[1]->a[1]"""
@@ -481,3 +493,4 @@ measure q[0] -> a[0];measure q[1]->a[1]"""
     assert isinstance(c.queue[1], gates.X)
     assert isinstance(c.queue[2], gates.CNOT)
     assert c.measurement_tuples == {"a": (0, 1)}
+    qibo.set_backend(original_backend)

--- a/src/qibo/tests_new/test_core_circuit_parametrized.py
+++ b/src/qibo/tests_new/test_core_circuit_parametrized.py
@@ -246,24 +246,23 @@ def test_set_parameters_with_gate_fusion(backend, trainable, accelerators):
 
 def test_variable_theta(backend):
     """Check that parametrized gates accept `tf.Variable` parameters."""
+    if "numpy" in backend:
+        pytest.skip("Numpy backends do not support variable parameters.")
+
     from qibo import K
     original_backend = qibo.get_backend()
     qibo.set_backend(backend)
-    if "numpy" in backend:
-        with pytest.raises(ValueError):
-            theta1 = K.optimization.Variable(0.1234, dtype=K.dtypes('DTYPE'))
-    else:
-        theta1 = K.optimization.Variable(0.1234, dtype=K.dtypes('DTYPE'))
-        theta2 = K.optimization.Variable(0.4321, dtype=K.dtypes('DTYPE'))
+    theta1 = K.optimization.Variable(0.1234, dtype=K.dtypes('DTYPE'))
+    theta2 = K.optimization.Variable(0.4321, dtype=K.dtypes('DTYPE'))
 
-        cvar = Circuit(2)
-        cvar.add(gates.RX(0, theta1))
-        cvar.add(gates.RY(1, theta2))
-        final_state = cvar()
+    cvar = Circuit(2)
+    cvar.add(gates.RX(0, theta1))
+    cvar.add(gates.RY(1, theta2))
+    final_state = cvar()
 
-        c = Circuit(2)
-        c.add(gates.RX(0, 0.1234))
-        c.add(gates.RY(1, 0.4321))
-        target_state = c()
-        np.testing.assert_allclose(final_state, target_state)
+    c = Circuit(2)
+    c.add(gates.RX(0, 0.1234))
+    c.add(gates.RY(1, 0.4321))
+    target_state = c()
+    np.testing.assert_allclose(final_state, target_state)
     qibo.set_backend(original_backend)

--- a/src/qibo/tests_new/test_core_circuit_qasm.py
+++ b/src/qibo/tests_new/test_core_circuit_qasm.py
@@ -34,7 +34,10 @@ h q[4];"""
     qibo.set_backend(original_backend)
 
 
-def test_simple_cirq():
+def test_simple_cirq(backend):
+    import qibo
+    original_backend = qibo.get_backend()
+    qibo.set_backend(backend)
     c1 = Circuit(2)
     c1.add(gates.H(0))
     c1.add(gates.H(1))
@@ -50,9 +53,13 @@ def test_simple_cirq():
     assert c3.depth == c2depth
     final_state_c3 = c3()
     np.testing.assert_allclose(final_state_c3, final_state_c2, atol=_atol)
+    qibo.set_backend(original_backend)
 
 
-def test_multiqubit_gates_cirq():
+def test_multiqubit_gates_cirq(backend):
+    import qibo
+    original_backend = qibo.get_backend()
+    qibo.set_backend(backend)
     c1 = Circuit(2)
     c1.add(gates.H(0))
     c1.add(gates.CNOT(0, 1))
@@ -71,9 +78,13 @@ def test_multiqubit_gates_cirq():
     assert c3.depth == c2depth
     final_state_c3 = c3()
     np.testing.assert_allclose(final_state_c3, final_state_c2, atol=_atol)
+    qibo.set_backend(original_backend)
 
 
-def test_toffoli_cirq():
+def test_toffoli_cirq(backend):
+    import qibo
+    original_backend = qibo.get_backend()
+    qibo.set_backend(backend)
     c1 = Circuit(3)
     c1.add(gates.Y(0))
     c1.add(gates.TOFFOLI(0, 1, 2))
@@ -93,9 +104,13 @@ def test_toffoli_cirq():
     assert c3.depth == c2depth
     final_state_c3 = c3()
     np.testing.assert_allclose(final_state_c3, final_state_c2, atol=_atol)
+    qibo.set_backend(original_backend)
 
 
-def test_parametrized_gate_cirq():
+def test_parametrized_gate_cirq(backend):
+    import qibo
+    original_backend = qibo.get_backend()
+    qibo.set_backend(backend)
     c1 = Circuit(2)
     c1.add(gates.Y(0))
     c1.add(gates.RY(1, 0.1234))
@@ -110,6 +125,7 @@ def test_parametrized_gate_cirq():
     c3 = Circuit.from_qasm(c2.to_qasm())
     final_state_c3 = c3()
     np.testing.assert_allclose(final_state_c3, final_state_c2, atol=_atol)
+    qibo.set_backend(original_backend)
 
 
 def test_cu1_cirq():
@@ -122,7 +138,10 @@ def test_cu1_cirq():
         c2 = circuit_from_qasm(c1.to_qasm())
 
 
-def test_ugates_cirq():
+def test_ugates_cirq(backend):
+    import qibo
+    original_backend = qibo.get_backend()
+    qibo.set_backend(backend)
     c1 = Circuit(3)
     c1.add(gates.RX(0, 0.1))
     c1.add(gates.RZ(1, 0.4))
@@ -148,6 +167,7 @@ def test_ugates_cirq():
     # catches unknown gate "cu3"
     with pytest.raises(exception.QasmException):
         c2 = circuit_from_qasm(c1.to_qasm())
+    qibo.set_backend(original_backend)
 
 
 def test_crotations_cirq():
@@ -161,7 +181,10 @@ def test_crotations_cirq():
         c2 = circuit_from_qasm(c1.to_qasm())
 
 
-def test_from_qasm_evaluation():
+def test_from_qasm_evaluation(backend):
+    import qibo
+    original_backend = qibo.get_backend()
+    qibo.set_backend(backend)
     import numpy as np
     target = f"""OPENQASM 2.0;
 include "qelib1.inc";
@@ -171,3 +194,4 @@ h q[1];"""
     c = Circuit.from_qasm(target)
     target_state = np.ones(4) / 2.0
     np.testing.assert_allclose(c(), target_state)
+    qibo.set_backend(original_backend)

--- a/src/qibo/tests_new/test_core_gates.py
+++ b/src/qibo/tests_new/test_core_gates.py
@@ -155,10 +155,13 @@ def test_collapse_gate_errors(backend):
 
 # TODO: Test :class:`qibo.core.cgates.M`
 
-def test_m_construct_unitary():
+def test_m_construct_unitary(backend):
+    original_backend = qibo.get_backend()
+    qibo.set_backend(backend)
     gate = gates.M(0)
     with pytest.raises(ValueError):
         matrix = gate.unitary
+    qibo.set_backend(original_backend)
 
 
 def test_rx(backend):


### PR DESCRIPTION
This PR:
- improves the mechanism to detect if custom operators are available
- if custom operators are not available but tf is available the defaulteinsum and matmuleinsum will be available.
- fixed tests_new to support `--engines numpy`

@stavros11 please have a look. I am still not able to run the `tests_new` with `--engine tensorflow` (when no custom operators are available) because circuits from some tests are still calling cgates (even if the backend is matmuleinsum and defaulteinsum).