### PR TITLE
Fix old tests for Windows

### DIFF
--- a/.github/workflows/rules.yml
+++ b/.github/workflows/rules.yml
@@ -31,13 +31,8 @@ jobs:
       run: |
         pylint src -E -d E1123,E1120
     - name: Test with pytest core
-      if: startsWith(matrix.os, 'windows') == 0
       run: |
         pytest --cov=qibo --cov-report=xml --pyargs qibo
-    - name: Test for Windows
-      if: startsWith(matrix.os, 'windows')
-      run: |
-        pytest src/qibo/tests_new
     - name: Test examples
       if: startsWith(matrix.os, 'ubuntu') && matrix.python-version == '3.8'
       run: |

--- a/src/qibo/parallel.py
+++ b/src/qibo/parallel.py
@@ -15,10 +15,6 @@ class ParallelResources:  # pragma: no cover
     import multiprocessing as mp
     if platform == 'darwin':
         mp.set_start_method('fork')  # enforce on Darwin
-    elif platform == 'win32': # pragma: no cover
-        from qibo.config import raise_error
-        raise_error(NotImplementedError,
-            "Parallel evaluation not supported on Windows")
 
     # private objects holding the state
     _instance = None
@@ -30,6 +26,11 @@ class ParallelResources:  # pragma: no cover
 
     def __new__(cls, *args, **kwargs):
         """Creates singleton instance."""
+        if platform == 'win32': # pragma: no cover
+            from qibo.config import raise_error
+            raise_error(NotImplementedError,
+                "Parallel evaluation not supported on Windows")
+
         if cls._instance is None:
             cls._instance = super(ParallelResources, cls).__new__(
                 cls, *args, **kwargs)

--- a/src/qibo/parallel.py
+++ b/src/qibo/parallel.py
@@ -26,7 +26,7 @@ class ParallelResources:  # pragma: no cover
 
     def __new__(cls, *args, **kwargs):
         """Creates singleton instance."""
-        if platform == 'win32': # pragma: no cover
+        if self.platform == 'win32': # pragma: no cover
             from qibo.config import raise_error
             raise_error(NotImplementedError,
                 "Parallel evaluation not supported on Windows")

--- a/src/qibo/parallel.py
+++ b/src/qibo/parallel.py
@@ -26,14 +26,13 @@ class ParallelResources:  # pragma: no cover
 
     def __new__(cls, *args, **kwargs):
         """Creates singleton instance."""
-        if self.platform == 'win32': # pragma: no cover
-            from qibo.config import raise_error
-            raise_error(NotImplementedError,
-                "Parallel evaluation not supported on Windows")
-
         if cls._instance is None:
             cls._instance = super(ParallelResources, cls).__new__(
                 cls, *args, **kwargs)
+            if cls.platform == 'win32': # pragma: no cover
+                from qibo.config import raise_error
+                raise_error(NotImplementedError,
+                    "Parallel evaluation not supported on Windows")
         return cls._instance
 
     def run(self, params=None):

--- a/src/qibo/parallel.py
+++ b/src/qibo/parallel.py
@@ -14,6 +14,10 @@ class ParallelResources:  # pragma: no cover
     import multiprocessing as mp
     if platform == 'darwin':
         mp.set_start_method('fork')  # enforce on Darwin
+    elif platform == 'win32': # pragma: no cover
+        from qibo.config import raise_error
+        raise_error(NotImplementedError,
+            "Parallel evaluation not supported on Windows")
 
     # private objects holding the state
     _instance = None

--- a/src/qibo/tests/conftest.py
+++ b/src/qibo/tests/conftest.py
@@ -28,13 +28,13 @@ def pytest_generate_tests(metafunc):
     if "accelerators" in metafunc.fixturenames:
         if "custom" in AVAILABLE_BACKENDS:
             accelerators = [None, {"/GPU:0": 1, "/GPU:1": 1}]
-        else:
+        else: # pragma: no cover
             accelerators = [None]
         metafunc.parametrize("accelerators", accelerators)
 
     if "backend" in metafunc.fixturenames:
         backends = ["custom", "defaulteinsum", "matmuleinsum"]
