### PR TITLE
Move state reshape in gates

### DIFF
--- a/src/qibo/core/circuit.py
+++ b/src/qibo/core/circuit.py
@@ -30,8 +30,6 @@ class Circuit(circuit.AbstractCircuit):
         self.param_tensor_types = K.tensor_types
         self._compiled_execute = None
         self.state_cls = states.VectorState
-        self.tensor_shape = K.cast(nqubits * (2,), dtype='DTYPEINT')
-        self.flat_shape = K.cast((2 ** nqubits,), dtype='DTYPEINT')
 
     def set_nqubits(self, gate):
         if gate.is_prepared and gate.nqubits != self.nqubits:
@@ -141,8 +139,6 @@ class Circuit(circuit.AbstractCircuit):
         """Performs all circuit gates on the state vector."""
         self._final_state = None
         state = self.get_initial_state(initial_state)
-        if not K.custom_gates:
-            state = K.reshape(state, self.tensor_shape)
 
         if self._compiled_execute is None:
             state = self._eager_execute(state)
@@ -150,9 +146,6 @@ class Circuit(circuit.AbstractCircuit):
             state, callback_results = self._compiled_execute(state)
             for callback, results in callback_results.items():
                 callback.extend(results)
-
-        if not K.custom_gates:
-            state = K.reshape(state, self.flat_shape)
 
         self._final_state = self.state_cls.from_tensor(state, self.nqubits)
         return self._final_state
@@ -276,8 +269,6 @@ class DensityMatrixCircuit(Circuit):
         super(DensityMatrixCircuit, self).__init__(nqubits)
         self.density_matrix = True
         self.state_cls = states.MatrixState
-        self.tensor_shape = K.cast(2 * nqubits * (2,), dtype='DTYPEINT')
-        self.flat_shape = K.cast(2 * (2 ** nqubits,), dtype='DTYPEINT')
 
     def get_initial_state(self, state=None):
         # Allow using state vectors as initial states but transform them

--- a/src/qibo/core/gates.py
+++ b/src/qibo/core/gates.py
@@ -645,6 +645,8 @@ class _ThermalRelaxationChannelB(BackendGate, gates._ThermalRelaxationChannelB):
 
     def prepare(self):
         self.is_prepared = True
