### PR TITLE
Fix controlled by Y gates for custom backend

### DIFF
--- a/src/qibo/core/cgates.py
+++ b/src/qibo/core/cgates.py
@@ -137,7 +137,13 @@ class Y(BackendGate, gates.Y):
         return matrices.Y
 
     def density_matrix_call(self, state):
-        return -BackendGate.density_matrix_call(self, state)
+        state = self.gate_op(state, self.qubits_tensor_dm, 2 * self.nqubits,
+                             *self.target_qubits, get_threads())
+        matrix = K.conj(matrices.Y)
+        state = K.op.apply_gate(state, matrix, self.qubits_tensor,
+                                2 * self.nqubits, *self.target_qubits_dm,
+                                get_threads())
+        return state
 
 
 class Z(BackendGate, gates.Z):


### PR DESCRIPTION
This PR fixes a bug related to using controlled by Y gates with density matrices with the custom backend. To reproduce:
```Python
from qibo import models, gates

c = models.Circuit(2, density_matrix=True)
c.add(gates.Y(1).controlled_by(0))
state = c().state()
print(np.trace(state))
```
prints -1 while the trace of the density matrix should always be 1. This appears only in the custom backend, all other backends work fine.

