### PR TITLE
Fix custom operator imports in tests

### DIFF
--- a/src/qibo/backends/numpy.py
+++ b/src/qibo/backends/numpy.py
@@ -2,25 +2,6 @@ from qibo.backends import abstract
 from qibo.config import raise_error, log
 
 
-class DummyModule:
-
-    def __init__(self, *names):
-        self.names = set(names)
-
-    def __getattr__(self, name):
-        if name in self.names:
-            return None
-        else: # pragma: no cover
-            raise_error(ValueError, "{} is not available in the numpy backend."
-                                    "".format(name))
-
-    def __enter__(self, *args):
-        pass
-
-    def __exit__(self, *args):
-        pass
-
-
 class NumpyBackend(abstract.AbstractBackend):
 
     def __init__(self):
@@ -40,8 +21,8 @@ class NumpyBackend(abstract.AbstractBackend):
         self.random = np.random
         self.newaxis = np.newaxis
         self.oom_error = MemoryError
-        self.optimization = DummyModule()
-        self.op = None#DummyModule("apply_gate")
+        self.optimization = None
+        self.op = None
 
     def set_device(self, name):
         log.warning("Numpy does not support device placement. "
@@ -216,6 +197,14 @@ class NumpyBackend(abstract.AbstractBackend):
         return func
 
     def device(self, device_name):
+        class DummyModule:
+
+            def __enter__(self, *args):
+                pass
+
+            def __exit__(self, *args):
+                pass
+
         return DummyModule()
 
     def set_seed(self, seed):

--- a/src/qibo/backends/numpy.py
+++ b/src/qibo/backends/numpy.py
@@ -41,7 +41,7 @@ class NumpyBackend(abstract.AbstractBackend):
         self.newaxis = np.newaxis
         self.oom_error = MemoryError
         self.optimization = DummyModule()
-        self.op = DummyModule("apply_gate")
+        self.op = None#DummyModule("apply_gate")
 
     def set_device(self, name):
         log.warning("Numpy does not support device placement. "

--- a/src/qibo/backends/tensorflow.py
+++ b/src/qibo/backends/tensorflow.py
@@ -136,11 +136,12 @@ class TensorflowBackend(numpy.NumpyBackend):
 
     def initial_state(self, nqubits, is_matrix=False):
         if self.op is None:
-            state = self.backend.zeros(2 ** nqubits, dtype=self.dtypes('DTYPECPX'))
+            dim = 1 + is_matrix
+            shape = dim * (2 ** nqubits,)
+            idx = self.backend.constant([dim * [0]], dtype=self.dtypes('DTYPEINT'))
+            state = self.backend.zeros(shape, dtype=self.dtypes('DTYPECPX'))
             update = self.backend.constant([1], dtype=self.dtypes('DTYPECPX'))
-            state = self.backend.tensor_scatter_nd_update(state,
-                        self.backend.constant([[0]], dtype=self.dtypes('DTYPEINT')),
-                        update)
+            state = self.backend.tensor_scatter_nd_update(state, idx, update)
             return state
         else:
             from qibo.config import get_threads

--- a/src/qibo/core/cgates.py
+++ b/src/qibo/core/cgates.py
@@ -27,7 +27,8 @@ class BackendGate(BaseBackendGate):
                         "Custom operator gates should not be used in compiled "
                         "mode.")
         super().__init__()
-        self.gate_op = K.op.apply_gate
+        if K.op:
+            self.gate_op = K.op.apply_gate
         self.qubits_tensor = None
         self.qubits_tensor_dm = None
         self.target_qubits_dm = None

--- a/src/qibo/core/cgates.py
+++ b/src/qibo/core/cgates.py
@@ -93,11 +93,11 @@ class MatrixGate(BackendGate):
         self.reprepare()
 
     def state_vector_call(self, state):
-        return self.gate_op(state, self.matrix, self.qubits_tensor,
+        return self.gate_op(state, self.matrix, self.qubits_tensor, # pylint: disable=E1121
                             self.nqubits, *self.target_qubits, get_threads())
 
     def density_matrix_call(self, state):
-        state = self.gate_op(state, self.matrix, self.qubits_tensor_dm,
+        state = self.gate_op(state, self.matrix, self.qubits_tensor_dm, # pylint: disable=E1121
                              2 * self.nqubits, *self.target_qubits, get_threads())
         adjmatrix = K.conj(self.matrix)
         state = self.gate_op(state, adjmatrix, self.qubits_tensor,

--- a/src/qibo/tests_new/conftest.py
+++ b/src/qibo/tests_new/conftest.py
@@ -106,8 +106,10 @@ def pytest_generate_tests(metafunc):
                 metafunc.parametrize("accelerators", [None])
             else:
                 config = [(b, None) for b in backends]
-                config.extend([("custom", {dev[1:]: int(dev[0]) for dev in x.split("+")})
-                               for x in accelerators.split(",")])
+                if "custom" in backends:
+                    for x in accelerators.split(","):
+                        devdict = {dev[1:]: int(dev[0]) for dev in x.split("+")}
+                        config.append(("custom", devdict))
                 metafunc.parametrize("backend,accelerators", config)
         else:
             metafunc.parametrize("backend", backends)

--- a/src/qibo/tests_new/test_core_circuit_parametrized.py
+++ b/src/qibo/tests_new/test_core_circuit_parametrized.py
@@ -246,24 +246,23 @@ def test_set_parameters_with_gate_fusion(backend, trainable, accelerators):
 
 def test_variable_theta(backend):
     """Check that parametrized gates accept `tf.Variable` parameters."""
+    if "numpy" in backend:
+        pytest.skip("Numpy backends do not support variable parameters.")
+
     from qibo import K
     original_backend = qibo.get_backend()
     qibo.set_backend(backend)
-    if "numpy" in backend:
-        with pytest.raises(ValueError):
-            theta1 = K.optimization.Variable(0.1234, dtype=K.dtypes('DTYPE'))
-    else:
-        theta1 = K.optimization.Variable(0.1234, dtype=K.dtypes('DTYPE'))
-        theta2 = K.optimization.Variable(0.4321, dtype=K.dtypes('DTYPE'))
+    theta1 = K.optimization.Variable(0.1234, dtype=K.dtypes('DTYPE'))
+    theta2 = K.optimization.Variable(0.4321, dtype=K.dtypes('DTYPE'))
 
-        cvar = Circuit(2)
-        cvar.add(gates.RX(0, theta1))
-        cvar.add(gates.RY(1, theta2))
-        final_state = cvar()
+    cvar = Circuit(2)
+    cvar.add(gates.RX(0, theta1))
+    cvar.add(gates.RY(1, theta2))
+    final_state = cvar()
 
-        c = Circuit(2)
-        c.add(gates.RX(0, 0.1234))
-        c.add(gates.RY(1, 0.4321))
-        target_state = c()
-        np.testing.assert_allclose(final_state, target_state)
+    c = Circuit(2)
+    c.add(gates.RX(0, 0.1234))
+    c.add(gates.RY(1, 0.4321))
+    target_state = c()
+    np.testing.assert_allclose(final_state, target_state)
     qibo.set_backend(original_backend)


### PR DESCRIPTION
This fixes the issue of importing custom operators when the non-custom tensorflow operators are used on a machine that cannot compile custom operators. Particularly I identified two issues:

1. Custom operators were indeed imported by some gates that  are only defined in `cgates.py` and not in `gates.py` (eg. the measurement gate). This was easy to fix because these gates do not actually use the custom operators.
2. The non-custom `initial_state` was not properly implemented when `is_matrix=True`.