-        if "custom" not in AVAILABLE_BACKENDS:
+        if "custom" not in AVAILABLE_BACKENDS: # pragma: no cover
             backends.remove("custom")
         metafunc.parametrize("backend", backends)
 

--- a/src/qibo/tests/test_callbacks.py
+++ b/src/qibo/tests/test_callbacks.py
@@ -227,7 +227,7 @@ def test_entropy_multiple_executions(accelerators):
 def test_entropy_large_circuit(accel):
     """Check that entropy calculation works for variational like circuit."""
     import qibo
-    if qibo.get_backend() != "custom" and accelerators: # pragma: no cover
+    if qibo.get_backend() != "custom" and accel: # pragma: no cover
         pytest.skip("Distributed circuit requires custom operators.")
 
     thetas = np.pi * np.random.random((3, 8))

--- a/src/qibo/tests/test_density_matrix.py
+++ b/src/qibo/tests/test_density_matrix.py
@@ -4,11 +4,10 @@ import qibo
 from qibo import models, gates, callbacks
 from qibo.tests import utils
 
-_BACKENDS = ["custom", "defaulteinsum", "matmuleinsum"]
+
 _atol = 1e-8
 
 
-@pytest.mark.parametrize("backend", _BACKENDS)
 def test_hgate_application_twoqubit(backend):
     """Check applying H gate to two qubit density matrix."""
     original_backend = qibo.get_backend()
@@ -30,7 +29,6 @@ def test_hgate_application_twoqubit(backend):
     qibo.set_backend(original_backend)
 
 
-@pytest.mark.parametrize("backend", _BACKENDS)
 def test_rygate_application_twoqubit(backend):
     """Check applying non-hermitian one qubit gate to one qubit density matrix."""
     original_backend = qibo.get_backend()
@@ -50,7 +48,6 @@ def test_rygate_application_twoqubit(backend):
     qibo.set_backend(original_backend)
 
 
