### PR TITLE
Use random seed for frequency custom operator

### DIFF
--- a/src/qibo/backends/tensorflow.py
+++ b/src/qibo/backends/tensorflow.py
@@ -192,13 +192,11 @@ class TensorflowBackend(numpy.NumpyBackend):
             frequencies = self.zeros(int(probs.shape[0]), dtype=self.dtypes('DTYPEINT'))
             frequencies = self.backend.tensor_scatter_nd_add(frequencies, res[:, self.newaxis], counts)
         else:
-            if self._seed is None:
-                # generate random seed
-                seed = self.np.random.randint(1e8)
-                self.backend.random.set_seed(seed)
-            else:
-                seed = self._seed
             from qibo.config import get_threads
+            # Generate random seed using tf
+            dtype = self.dtypes('DTYPEINT')
+            seed = self.backend.random.uniform(
+                shape=tuple(), maxval=int(1e8), dtype=dtype)
             nqubits = int(self.np.log2(tuple(probs.shape)[0]))
             shape = self.cast(2 ** nqubits, dtype='DTYPEINT')
             frequencies = self.zeros(shape, dtype='DTYPEINT')
@@ -215,7 +213,6 @@ class TensorflowBackend(numpy.NumpyBackend):
     def executing_eagerly(self):
         return self.backend.executing_eagerly()
 
-    def set_seed(self, seed=None):
+    def set_seed(self, seed):
         self._seed = seed
-        if seed is not None:
-            self.backend.random.set_seed(seed)
+        self.backend.random.set_seed(seed)

--- a/src/qibo/tests_new/test_tensorflow_custom_operators.py
+++ b/src/qibo/tests_new/test_tensorflow_custom_operators.py
@@ -550,7 +550,6 @@ def test_backend_sample_frequencies_seed():
     """Check that frequencies generated using custom operator are different in each call."""
     from qibo import K
     from qibo.config import SHOT_CUSTOM_OP_THREASHOLD
-    K.set_seed()
     nshots = SHOT_CUSTOM_OP_THREASHOLD + 1
     probs = np.random.random(8)
     probs = probs / np.sum(probs)

--- a/src/qibo/tests_new/test_tensorflow_custom_operators.py
+++ b/src/qibo/tests_new/test_tensorflow_custom_operators.py
@@ -517,7 +517,7 @@ def test_measure_frequencies(dtype, inttype):
         target_frequencies = [60, 50, 68, 64, 53, 53, 67, 54, 64, 53, 67,
                               69, 76, 57, 64, 81]
     elif sys.platform == "darwin": # pragma: no cover
-        target_frequencies = [57, 51, 62, 63, 55, 70, 52, 47, 75, 58, 63, 
+        target_frequencies = [57, 51, 62, 63, 55, 70, 52, 47, 75, 58, 63,
                               73, 68, 72, 60, 74]
     assert np.sum(frequencies) == 1000
     np.testing.assert_allclose(frequencies, target_frequencies)
@@ -544,3 +544,17 @@ def test_measure_frequencies_sparse_probabilities(nonzero):
             assert freq != 0
         else:
             assert freq == 0
+
+
+def test_backend_sample_frequencies_seed():
+    """Check that frequencies generated using custom operator are different in each call."""
+    from qibo import K
+    from qibo.config import SHOT_CUSTOM_OP_THREASHOLD
+    K.set_seed()
+    nshots = SHOT_CUSTOM_OP_THREASHOLD + 1
+    probs = np.random.random(8)
+    probs = probs / np.sum(probs)
+    frequencies1 = K.sample_frequencies(probs, nshots)
+    frequencies2 = K.sample_frequencies(probs, nshots)
+    np.testing.assert_raises(AssertionError, np.testing.assert_allclose,
+                             frequencies1, frequencies2)


### PR DESCRIPTION
As @igres26 pointed out, currently the seed used in the frequency custom operator is generated using the system's time during the backend initialization. Because the backend is normally initialized once when a script is executed, all calls of the `K.sample_frequencies` method return the same frequencies if executed in the same runtime. For example in:
```Python
probs = np.random.random(8)
probs = probs / np.sum(probs)
frequencies1 = K.sample_frequencies(probs, nshots=int(1e6))
frequencies2 = K.sample_frequencies(probs, nshots=int(1e6))
```
`frequencies1` will be exactly the same as `frequencies2`, while usually the user would expect them to be different. This is very relevant in notebooks where the same cell may be executed several times in the same runtime with the user expecting different results.

This PR fixes this issue by generating a new random seed each time `K.sample_frequencies` is called.