+        self.tensor_shape = K.cast(2 * self.nqubits * (2,), dtype='DTYPEINT')
+        self.flat_shape = K.cast(2 * (2 ** self.nqubits,), dtype='DTYPEINT')
         self.reprepare()
         qubits = self.qubits + tuple(q + self.nqubits for q in self.qubits)
         self.calculation_cache = self.einsum.create_cache(
@@ -661,4 +663,6 @@ class _ThermalRelaxationChannelB(BackendGate, gates._ThermalRelaxationChannelB):
 
     def density_matrix_call(self, state):
         einsum_str = self.calculation_cache.vector
-        return self.einsum(einsum_str, state, self.matrix)
+        state = K.reshape(state, self.tensor_shape)
+        state = self.einsum(einsum_str, state, self.matrix)
+        return K.reshape(state, self.flat_shape)

--- a/src/qibo/core/gates.py
+++ b/src/qibo/core/gates.py
@@ -116,9 +116,7 @@ class BackendGate(BaseBackendGate):
     def __call__(self, state):
         if not self.is_prepared:
             self.set_nqubits(state)
-        original_shape = state.shape
-        state = getattr(self, self._active_call)(state)
-        return K.reshape(state, original_shape)
+        return getattr(self, self._active_call)(state)
 
 
 class H(BackendGate, gates.H):

--- a/src/qibo/tests/test_density_matrix.py
+++ b/src/qibo/tests/test_density_matrix.py
@@ -20,7 +20,7 @@ def test_circuit_dm(backend):
     c.add(gates.H(1))
     c.add(gates.CNOT(0, 1))
     c.add(gates.H(2))
-    final_rho = c(np.copy(initial_rho)).numpy().reshape(initial_rho.shape)
+    final_rho = c(np.copy(initial_rho))
 
     h = np.array([[1, 1], [1, -1]]) / np.sqrt(2)
     cnot = np.array([[1, 0, 0, 0], [0, 1, 0, 0],
@@ -131,13 +131,9 @@ def test_general_channel(backend, tfmatrices, oncircuit):
     if oncircuit:
         c = models.Circuit(2, density_matrix=True)
         c.add(gate)
-        final_rho = c(np.copy(initial_rho)).numpy()
+        final_rho = c(np.copy(initial_rho))
     else:
-        if backend == "custom":
-            final_rho = gate(np.copy(initial_rho))
-        else:
-            final_rho = gate(np.copy(initial_rho).reshape(4 * (2,)))
-            final_rho = final_rho.numpy().reshape((4, 4))
+        final_rho = gate(np.copy(initial_rho))
 
     m1 = np.kron(np.eye(2), np.array(a1))
     m2 = np.array(a2)
@@ -498,12 +494,7 @@ def test_variational_layer(backend, nqubits):
     gate = gates.VariationalLayer(range(nqubits), pairs,
                                   gates.RY, gates.CZ, theta)
     gate.density_matrix = True
-    initial_state = c.get_initial_state()
-    if backend != "custom":
-        initial_state = np.reshape(initial_state, 2 * nqubits * (2,))
-    final_state = gate(initial_state)
-    if backend != "custom":
-        final_state = np.reshape(final_state, 2 * (2 ** nqubits,))
+    final_state = gate(c.get_initial_state())
     np.testing.assert_allclose(target_state, final_state)
     qibo.set_backend(original_backend)
 

--- a/src/qibo/tests/test_qft.py
+++ b/src/qibo/tests/test_qft.py
@@ -3,6 +3,7 @@ Testing Quantum Fourier Transform (QFT) circuit.
 """
 import numpy as np
 import pytest
+import qibo
 from qibo import gates, models
 from qibo.tests import utils
 
@@ -31,11 +32,14 @@ def exact_qft(x: np.ndarray, inverse: bool = False) -> np.ndarray:
 
 
 @pytest.mark.parametrize("nqubits", [4, 10, 100])
-def test_qft_circuit_size(nqubits):
+def test_qft_circuit_size(backend, nqubits):
+    original_backend = qibo.get_backend()
+    qibo.set_backend(backend)
     c = models.QFT(nqubits)
     assert c.nqubits == nqubits
     assert c.depth == 2 * nqubits
     assert c.ngates == nqubits ** 2 // 2 + nqubits
+    qibo.set_backend(original_backend)
 
 
 @pytest.mark.parametrize("nqubits", [4, 5])

--- a/src/qibo/tests/test_qft.py
+++ b/src/qibo/tests/test_qft.py
@@ -30,11 +30,12 @@ def exact_qft(x: np.ndarray, inverse: bool = False) -> np.ndarray:
     return qft_matrix(dim, inverse).dot(x) / np.sqrt(dim)
 
 
-def test_qft_sanity():
-    c = models.QFT(4)
-    assert c.nqubits == 4
-    assert c.depth == 8
-    assert c.ngates == 12
+@pytest.mark.parametrize("nqubits", [4, 10, 100])
+def test_qft_circuit_size(nqubits):
+    c = models.QFT(nqubits)
+    assert c.nqubits == nqubits
+    assert c.depth == 2 * nqubits
+    assert c.ngates == nqubits ** 2 // 2 + nqubits
 
 
 @pytest.mark.parametrize("nqubits", [4, 5])

--- a/src/qibo/tests_new/test_core_circuit_features.py
+++ b/src/qibo/tests_new/test_core_circuit_features.py
@@ -27,9 +27,6 @@ def test_circuit_vs_gate_execution(backend):
 
     init2 = c.get_initial_state()
     init3 = c.get_initial_state()
-    if backend != "custom":
-        init2 = K.reshape(init2, (2, 2))
-        init3 = K.reshape(init3, (2, 2))
 
     r2 = K.reshape(custom_circuit(init2, theta), (4,))
     np.testing.assert_allclose(r1, r2)

--- a/src/qibo/tests_new/test_core_gates.py
+++ b/src/qibo/tests_new/test_core_gates.py
@@ -28,12 +28,8 @@ def apply_gates(gatelist, nqubits=None, initial_state=None):
                                "".format(type(initial_state)))
 
     state = K.cast(state)
-    if qibo.get_backend() != "custom":
-        state = K.qnp.reshape(state, nqubits * (2,))
     for gate in gatelist:
         state = gate(state)
-    if qibo.get_backend() != "custom":
-        state = np.array(state).ravel()
     return state
 
 

--- a/src/qibo/tests_new/test_core_gates.py
+++ b/src/qibo/tests_new/test_core_gates.py
@@ -522,4 +522,5 @@ def test_callback_gate_errors():
     with pytest.raises(ValueError):
         gate.construct_unitary()
 
+
 # TODO: Test channels

--- a/src/qibo/tests_new/test_core_gates_density_matrix.py
+++ b/src/qibo/tests_new/test_core_gates_density_matrix.py
@@ -37,15 +37,10 @@ def test_hgate_density_matrix(backend):
     initial_rho = random_density_matrix(2)
     gate = gates.H(1)
     gate.density_matrix = True
-    if backend == "custom":
-        final_rho = np.copy(initial_rho)
-    else:
-        final_rho = np.copy(initial_rho).reshape(4 * (2,))
-    final_rho = np.reshape(gate(final_rho), (4, 4))
+    final_rho = gate(np.copy(initial_rho))
 
     matrix = np.array([[1, 1], [1, -1]]) / np.sqrt(2)
     matrix = np.kron(np.eye(2), matrix)
-    initial_rho = initial_rho.reshape((4, 4))
     target_rho = matrix.dot(initial_rho).dot(matrix)
     np.testing.assert_allclose(final_rho, target_rho)
     qibo.set_backend(original_backend)
@@ -156,13 +151,9 @@ def test_cu1gate_application_twoqubit(backend):
     theta = 0.1234
     nqubits = 3
     initial_rho = random_density_matrix(nqubits)
-    if backend == "custom":
-        final_rho = np.copy(initial_rho)
-    else:
-        final_rho = np.copy(initial_rho).reshape(2 * nqubits * (2,))
     gate = gates.CU1(0, 1, theta=theta)
     gate.density_matrix = True
-    final_rho = np.reshape(gate(final_rho), initial_rho.shape)
+    final_rho = gate(np.copy(initial_rho))
 
     matrix = np.eye(4, dtype=np.complex128)
     matrix[3, 3] = np.exp(1j * theta)


### PR DESCRIPTION
Moves the state reshape required for non-custom backends inside the gates instead of the circuit. This fixes some compatibility issues between gates of different backends and makes testing easier. 

It also fixes #337 since the `tensor_shape` and `flat_shape` attributes are no longer required during circuit creation. For this point I also added a test that initializes a QFT for n=100 qubits and checks that the depth is 2n and the number of gates n^2/2 + n.