### PR TITLE
Speeding up Metropolis for frequency

### DIFF
--- a/src/qibo/config.py
+++ b/src/qibo/config.py
@@ -25,6 +25,9 @@ EIGVAL_CUTOFF = 1e-14
 # Batch size for sampling shots in measurement frequencies calculation
 SHOT_BATCH_SIZE = 2 ** 18
 
+# Threshold size for sampling shots in measurements frequencies with custom operator
+SHOT_CUSTOM_OP_THREASHOLD = 100000
+
 # Flag for raising warning in ``set_precision`` and ``set_backend``
 ALLOW_SWITCHERS = True
 

--- a/src/qibo/tests_new/test_measurement_gate_probabilistic.py
+++ b/src/qibo/tests_new/test_measurement_gate_probabilistic.py
@@ -28,16 +28,11 @@ def test_probabilistic_measurement(backend, accelerators, use_samples):
 
     # update reference values based on backend and device
     if K.name == "tensorflow":
-        if K.gpu_devices and not accelerators: # pragma: no cover
+        if K.gpu_devices: # pragma: no cover
             # CI does not use GPU
             decimal_frequencies = {0: 273, 1: 233, 2: 242, 3: 252}
-        elif use_samples or sys.platform not in {"linux", "darwin"}:
+        else:
             decimal_frequencies = {0: 271, 1: 239, 2: 242, 3: 248}
-        elif sys.platform == "linux":
-            decimal_frequencies = {0: 261, 1: 258, 2: 242, 3: 239}
-        elif sys.platform == "darwin": # pragma: no cover
-            # coverage does not use macos
-            decimal_frequencies = {0: 244, 1: 248, 2: 252, 3: 256}
     elif K.name == "numpy":
         decimal_frequencies = {0: 249, 1: 231, 2: 253, 3: 267}
     assert sum(result.frequencies().values()) == 1000
@@ -69,13 +64,8 @@ def test_unbalanced_probabilistic_measurement(backend, use_samples):
         if K.gpu_devices: # pragma: no cover
             # CI does not use GPU
             decimal_frequencies = {0: 196, 1: 153, 2: 156, 3: 495}
-        elif use_samples or sys.platform not in {"linux", "darwin"}:
+        else:
             decimal_frequencies = {0: 168, 1: 188, 2: 154, 3: 490}
-        elif sys.platform == "linux":
-            decimal_frequencies = {0: 165, 1: 167, 2: 162, 3: 506}
-        elif sys.platform == "darwin": # pragma: no cover
-            # coverage does not use macos
-            decimal_frequencies = {0: 164, 1: 157, 2: 171, 3: 508}
     elif K.name == "numpy":
         decimal_frequencies = {0: 171, 1: 148, 2: 161, 3: 520}
     assert sum(result.frequencies().values()) == 1000


### PR DESCRIPTION
As discussed, this PR removes the GPU ops and alleviates the computation by consuming more memory, but it is usually 2x faster than #332.

@stavros11 could you please have a look and then perform the benchmarks?
- [x] KL computation
- [x] performance in comparison, including small-large qubits/nshots regimes to random categorical

The last point is quite important in order to decide if we should keep the random categorical.