-@pytest.mark.parametrize("backend", _BACKENDS)
 @pytest.mark.parametrize("gatename,gatekwargs",
                          [("H", {}), ("X", {}), ("Y", {}), ("Z", {}), ("I", {}),
                           ("RX", {"theta": 0.123}), ("RY", {"theta": 0.123}),
@@ -76,7 +73,6 @@ def test_one_qubit_gates(backend, gatename, gatekwargs):
     qibo.set_backend(original_backend)
 
 
-@pytest.mark.parametrize("backend", _BACKENDS)
 @pytest.mark.parametrize("gatename,gatekwargs",
                          [("CNOT", {}), ("CZ", {}), ("SWAP", {}),
                           ("CRX", {"theta": 0.123}), ("CRY", {"theta": 0.123}),
@@ -103,7 +99,6 @@ def test_two_qubit_gates(backend, gatename, gatekwargs):
     qibo.set_backend(original_backend)
 
 
-@pytest.mark.parametrize("backend", _BACKENDS)
 def test_toffoli_gate(backend):
     """Check applying Toffoli to three qubit density matrix."""
     original_backend = qibo.get_backend()
@@ -122,7 +117,6 @@ def test_toffoli_gate(backend):
     qibo.set_backend(original_backend)
 
 
-@pytest.mark.parametrize("backend", _BACKENDS)
 @pytest.mark.parametrize("nqubits", [1, 2, 3])
 def test_unitary_gate(backend, nqubits):
     """Check applying `gates.Unitary` to density matrix."""
@@ -148,7 +142,6 @@ def test_unitary_gate(backend, nqubits):
     qibo.set_backend(original_backend)
 
 
-@pytest.mark.parametrize("backend", _BACKENDS)
 def test_cu1gate_application_twoqubit(backend):
     """Check applying two qubit gate to three qubit density matrix."""
     original_backend = qibo.get_backend()
@@ -174,7 +167,6 @@ def test_cu1gate_application_twoqubit(backend):
     qibo.set_backend(original_backend)
 
 
-@pytest.mark.parametrize("backend", _BACKENDS)
 def test_flatten_density_matrix(backend):
     """Check ``Flatten`` gate works with density matrices."""
     original_backend = qibo.get_backend()
@@ -188,7 +180,6 @@ def test_flatten_density_matrix(backend):
     qibo.set_backend(original_backend)
 
 
-@pytest.mark.parametrize("backend", _BACKENDS)
 def test_circuit_dm(backend):
     """Check passing density matrix as initial state to a circuit."""
     original_backend = qibo.get_backend()
@@ -217,7 +208,6 @@ def test_circuit_dm(backend):
     qibo.set_backend(original_backend)
 
 
-@pytest.mark.parametrize("backend", _BACKENDS)
 def test_controlled_by_no_effect(backend):
     """Check controlled_by SWAP that should not be applied."""
     original_backend = qibo.get_backend()
@@ -239,7 +229,6 @@ def test_controlled_by_no_effect(backend):
     qibo.set_backend(original_backend)
 
 
-@pytest.mark.parametrize("backend", _BACKENDS)
 def test_controlled_with_effect(backend):
     """Check controlled_by SWAP that should be applied."""
     original_backend = qibo.get_backend()
@@ -264,7 +253,6 @@ def test_controlled_with_effect(backend):
     qibo.set_backend(original_backend)
 
 
-@pytest.mark.parametrize("backend", _BACKENDS)
 @pytest.mark.parametrize("nqubits", [4, 5])
 def test_controlled_by_random(backend, nqubits):
     """Check controlled_by method on gate."""
@@ -286,7 +274,6 @@ def test_controlled_by_random(backend, nqubits):
     qibo.set_backend(original_backend)
 
 
-@pytest.mark.parametrize("backend", _BACKENDS)
 def test_density_matrix_circuit_initial_state(backend):
     """Check that circuit transforms state vector initial state to density matrix."""
     import tensorflow as tf
@@ -304,7 +291,6 @@ def test_density_matrix_circuit_initial_state(backend):
     qibo.set_backend(original_backend)
 
 
-@pytest.mark.parametrize("backend", _BACKENDS)
 def test_bitflip_noise(backend):
     """Test `gates.PauliNoiseChannel` on random initial density matrix."""
     original_backend = qibo.get_backend()
@@ -324,7 +310,6 @@ def test_bitflip_noise(backend):
     qibo.set_backend(original_backend)
 
 
-@pytest.mark.parametrize("backend", _BACKENDS)
 def test_multiple_noise(backend):
     """Test `gates.NoiseChnanel` with multiple noise probabilities."""
     from qibo import matrices
@@ -349,7 +334,6 @@ def test_multiple_noise(backend):
     qibo.set_backend(original_backend)
 
 
-@pytest.mark.parametrize("backend", _BACKENDS)
 def test_circuit_reexecution(backend):
     """Test re-executing a circuit with `gates.NoiseChnanel`."""
     original_backend = qibo.get_backend()
@@ -365,7 +349,6 @@ def test_circuit_reexecution(backend):
     qibo.set_backend(original_backend)
 
 
-@pytest.mark.parametrize("backend", _BACKENDS)
 @pytest.mark.parametrize("tfmatrices", [False, True])
 @pytest.mark.parametrize("oncircuit", [False, True])
 def test_general_channel(backend, tfmatrices, oncircuit):
@@ -416,7 +399,6 @@ def test_controlled_by_channel():
         gates.KrausChannel(config).controlled_by(1)
 
 
-@pytest.mark.parametrize("backend", _BACKENDS)
 def test_krauss_channel_errors(backend):
     """Test errors raised by `gates.KrausChannel`."""
     original_backend = qibo.get_backend()
@@ -435,7 +417,6 @@ def test_krauss_channel_errors(backend):
     qibo.set_backend(original_backend)
 
 
-@pytest.mark.parametrize("backend", _BACKENDS)
 @pytest.mark.parametrize("density_matrix", [True, False])
 def test_unitary_channel(backend, density_matrix):
     """Test creating `gates.UnitaryChannel` from matrices and errors."""
@@ -503,10 +484,9 @@ def test_circuit_with_noise_gates():
     assert noisy_c.depth == 4
     assert noisy_c.ngates == 7
     for i in [1, 3, 5, 6]:
-        assert isinstance(noisy_c.queue[i], gates.PauliNoiseChannel)
+        assert noisy_c.queue[i].__class__.__name__ == "PauliNoiseChannel"
 
 
-@pytest.mark.parametrize("backend", _BACKENDS)
 def test_circuit_with_noise_execution(backend):
     """Check ``circuit.with_noise()`` execution."""
     original_backend = qibo.get_backend()
@@ -527,7 +507,6 @@ def test_circuit_with_noise_execution(backend):
     qibo.set_backend(original_backend)
 
 
-@pytest.mark.parametrize("backend", _BACKENDS)
 def test_circuit_with_noise_with_measurements(backend):
     """Check ``circuit.with_noise() when using measurement noise."""
     original_backend = qibo.get_backend()
@@ -549,7 +528,6 @@ def test_circuit_with_noise_with_measurements(backend):
     qibo.set_backend(original_backend)
 
 
-@pytest.mark.parametrize("backend", _BACKENDS)
 def test_circuit_with_noise_noise_map(backend):
     """Check ``circuit.with_noise() when giving noise map."""
     original_backend = qibo.get_backend()
@@ -597,7 +575,6 @@ def test_circuit_with_noise_exception():
         noisy_c = c.with_noise((0.2, 0.3, 0.0))
 
 
-@pytest.mark.parametrize("backend", _BACKENDS)
 def test_density_matrix_measurement(backend):
     """Check measurement gate on density matrices."""
     from qibo.tests.test_measurements import assert_results
@@ -620,7 +597,6 @@ def test_density_matrix_measurement(backend):
     qibo.set_backend(original_backend)
 
 
-@pytest.mark.parametrize("backend", _BACKENDS)
 def test_density_matrix_circuit_measurement(backend):
     """Check measurement gate on density matrices using circuit."""
     from qibo.tests.test_measurements import assert_results
@@ -660,7 +636,6 @@ def test_density_matrix_circuit_measurement(backend):
     qibo.set_backend(original_backend)
 
 
-@pytest.mark.parametrize("backend", _BACKENDS)
 @pytest.mark.parametrize("nqubits,targets,results",
                          [(2, [1], [0]), (3, [1], 0), (4, [1, 3], [0, 1]),
                           (5, [0, 3, 4], [1, 1, 0])])
@@ -681,7 +656,6 @@ def test_collapse_gate(backend, nqubits, targets, results):
     qibo.set_backend(original_backend)
 
 
-@pytest.mark.parametrize("backend", _BACKENDS)
 def test_reset_channel(backend):
     """Check ``gates.ResetChannel`` on a 3-qubit random density matrix."""
     original_backend = qibo.get_backend()
@@ -705,7 +679,6 @@ def test_reset_channel(backend):
     qibo.set_backend(original_backend)
 
 
-@pytest.mark.parametrize("backend", _BACKENDS)
 @pytest.mark.parametrize("t1,t2,time,excpop",
                          [(0.8, 0.5, 1.0, 0.4), (0.5, 0.8, 1.0, 0.4)])
 def test_thermal_relaxation_channel(backend, t1, t2, time, excpop):
@@ -752,7 +725,6 @@ def test_thermal_relaxation_channel(backend, t1, t2, time, excpop):
     qibo.set_backend(original_backend)
 
 
-@pytest.mark.parametrize("backend", _BACKENDS)
 @pytest.mark.parametrize("t1,t2,time,excpop",
                          [(1.0, 0.5, 1.5, 1.5), (1.0, 0.5, -0.5, 0.5),
                           (1.0, -0.5, 1.5, 0.5), (-1.0, 0.5, 1.5, 0.5),
@@ -766,7 +738,6 @@ def test_thermal_relaxation_channel_errors(backend, t1, t2, time, excpop):
     qibo.set_backend(original_backend)
 
 
-@pytest.mark.parametrize("backend", _BACKENDS)
 @pytest.mark.parametrize("nqubits", [5, 6])
 def test_variational_layer(backend, nqubits):
     original_backend = qibo.get_backend()
@@ -795,7 +766,6 @@ def test_variational_layer(backend, nqubits):
     qibo.set_backend(original_backend)
 
 
-@pytest.mark.parametrize("backend", _BACKENDS)
 def test_entanglement_entropy(backend):
     """Check that entanglement entropy calculation works for density matrices."""
     original_backend = qibo.get_backend()

--- a/src/qibo/tests/test_distributed.py
+++ b/src/qibo/tests/test_distributed.py
@@ -399,14 +399,14 @@ def test_distributed_qft_global_qubits_validity(nqubits, ndevices):
 
 
 @pytest.mark.parametrize("nqubits", [7, 8, 12, 13])
-@pytest.mark.parametrize("accelerators",
+@pytest.mark.parametrize("accel",
                          [{"/GPU:0": 2},
                           {"/GPU:0": 2, "/GPU:1": 2},
                           {"/GPU:0": 2, "/GPU:1": 5, "/GPU:2": 1}])
-def test_distributed_qft_execution(nqubits, accelerators):
+def test_distributed_qft_execution(nqubits, accel):
     original_backend = qibo.get_backend()
     qibo.set_backend("custom")
-    dist_c = models.QFT(nqubits, accelerators=accelerators)
+    dist_c = models.QFT(nqubits, accelerators=accel)
     c = models.QFT(nqubits)
 
     initial_state = utils.random_numpy_state(nqubits)

--- a/src/qibo/tests/test_evolution.py
+++ b/src/qibo/tests/test_evolution.py
@@ -80,12 +80,11 @@ def test_state_time_dependent_evolution_final_state(nqubits=2, dt=1e-2):
     final_psi = evolution(final_time=1, initial_state=np.copy(target_psi[0]))
 
 
-@pytest.mark.parametrize("nqubits,solver,accelerators,dt",
-                         [(3, "exp", None, 1e-3),
-                          (4, "exp", None, 1e-3),
-                          (4, "rk45", None, 1e-3),
-                          (4, "exp", {"/GPU:0": 2}, 1e-2)])
-def test_trotterized_evolution(nqubits, solver, accelerators, dt, h=1.0):
+@pytest.mark.parametrize("nqubits,solver,dt",
+                         [(3, "exp", 1e-3),
+                          (4, "exp", 1e-3),
+                          (4, "rk45", 1e-3)])
+def test_trotterized_evolution(nqubits, solver, dt, h=1.0):
     """Test state evolution using trotterization of ``TrotterHamiltonian``."""
     atol = 1e-4 if solver == "exp" else 1e-2
     target_psi = [np.ones(2 ** nqubits) / np.sqrt(2 ** nqubits)]
@@ -97,12 +96,11 @@ def test_trotterized_evolution(nqubits, solver, accelerators, dt, h=1.0):
     ham = hamiltonians.TFIM(nqubits, h=h, trotter=True)
     checker = TimeStepChecker(target_psi, atol=atol)
     evolution = models.StateEvolution(ham, dt, solver=solver,
-                                      callbacks=[checker],
-                                      accelerators=accelerators)
+                                      callbacks=[checker])
     final_psi = evolution(final_time=1, initial_state=np.copy(target_psi[0]))
 
     # Change dt
-    evolution = models.StateEvolution(ham, dt / 10, accelerators=accelerators)
+    evolution = models.StateEvolution(ham, dt / 10)
     final_psi = evolution(final_time=1, initial_state=np.copy(target_psi[0]))
     assert_states_equal(final_psi, target_psi[-1], atol=atol)
 
@@ -268,11 +266,8 @@ def test_trotter_hamiltonian_t(nqubits, h=1.0, dt=1e-3):
         np.testing.assert_allclose(local_matrix, target_matrix)
 
 
-@pytest.mark.parametrize("nqubits,accelerators,dt",
-                         [(3, None, 1e-3),
-                          (4, None, 1e-3),
-                          (4, {"/GPU:0": 2}, 1e-2)])
-def test_trotterized_adiabatic_evolution(nqubits, accelerators, dt):
+@pytest.mark.parametrize("nqubits,dt", [(3, 1e-3), (4, 1e-2)])
+def test_trotterized_adiabatic_evolution(accelerators, nqubits, dt):
     """Test adiabatic evolution using trotterization of ``TrotterHamiltonian``."""
     dense_h0 = hamiltonians.X(nqubits)
     dense_h1 = hamiltonians.TFIM(nqubits)

--- a/src/qibo/tests/test_fusion.py
+++ b/src/qibo/tests/test_fusion.py
@@ -11,6 +11,7 @@ from qibo.core import fusion
 def test_one_qubit_gate_multiplication(backend):
     """Check gate multiplication for one-qubit gates."""
     import qibo
+    original_backend = qibo.get_backend()
     qibo.set_backend(backend)
     gate1 = gates.X(0)
     gate2 = gates.H(0)
@@ -30,6 +31,7 @@ def test_one_qubit_gate_multiplication(backend):
     gate2 = gates.X(1)
     assert (gate1 @ gate2).__class__.__name__ == "I"
     assert (gate2 @ gate1).__class__.__name__ == "I"
+    qibo.set_backend(original_backend)
 
 
 def test_two_qubit_gate_multiplication(backend):
@@ -154,6 +156,8 @@ def test_fused_gate_calculation():
 def test_circuit_fuse_variational_layer(backend, nqubits, nlayers, accelerators):
     """Check fused variational layer execution."""
     import qibo
+    if accelerators:
+        backend = "custom"
     original_backend = qibo.get_backend()
     qibo.set_backend(backend)
     theta = 2 * np.pi * np.random.random((2 * nlayers * nqubits,))

--- a/src/qibo/tests/test_fusion.py
+++ b/src/qibo/tests/test_fusion.py
@@ -8,7 +8,6 @@ from qibo import gates
 from qibo.core import fusion
 
 
-@pytest.mark.parametrize("backend", ["custom", "matmuleinsum"])
 def test_one_qubit_gate_multiplication(backend):
     """Check gate multiplication for one-qubit gates."""
     import qibo
@@ -33,7 +32,6 @@ def test_one_qubit_gate_multiplication(backend):
     assert (gate2 @ gate1).__class__.__name__ == "I"
 
 
-@pytest.mark.parametrize("backend", ["custom", "matmuleinsum"])
 def test_two_qubit_gate_multiplication(backend):
     """Check gate multiplication for two-qubit gates."""
     import qibo
@@ -150,9 +148,6 @@ def test_fused_gate_calculation():
 
 @pytest.mark.parametrize("nqubits", [4, 5, 10, 11])
 @pytest.mark.parametrize("nlayers", [1, 4])
-@pytest.mark.parametrize(("backend", "accelerators"),
-                         [("custom", None), ("matmuleinsum", None),
-                          ("custom", {"/GPU:0": 1, "/GPU:1": 1})])
 def test_circuit_fuse_variational_layer(backend, nqubits, nlayers, accelerators):
     """Check fused variational layer execution."""
     import qibo
@@ -177,7 +172,6 @@ def test_circuit_fuse_variational_layer(backend, nqubits, nlayers, accelerators)
     qibo.set_backend("custom")
 
 
-@pytest.mark.parametrize("accelerators", [None, {"/GPU:0": 2}])
 def test_fuse_with_callback(accelerators):
     """Check entropy calculation in fused circuit."""
     from qibo import callbacks
@@ -199,7 +193,6 @@ def test_fuse_with_callback(accelerators):
 
 @pytest.mark.parametrize("nqubits", [3, 4])
 @pytest.mark.parametrize("ngates", [10, 20, 40])
-@pytest.mark.parametrize("accelerators", [None, {"/GPU:0": 1, "/GPU:1": 1}])
 def test_fuse_random_circuits(nqubits, ngates, accelerators):
     """Check gate fusion in randomly generated circuits."""
     one_qubit_gates = [gates.RX, gates.RY, gates.RZ]

--- a/src/qibo/tests/test_hamiltonians.py
+++ b/src/qibo/tests/test_hamiltonians.py
@@ -347,7 +347,6 @@ def test_trotter_hamiltonian_matmul(nqubits, normalize):
     np.testing.assert_allclose(trotter_ev, target_ev)
 
 
-@pytest.mark.parametrize("backend", ["custom", "defaulteinsum", "matmuleinsum"])
 def test_trotter_hamiltonian_three_qubit_term(backend):
     """Test creating ``TrotterHamiltonian`` with three qubit term."""
     import qibo

--- a/src/qibo/tests/test_measurements.py
+++ b/src/qibo/tests/test_measurements.py
@@ -4,8 +4,6 @@ import pytest
 from qibo import gates, models
 from typing import Optional
 
-_ACCELERATORS = [None, {"/GPU:0": 2}, {"/GPU:0": 1, "/GPU:1": 1}]
-
 
 def assert_results(result,
                    decimal_samples: Optional[np.ndarray] = None,
@@ -156,7 +154,6 @@ def test_controlled_measurement_error():
         gates.M(0).controlled_by(1)
 
 
-@pytest.mark.parametrize("accelerators", _ACCELERATORS)
 def test_measurement_circuit(accelerators):
     """Check that measurement gate works as part of circuit."""
     c = models.Circuit(2, accelerators)
@@ -170,7 +167,6 @@ def test_measurement_circuit(accelerators):
                    binary_frequencies={"1": 100})
 
 
-@pytest.mark.parametrize("accelerators", _ACCELERATORS)
 def test_gate_after_measurement_error(accelerators):
     """Check that reusing measured qubits is not allowed."""
     c = models.Circuit(2, accelerators)
@@ -191,7 +187,6 @@ def test_register_name_error():
         c.add(gates.M(1, register_name="a"))
 
 
-@pytest.mark.parametrize("accelerators", _ACCELERATORS)
 def test_multiple_qubit_measurement_circuit(accelerators):
     """Check multiple measurement gates in circuit."""
     c = models.Circuit(2, accelerators)
@@ -232,7 +227,6 @@ def test_measurement_qubit_order_simple():
     assert_results(result2, **target)
 
 
-@pytest.mark.parametrize("accelerators", _ACCELERATORS)
 def test_measurement_qubit_order(accelerators):
     """Check that measurement results follow order defined by user."""
     c = models.Circuit(6, accelerators)
@@ -251,7 +245,6 @@ def test_measurement_qubit_order(accelerators):
                    binary_frequencies={"1001": 100})
 
 
-@pytest.mark.parametrize("accelerators", _ACCELERATORS)
 def test_measurement_qubit_order_multiple_registers(accelerators):
     """Check that measurement results follow order defined by user."""
     c = models.Circuit(6, accelerators)
@@ -306,7 +299,6 @@ def test_multiple_measurement_gates_circuit():
                    binary_frequencies={"011": 100})
 
 
-@pytest.mark.parametrize("accelerators", _ACCELERATORS)
 def test_final_state(accelerators):
     """Check that final state is logged correctly when using measurements."""
     c = models.Circuit(4, accelerators)
@@ -327,7 +319,6 @@ def test_final_state(accelerators):
     np.testing.assert_allclose(logged_final_state, target_state)
 
 
-@pytest.mark.parametrize("accelerators", _ACCELERATORS)
 def test_circuit_with_unmeasured_qubits(accelerators):
     """Check that unmeasured qubits are not taken into account."""
     c = models.Circuit(5, accelerators)
@@ -402,7 +393,6 @@ def test_register_measurements():
     assert_register_results(result, **target)
 
 
-@pytest.mark.parametrize("accelerators", _ACCELERATORS)
 def test_registers_in_circuit_with_unmeasured_qubits(accelerators):
     """Check that register measurements are unaffected by unmeasured qubits."""
     c = models.Circuit(5, accelerators)
@@ -425,7 +415,6 @@ def test_registers_in_circuit_with_unmeasured_qubits(accelerators):
     assert_register_results(result, **target)
 
 
-@pytest.mark.parametrize("accelerators", _ACCELERATORS)
 def test_probabilistic_measurement(accelerators):
     import tensorflow as tf
     tf.random.set_seed(1234)
@@ -488,7 +477,6 @@ def test_circuit_addition_with_measurements():
     assert c.measurement_tuples == {"register0": (0, 1)}
 
 
-@pytest.mark.parametrize("accelerators", _ACCELERATORS)
 def test_circuit_addition_with_measurements_in_both_circuits(accelerators):
     """Check if measurements of two circuits are added during circuit addition."""
     c1 = models.Circuit(2, accelerators)
@@ -505,7 +493,6 @@ def test_circuit_addition_with_measurements_in_both_circuits(accelerators):
     assert c.measurement_tuples == {"a": (1,), "b": (0,)}
 
 
-@pytest.mark.parametrize("accelerators", _ACCELERATORS)
 def test_gate_after_measurement_with_addition_error(accelerators):
     """Check that measured qubits cannot be reused by adding gates."""
     c = models.Circuit(2, accelerators)
@@ -538,7 +525,6 @@ def test_registers_with_same_name_error():
         c = c1 + c2
 
 
-@pytest.mark.parametrize("accelerators", _ACCELERATORS)
 def test_copy_measurements(accelerators):
     """Check that ``circuit.copy()`` properly copies measurements."""
     c1 = models.Circuit(6, accelerators)
@@ -632,7 +618,6 @@ def test_post_measurement_asymmetric_bitflips():
     np.testing.assert_allclose(noisy_result.samples(), target_samples)
 
 
-@pytest.mark.parametrize("accelerators", _ACCELERATORS)
 @pytest.mark.parametrize("probs,target",
                          [([0.0, 0.0, 0.0], {5:30}),
                           ([0.1, 0.3, 0.2], {5:16, 7:10, 6:2, 3: 1, 4: 1}),

--- a/src/qibo/tests/test_variational.py
+++ b/src/qibo/tests/test_variational.py
@@ -154,8 +154,7 @@ def test_initial_state(accelerators):
                           ("rk45", False),
                           ("exp", True),
                           ("rk4", True),
-                          ("rk45", True),
-                          ("exp", True)])
+                          ("rk45", True)])
 def test_qaoa_execution(solver, trotter, accel=None):
     h = hamiltonians.TFIM(4, h=1.0, trotter=trotter)
     m = hamiltonians.X(4, trotter=trotter)
@@ -186,8 +185,8 @@ def test_qaoa_execution(solver, trotter, accel=None):
     np.testing.assert_allclose(final_state, target_state, atol=atol)
 
 
-def test_qaoa_distributed_execution():
-    test_qaoa_execution("exp", True, {"/GPU:0": 1, "/GPU:1": 1})
+def test_qaoa_distributed_execution(accelerators):
+    test_qaoa_execution("exp", True, accelerators)
 
 
 def test_qaoa_callbacks(accelerators):

--- a/src/qibo/tests/test_variational.py
+++ b/src/qibo/tests/test_variational.py
@@ -180,7 +180,7 @@ def test_qaoa_execution(solver, trotter, accel=None):
             u = expm(-1j * p * h_matrix)
         target_state = u @ target_state
 
-    qaoa = models.QAOA(h, mixer=m, solver=solver, accelerators=accelerators)
+    qaoa = models.QAOA(h, mixer=m, solver=solver, accelerators=accel)
     qaoa.set_parameters(params)
     final_state = qaoa(np.copy(state))
     np.testing.assert_allclose(final_state, target_state, atol=atol)
@@ -188,6 +188,7 @@ def test_qaoa_execution(solver, trotter, accel=None):
 
 def test_qaoa_distributed_execution():
     test_qaoa_execution("exp", True, {"/GPU:0": 1, "/GPU:1": 1})
+
 
 def test_qaoa_callbacks(accelerators):
     from qibo import callbacks


### PR DESCRIPTION
Fixes the issue with the old `tests` mentioned in #316. This is mostly a temporary fix until we migrate all tests to `tests_new`.

Regarding the new tests, there may be a possibility to move the
```Python
original_backend = qibo.get_backend()
qibo.set_backend(backend)
...
qibo.set_backend(original_backend)
```
mechanism to `conftest.py` and avoid all the code repetition, however I am not yet sure if this could work.