### PR TITLE
Fix Metropolis for sparse distributions

### DIFF
--- a/src/qibo/tensorflow/custom_operators/cc/kernels/measurements.cc
+++ b/src/qibo/tensorflow/custom_operators/cc/kernels/measurements.cc
@@ -38,11 +38,7 @@ struct MeasureFrequenciesFunctor<CPUDevice, Tint, Tfloat> {
         int64 shot = initial_shot;
         #pragma omp for
         for (int64 i = 0; i < nshots; i++) {
-          // Generate random index to flip its bit
-          int flip_index = ((int) rand_r(&seed) % nqubits);
-          // Flip the corresponding bit
-          int current_value = ((int64) shot >> flip_index) % 2;
-          int64 new_shot = shot + ((int64)(1 - 2 * current_value)) * ((int64) 1 << flip_index);
+          int64 new_shot = (shot + ((int64) rand_r(&seed) % nstates)) % nstates;
           // Accept or reject move
           Tfloat ratio = probs[new_shot] / probs[shot];
           if (ratio > ((Tfloat) rand_r(&seed) / RAND_MAX)) {

--- a/src/qibo/tests_new/test_tensorflow_custom_operators.py
+++ b/src/qibo/tests_new/test_tensorflow_custom_operators.py
@@ -517,8 +517,8 @@ def test_measure_frequencies(dtype, inttype):
         target_frequencies = [60, 50, 68, 64, 53, 53, 67, 54, 64, 53, 67,
                               69, 76, 57, 64, 81]
     elif sys.platform == "darwin": # pragma: no cover
-        target_frequencies = [65, 45, 74, 70, 68, 50, 67, 61, 65, 64, 71,
-                              71, 55, 52, 64, 58]
+        target_frequencies = [57, 51, 62, 63, 55, 70, 52, 47, 75, 58, 63, 
+                              73, 68, 72, 60, 74]
     assert np.sum(frequencies) == 1000
     np.testing.assert_allclose(frequencies, target_frequencies)
 

--- a/src/qibo/tests_new/test_tensorflow_custom_operators.py
+++ b/src/qibo/tests_new/test_tensorflow_custom_operators.py
@@ -513,10 +513,33 @@ def test_measure_frequencies(dtype, inttype):
                                            nqubits=4, omp_num_threads=1,
                                            seed=1234)
     if sys.platform == "linux":
-        target_frequencies = [72, 56, 61, 60, 61, 47, 52, 55, 67, 64, 69,
-                              68, 63, 59, 73, 73]
+        target_frequencies = [60, 50, 68, 64, 53, 53, 67, 54, 64, 53, 67,
+                              69, 76, 57, 64, 81]
     elif sys.platform == "darwin": # pragma: no cover
         target_frequencies = [65, 45, 74, 70, 68, 50, 67, 61, 65, 64, 71,
                               71, 55, 52, 64, 58]
     assert np.sum(frequencies) == 1000
     np.testing.assert_allclose(frequencies, target_frequencies)
+
+
+
+@pytest.mark.parametrize("nonzero",
+                         [[0, 1], [0, 3], [0, 4], [0, 5], [0, 6], [0, 7],
+                          [1, 2], [1, 3], [1, 4], [3, 4], [2, 5], [1, 7],
+                          [1, 2, 7], [2, 5, 7], [0, 1, 7], [2, 6, 7]])
+def test_measure_frequencies_sparse_probabilities(nonzero):
+    import sys
+    probs = np.zeros(8, dtype=np.float64)
+    for i in nonzero:
+        probs[i] = 1
+    probs = probs / np.sum(probs)
+    frequencies = np.zeros(8, dtype=np.int64)
+    frequencies = K.op.measure_frequencies(frequencies, probs, nshots=1000,
+                                           nqubits=3, omp_num_threads=1,
+                                           seed=1234)
+    assert np.sum(frequencies) == 1000
+    for i, freq in enumerate(frequencies):
+        if i in nonzero:
+            assert freq != 0
+        else:
+            assert freq == 0

--- a/src/qibo/tests_new/test_tensorflow_custom_operators.py
+++ b/src/qibo/tests_new/test_tensorflow_custom_operators.py
@@ -1,6 +1,7 @@
 """
 Testing Tensorflow custom operators circuit.
 """
+import itertools
 import pytest
 import numpy as np
 from qibo import K, get_threads
@@ -522,11 +523,11 @@ def test_measure_frequencies(dtype, inttype):
     np.testing.assert_allclose(frequencies, target_frequencies)
 
 
-
-@pytest.mark.parametrize("nonzero",
-                         [[0, 1], [0, 3], [0, 4], [0, 5], [0, 6], [0, 7],
-                          [1, 2], [1, 3], [1, 4], [3, 4], [2, 5], [1, 7],
-                          [1, 2, 7], [2, 5, 7], [0, 1, 7], [2, 6, 7]])
+NONZERO = list(itertools.combinations(range(8), r=1))
+NONZERO.extend(itertools.combinations(range(8), r=2))
+NONZERO.extend(itertools.combinations(range(8), r=3))
+NONZERO.extend(itertools.combinations(range(8), r=4))
+@pytest.mark.parametrize("nonzero", NONZERO)
 def test_measure_frequencies_sparse_probabilities(nonzero):
     import sys
     probs = np.zeros(8, dtype=np.float64)


### PR DESCRIPTION
Fixes #346 using the idea mentioned there. Execution time and KL divergence for random distributions are the same as our existing code:

nshots | master time (sec) | fix time (sec) | KL master | KL fix
-- | -- | -- | -- | --
100000000 | 0.148165 | 0.238486 | 1.99e-05 | 1.25e-05
200000000 | 0.309631 | 0.478443 | 1.15e-05 | 9.90e-06
400000000 | 0.458794 | 0.828578 | 1.23e-05 | 8.05e-06
600000000 | 0.676857 | 1.156601 | 9.35e-06 | 8.28e-06
800000000 | 1.037136 | 1.502599 | 1.14e-05 | 6.70e-06
1000000000 | 0.986530 | 1.843876 | 1.03e-05 | 8.21e-06
2000000000 | 1.920199 | 3.533490 | 9.72e-06 | 7.11e-06
4000000000 | 3.620555 | 7.008676 | 9.70e-06 | 6.89e-06
6000000000 | 5.468573 | 10.519186 | 9.39e-06 | 7.12e-06
100 | 0.001501 | 0.001475 | 1.80e+01 | 1.82e+01
10000 | 0.002878 | 0.002937 | 1.51e-01 | 1.57e-01
10000000 | 0.022121 | 0.027112 | 1.16e-04 | 9.69e-05


nqubits | master time (sec) | fix time (sec) | KL master | KL fix
-- | -- | -- | -- | --
6 | 0.020047 | 0.036727 | 1.57e-05 | 8.39e-06
8 | 0.023921 | 0.029751 | 3.62e-05 | 2.38e-05
10 | 0.022121 | 0.027112 | 1.16e-04 | 9.69e-05
12 | 0.026822 | 0.034296 | 5.29e-04 | 3.59e-04
14 | 0.024820 | 0.040488 | 1.75e-03 | 1.56e-03
16 | 0.032375 | 0.042690 | 7.62e-03 | 6.16e-03
18 | 0.037547 | 0.060351 | 3.12e-02 | 2.92e-02
20 | 0.083534 | 0.113640 | 1.96e-01 | 1.72e-01
22 | 0.271751 | 0.321594 | 2.22e+00 | 1.98e+00
24 | 0.891320 | 0.934847 | 6.75e+00 | 6.53e+00
26 | 3.006421 | 3.102790 | 8.49e+00 | 8.42e+00
