### PR TITLE
Multiple collapse measurements with single circuit call

### DIFF
--- a/examples/shor/functions.py
+++ b/examples/shor/functions.py
@@ -363,47 +363,38 @@ def quantum_order_finding_semiclassical(N, a):
     x = [n+1+i for i in range(n)]
     ancilla = 2*n + 1
     q_reg = 2*n + 2
-    circuit = Circuit(2*n+3)
     print(f'  - Total number of qubits used: {2*n+3}.\n')
-    r = []
+    results = []
     exponents = []
     exp = a%N
     for i in range(2*n):
         exponents.append(exp)
         exp = (exp**2)%N
-    
+
+    circuit = Circuit(2 * n + 3)
     # Building the quantum circuit
     circuit.add(gates.H(q_reg))
-    circuit.add(gates.X(x[len(x)-1]))
+    circuit.add(gates.X(x[len(x) - 1]))
     #a_i = (a**(2**(2*n - 1)))
     circuit.add(c_U(q_reg, x, b, exponents[-1], N, ancilla, n))
     circuit.add(gates.H(q_reg))
-    circuit.add(gates.M(q_reg))
-    result = circuit(nshots=1)
-    r.append(result.frequencies(binary=False).most_common()[0][0])
-    initial_state = circuit.final_state
-    
+    results.append(circuit.add(gates.M(q_reg, collapse=True)))
     # Using multiple measurements for the semiclassical QFT.
     for i in range(1, 2*n):
-        circuit = Circuit(2*n+3)
-        circuit.add(gates.Collapse(q_reg, result=[r[-1]]))
-        if r[-1] == 1:
-            circuit.add(gates.X(q_reg))
+        # reset measured qubit to |0>
+        circuit.add(gates.RX(q_reg, theta=np.pi * results[-1]))
         circuit.add(gates.H(q_reg))
         #a_i = (a**(2**(2*n - 1 - i)))
         circuit.add(c_U(q_reg, x, b, exponents[-1-i], N, ancilla, n))
         angle = 0
         for k in range(2, i+2):
-            angle += 2*np.pi*r[i+1-k]/(2**k)
+            angle += 2 * np.pi * results[i + 1 - k] / (2 ** k)
         circuit.add(gates.U1(q_reg, -angle))
         circuit.add(gates.H(q_reg))
-        circuit.add(gates.M(q_reg))
-        result = circuit(initial_state, nshots=1)
-        r.append(result.frequencies(binary=False).most_common()[0][0])
-        initial_state = circuit.final_state
-    s = 0
-    for i in range(2*n):
-        s += r[i]*2**(i)
+        results.append(circuit.add(gates.M(q_reg, collapse=True)))
+
+    circuit() # execute
+    s = sum(int(r.outcome()) * (2 ** i) for i, r in enumerate(results))
     print(f"The quantum circuit measures s = {s}.\n")
     return s
 

--- a/examples/test_examples.py
+++ b/examples/test_examples.py
@@ -233,7 +233,7 @@ def test_ef_qae(layers, autoencoder, example):
 @pytest.mark.parametrize("N", [15, 21])
 @pytest.mark.parametrize("times", [2, 10])
 @pytest.mark.parametrize("A", [None])
-@pytest.mark.parametrize("semiclassical", [False])
+@pytest.mark.parametrize("semiclassical", [True, False])
 @pytest.mark.parametrize("enhance", [True, False])
 def test_shor(N, times, A, semiclassical, enhance):
     if "functions" in sys.modules:

--- a/src/qibo/abstractions/circuit.py
+++ b/src/qibo/abstractions/circuit.py
@@ -372,13 +372,8 @@ class AbstractCircuit(ABC):
             a ``sympy.Symbol`` that parametrizes the corresponding outcome.
         """
         if isinstance(gate, collections.abc.Iterable):
-            outputs = []
             for g in gate:
-                output = self.add(g)
-                if output is not None:
-                    outputs.append(output)
-            if outputs:
-                return outputs
+                self.add(g)
         elif isinstance(gate, gates.Gate):
             return self._add(gate)
         else:

--- a/src/qibo/abstractions/circuit.py
+++ b/src/qibo/abstractions/circuit.py
@@ -405,7 +405,7 @@ class AbstractCircuit(ABC):
             self.queue.append(gate)
             if isinstance(gate, gates.M):
                 self.repeated_execution = True
-                return gate.symbols()
+                return gate.symbol()
             if isinstance(gate, gates.UnitaryChannel):
                 self.repeated_execution = not self.density_matrix
         if isinstance(gate, gates.ParametrizedGate):

--- a/src/qibo/abstractions/circuit.py
+++ b/src/qibo/abstractions/circuit.py
@@ -366,6 +366,10 @@ class AbstractCircuit(ABC):
                 `gate` can also be an iterable or generator of gates.
                 In this case all gates in the iterable will be added in the
                 circuit.
+
+        Returns:
+            If the circuit contains measurement gates with ``collapse=True``
+            a ``sympy.Symbol`` that parametrizes the corresponding outcome.
         """
         if isinstance(gate, collections.abc.Iterable):
             outputs = []

--- a/src/qibo/abstractions/circuit.py
+++ b/src/qibo/abstractions/circuit.py
@@ -404,6 +404,7 @@ class AbstractCircuit(ABC):
             self.set_nqubits(gate)
             self.queue.append(gate)
             if isinstance(gate, gates.M):
+                self.repeated_execution = True
                 return gate.result
             if isinstance(gate, gates.UnitaryChannel):
                 self.repeated_execution = not self.density_matrix

--- a/src/qibo/abstractions/circuit.py
+++ b/src/qibo/abstractions/circuit.py
@@ -405,7 +405,7 @@ class AbstractCircuit(ABC):
             self.queue.append(gate)
             if isinstance(gate, gates.M):
                 self.repeated_execution = True
-                return gate.result
+                return gate.symbols()
             if isinstance(gate, gates.UnitaryChannel):
                 self.repeated_execution = not self.density_matrix
         if isinstance(gate, gates.ParametrizedGate):

--- a/src/qibo/abstractions/circuit.py
+++ b/src/qibo/abstractions/circuit.py
@@ -370,8 +370,11 @@ class AbstractCircuit(ABC):
         if isinstance(gate, collections.abc.Iterable):
             outputs = []
             for g in gate:
-                outputs.append(self.add(g))
-            return outputs
+                output = self.add(g)
+                if output is not None:
+                    outputs.append(output)
+            if outputs:
+                return outputs
         elif isinstance(gate, gates.Gate):
             return self._add(gate)
         else:
@@ -412,7 +415,6 @@ class AbstractCircuit(ABC):
             self.parametrized_gates.append(gate)
             if gate.trainable:
                 self.trainable_gates.append(gate)
-        return
 
     def set_nqubits(self, gate: gates.Gate):
         """Sets the number of qubits and prepares all gates.

--- a/src/qibo/abstractions/gates.py
+++ b/src/qibo/abstractions/gates.py
@@ -213,7 +213,7 @@ class M(Gate):
         self.register_name = register_name
         self.collapse = collapse
         self.result = None
-        self._symbols = None
+        self._symbol = None
 
         self.init_args = q
         self.init_kwargs = {"register_name": register_name,
@@ -295,9 +295,9 @@ class M(Gate):
         pt = self._get_bitflip_tuple(self.qubits, p)
         return {q: p for q, p in zip(self.qubits, pt)}
 
-    def symbols(self):
-        """Returns symbols containing measurement outcomes for ``collapse=True`` gates."""
-        return self._symbols
+    def symbol(self):
+        """Returns symbol containing measurement outcomes for ``collapse=True`` gates."""
+        return self._symbol
 
     def add(self, gate: "M"):
         """Adds target qubits to a measurement gate.

--- a/src/qibo/abstractions/gates.py
+++ b/src/qibo/abstractions/gates.py
@@ -213,6 +213,7 @@ class M(Gate):
         self.register_name = register_name
         self.collapse = collapse
         self.result = None
+        self._symbols = None
 
         self.init_args = q
         self.init_kwargs = {"register_name": register_name,
@@ -293,6 +294,10 @@ class M(Gate):
             return {q: 0 for q in self.qubits}
         pt = self._get_bitflip_tuple(self.qubits, p)
         return {q: p for q, p in zip(self.qubits, pt)}
+
+    def symbols(self):
+        """Returns symbols containing measurement outcomes for ``collapse=True`` gates."""
+        return self._symbols
 
     def add(self, gate: "M"):
         """Adds target qubits to a measurement gate.

--- a/src/qibo/core/cgates.py
+++ b/src/qibo/core/cgates.py
@@ -218,11 +218,11 @@ class M(BackendGate, gates.M):
         raise_error(ValueError, "Measurement gate does not have unitary "
                                 "representation.")
 
-    def symbols(self):
-        if self._symbols is None:
+    def symbol(self):
+        if self._symbol is None:
             from qibo.core.measurements import MeasurementSymbol
-            self._symbols = MeasurementSymbol(self.result)
-        return self._symbols
+            self._symbol = MeasurementSymbol(self.result)
+        return self._symbol
 
     def state_vector_collapse(self, state, result):
         return self.gate_op(state, self.qubits_tensor, result,

--- a/src/qibo/core/cgates.py
+++ b/src/qibo/core/cgates.py
@@ -199,8 +199,6 @@ class M(BackendGate, gates.M):
             raise_error(RuntimeError, "Cannot add qubits to a measurement "
                                       "gate that is prepared.")
         gates.M.add(self, gate)
-        if self.result:
-            self.result.add_qubits(gate.target_qubits)
 
     def prepare(self):
         BackendGate.prepare(self)

--- a/src/qibo/core/cgates.py
+++ b/src/qibo/core/cgates.py
@@ -231,7 +231,8 @@ class M(BackendGate, gates.M):
 
     def result_list(self):
         if self._result_list is None:
-            resdict = {q: r for q, r in zip(self.target_qubits, self.result.binary[0])}
+            pairs = zip(self.target_qubits, self.result.binary[-1])
+            resdict = {q: r for q, r in pairs}
             self._result_list = [resdict[q] for q in sorted(self.target_qubits)]
         return self._result_list
 

--- a/src/qibo/core/cgates.py
+++ b/src/qibo/core/cgates.py
@@ -191,7 +191,7 @@ class M(BackendGate, gates.M):
         self._result_list = None
         self._result_tensor = None
         if collapse:
-            self.result = self.measurements.MeasurementSymbol(self.qubits)
+            self.result = self.measurements.MeasurementResult(self.qubits)
         self.gate_op = K.op.collapse_state
 
     def add(self, gate: gates.M):
@@ -217,6 +217,12 @@ class M(BackendGate, gates.M):
     def construct_unitary(self):
         raise_error(ValueError, "Measurement gate does not have unitary "
                                 "representation.")
+
+    def symbols(self):
+        if self._symbols is None:
+            from qibo.core.measurements import MeasurementSymbol
+            self._symbols = MeasurementSymbol(self.result)
+        return self._symbols
 
     def state_vector_collapse(self, state, result):
         return self.gate_op(state, self.qubits_tensor, result,

--- a/src/qibo/core/cgates.py
+++ b/src/qibo/core/cgates.py
@@ -289,7 +289,6 @@ class M(BackendGate, gates.M):
             if nshots > 1:
                 raise_error(ValueError, "Cannot perform measurement collapse "
                                         "for more than one shots.")
-            print(self.result.samples())
             return getattr(self, self._active_call)(state)
         return self.result
 

--- a/src/qibo/core/gates.py
+++ b/src/qibo/core/gates.py
@@ -254,9 +254,6 @@ class M(BackendGate, gates.M):
     def result_list(self):
         return cgates.M.result_list(self)
 
-    def set_result(self, probs, nshots):
-        return cgates.M.set_result(self, probs, nshots)
-
     def measure(self, state, nshots):
         return cgates.M.measure(self, state, nshots)
 

--- a/src/qibo/core/gates.py
+++ b/src/qibo/core/gates.py
@@ -258,7 +258,7 @@ class M(BackendGate, gates.M):
         return cgates.M.measure(self, state, nshots)
 
     def state_vector_call(self, state):
-        return self.state_vector_collapse(state, self.result.binary[0])
+        return self.state_vector_collapse(state, self.result.binary[-1])
 
     def density_matrix_call(self, state):
         return self.density_matrix_collapse(state, self.result_list())

--- a/src/qibo/core/gates.py
+++ b/src/qibo/core/gates.py
@@ -187,9 +187,11 @@ class M(BackendGate, gates.M):
         self.unmeasured_qubits = None # Tuple
         self.reduced_target_qubits = None # List
 
-        self.result = self.measurements.MeasurementResult(self.qubits)
+        self.result = None
         self._result_list = None
         self._result_tensor = None
+        if collapse:
+            self.result = self.measurements.MeasurementSymbol(self.qubits)
         self.order = None
 
     def add(self, gate: gates.M):

--- a/src/qibo/core/gates.py
+++ b/src/qibo/core/gates.py
@@ -220,8 +220,8 @@ class M(BackendGate, gates.M):
     def construct_unitary(self):
         cgates.M.construct_unitary(self)
 
-    def symbols(self):
-        return cgates.M.symbols(self)
+    def symbol(self):
+        return cgates.M.symbol(self)
 
     @staticmethod
     def _append_zeros(state, qubits: List[int], results: List[int]):

--- a/src/qibo/core/gates.py
+++ b/src/qibo/core/gates.py
@@ -191,7 +191,7 @@ class M(BackendGate, gates.M):
         self._result_list = None
         self._result_tensor = None
         if collapse:
-            self.result = self.measurements.MeasurementSymbol(self.qubits)
+            self.result = self.measurements.MeasurementResult(self.qubits)
         self.order = None
 
     def add(self, gate: gates.M):
@@ -219,6 +219,9 @@ class M(BackendGate, gates.M):
 
     def construct_unitary(self):
         cgates.M.construct_unitary(self)
+
+    def symbols(self):
+        return cgates.M.symbols(self)
 
     @staticmethod
     def _append_zeros(state, qubits: List[int], results: List[int]):

--- a/src/qibo/core/measurements.py
+++ b/src/qibo/core/measurements.py
@@ -220,7 +220,7 @@ class MeasurementSymbol(MeasurementResult, sympy.Symbol):
         return super().__new__(cls=cls, name=name)
 
     def __init__(self, qubits, probabilities=None, nshots=0):
-        return MeasurementResult.__init__(self, qubits, probabilities, nshots)
+        MeasurementResult.__init__(self, qubits, probabilities, nshots)
 
     def add_qubits(self, *qubits):
         self.qubits += tuple(*qubits)

--- a/src/qibo/core/measurements.py
+++ b/src/qibo/core/measurements.py
@@ -255,6 +255,9 @@ class MeasurementSymbol(sympy.Symbol):
     def __init__(self, measurement_result, qubit=None):
         self.result = measurement_result
         self.qubit = qubit
+        # create seperate ``MeasurementSymbol`` object that maps to the same
+        # result for each measured qubit so that the user can use the symbol
+        # to control subsequent parametrized gates
         if qubit is None:
             self.elements = [self.__class__(self.result, q)
                              for q in self.result.qubits]

--- a/src/qibo/core/measurements.py
+++ b/src/qibo/core/measurements.py
@@ -37,7 +37,7 @@ class MeasurementResult(sympy.Symbol):
         cls._counter += 1
         return super().__new__(cls=cls, name=name)
 
-    def __init__(self, qubits, probabilities=None, nshots=None):
+    def __init__(self, qubits, probabilities=None, nshots=0):
         self.qubits = tuple(qubits)
         self.probabilities = probabilities
         self.nshots = nshots
@@ -56,7 +56,7 @@ class MeasurementResult(sympy.Symbol):
     def add_qubits(self, *qubits):
         self.qubits += tuple(*qubits)
 
-    def set_probabilities(self, probabilities, nshots=None):
+    def set_probabilities(self, probabilities, nshots=0):
         self.reset()
         self.probabilities = probabilities
         self.nshots = nshots
@@ -114,7 +114,7 @@ class MeasurementResult(sympy.Symbol):
         if len(self.qubits) > 1:
             raise_error(ValueError, "Cannot return measurement outcome if more "
                                     "than one qubit is measured.")
-        if self.nshots is None:
+        if not self.nshots:
             nshots = int(self.binary.shape[0])
         else:
             nshots = self.nshots
@@ -176,7 +176,7 @@ class MeasurementResult(sympy.Symbol):
 
     def _sample_shots(self):
         self._frequencies = None
-        if self.probabilities is None:
+        if self.probabilities is None or not self.nshots:
             raise_error(RuntimeError, "Cannot sample measurement shots if "
                                       "a probability distribution is not "
                                       "provided.")
@@ -191,7 +191,7 @@ class MeasurementResult(sympy.Symbol):
 
     def _calculate_frequencies(self):
         if self._binary is None and self._decimal is None:
-            if self.probabilities is None or self.nshots is None:
+            if self.probabilities is None or not self.nshots:
                 raise_error(RuntimeError, "Cannot calculate measurement "
                                           "frequencies without a probability "
                                           "distribution or  samples.")

--- a/src/qibo/core/measurements.py
+++ b/src/qibo/core/measurements.py
@@ -252,19 +252,12 @@ class MeasurementSymbol(sympy.Symbol):
         cls._counter += 1
         return super().__new__(cls=cls, name=name)
 
-    def __init__(self, measurement_result):
+    def __init__(self, measurement_result, qubit=None):
         self.result = measurement_result
-
-    def set_probabilities(self, *args, **kwargs):
-        self.result.set_probabilities(*args, **kwargs)
-
-    @property
-    def decimal(self):
-        return self.result.decimal
-
-    @property
-    def binary(self):
-        return self.result.binary
+        self.qubit = qubit
+        if qubit is None:
+            self.elements = [self.__class__(self.result, q)
+                             for q in self.result.qubits]
 
     def samples(self, *args, **kwargs):
         return self.result.samples(*args, **kwargs)
@@ -273,7 +266,12 @@ class MeasurementSymbol(sympy.Symbol):
         return self.result.frequencies(*args, **kwargs)
 
     def outcome(self):
-        return self.result.outcome()
+        if self.qubit is None:
+            return self.result.outcome()
+        return self.result.outcome(self.qubit)
+
+    def __getitem__(self, i):
+        return self.elements[i]
 
     def evaluate(self, expr):
         """Substitutes the symbol's value in the given expression.

--- a/src/qibo/core/measurements.py
+++ b/src/qibo/core/measurements.py
@@ -280,12 +280,12 @@ class MeasurementSymbol(sympy.Symbol):
             expr (sympy.Expr): Sympy expression that involves the current
                 measurement symbol.
         """
-        if len(self.result.qubits) > 1:
+        if self.qubit is None and len(self.result.qubits) > 1:
             raise_error(NotImplementedError, "Symbolic measurements are not "
                                              "available for more than one "
                                              "measured qubits. Please use "
                                              "seperate measurement gates.")
-        return expr.subs(self, self.result.outcome())
+        return expr.subs(self, self.outcome())
 
 
 class MeasurementRegistersResult:

--- a/src/qibo/core/measurements.py
+++ b/src/qibo/core/measurements.py
@@ -226,11 +226,18 @@ class MeasurementSymbol(MeasurementResult, sympy.Symbol):
         self.qubits += tuple(*qubits)
 
     def add_shot(self, probabilities=None):
+        """Adds a measurement shot to an existing measurement symbol.
+
+        Useful for sampling more than one shots with collapse measurement gates.
+        """
         if self.nshots:
             if probabilities is not None:
                 self.probabilities = probabilities
             self.nshots += 1
-            pass
+            # sample new shot
+            new_shot = K.cpu_fallback(K.sample_shots, self.probabilities, 1)
+            self._decimal = K.concatenate([self.decimal, new_shot], axis=0)
+            self._binary = None
         else:
             if probabilities is None:
                 raise_error(ValueError, "Cannot add shots in measurement that "

--- a/src/qibo/core/measurements.py
+++ b/src/qibo/core/measurements.py
@@ -222,9 +222,6 @@ class MeasurementSymbol(MeasurementResult, sympy.Symbol):
     def __init__(self, qubits, probabilities=None, nshots=0):
         MeasurementResult.__init__(self, qubits, probabilities, nshots)
 
-    def add_qubits(self, *qubits):
-        self.qubits += tuple(*qubits)
-
     def add_shot(self, probabilities=None):
         """Adds a measurement shot to an existing measurement symbol.
 

--- a/src/qibo/core/measurements.py
+++ b/src/qibo/core/measurements.py
@@ -246,7 +246,7 @@ class MeasurementSymbol(MeasurementResult, sympy.Symbol):
             self.set_probabilities(probabilities)
 
     def outcome(self):
-        """Returns the outcome for single qubit, single shot measurements."""
+        """Returns the last outcome for single qubit measurements."""
         if len(self.qubits) > 1:
             raise_error(ValueError, "Cannot return measurement outcome if more "
                                     "than one qubit is measured.")
@@ -254,11 +254,7 @@ class MeasurementSymbol(MeasurementResult, sympy.Symbol):
             nshots = int(self.binary.shape[0])
         else:
             nshots = self.nshots
-        if nshots > 1:
-            raise_error(ValueError, "Cannot return measurement outcome if the "
-                                    "number of shots is different than 1.")
-        return self.binary[0, 0]
-
+        return self.binary[-1, 0]
 
     def evaluate(self, expr):
         """Substitutes the symbol's value in the given expression.
@@ -272,11 +268,7 @@ class MeasurementSymbol(MeasurementResult, sympy.Symbol):
                                              "available for more than one "
                                              "measured qubits. Please use "
                                              "seperate measurement gates.")
-        if self.nshots > 1:
-            raise_error(NotImplementedError, "Symbolic measurements are only "
-                                             "available for single shot but "
-                                             "{} shots were given.")
-        return expr.subs(self, self.binary[0, 0])
+        return expr.subs(self, self.outcome())
 
 
 class MeasurementRegistersResult:

--- a/src/qibo/tests_new/test_core_gates_features.py
+++ b/src/qibo/tests_new/test_core_gates_features.py
@@ -91,7 +91,7 @@ def test_measurement_collapse_distributed(backend, accelerators, nqubits, target
     output = c.add(gates.M(*targets, collapse=True))
     result = c(np.copy(initial_state))
     slicer = nqubits * [slice(None)]
-    for t, r in zip(targets, output.binary[0]):
+    for t, r in zip(targets, output.samples()[0]):
         slicer[t] = r
     slicer = tuple(slicer)
     initial_state = initial_state.reshape(nqubits * (2,))
@@ -112,7 +112,7 @@ def test_collapse_after_measurement(backend):
     output = c.add(gates.M(*qubits, collapse=True))
     c.add((gates.H(i) for i in range(5)))
     result = c()
-    bitstring = output.binary[0]
+    bitstring = output.samples()[0]
     final_state = result.state()
 
     ct = Circuit(5)

--- a/src/qibo/tests_new/test_core_gates_features.py
+++ b/src/qibo/tests_new/test_core_gates_features.py
@@ -111,7 +111,7 @@ def test_collapse_after_measurement(backend):
     c.add((gates.H(i) for i in range(5)))
     output = c.add(gates.M(*qubits, collapse=True))
     c.add((gates.H(i) for i in range(5)))
-    result = c(nshots=1)
+    result = c()
     bitstring = output.binary[0]
     final_state = result.state()
 

--- a/src/qibo/tests_new/test_core_measurements.py
+++ b/src/qibo/tests_new/test_core_measurements.py
@@ -189,7 +189,7 @@ def test_measurementsymbol_counter():
     assert symbol2.result.qubits == (1, 3)
     assert symbol1.name[0] == "m" # pylint: disable=E1101
     assert symbol2.name[0] == "m" # pylint: disable=E1101
-    assert int(symbol1.name[1:]) + 1 == int(symbol2.name[1:]) # pylint: disable=E1101
+    assert int(symbol1.name[1:]) + 3 == int(symbol2.name[1:]) # pylint: disable=E1101
 
 
 def test_measurementsymbol_evaluate(backend):
@@ -200,7 +200,7 @@ def test_measurementsymbol_evaluate(backend):
     with pytest.raises(NotImplementedError):
         value = result.evaluate(expr)
     result = measurements.MeasurementSymbol(measurements.MeasurementResult((0,)))
-    result.set_probabilities(np.array([0., 1.]), nshots=1)
+    result.result.set_probabilities(np.array([0., 1.]), nshots=1)
     expr = 2 * result
     value = result.evaluate(expr)
     assert value == 2

--- a/src/qibo/tests_new/test_core_measurements.py
+++ b/src/qibo/tests_new/test_core_measurements.py
@@ -25,6 +25,37 @@ def test_measurementresult_errors():
         result.set_frequencies({0: 100})
 
 
+def test_measurementresult_add_shots(backend):
+    original_backend = qibo.get_backend()
+    qibo.set_backend(backend)
+    result = measurements.MeasurementResult((0, 1))
+    with pytest.raises(ValueError):
+        result.add_shot()
+    probs = np.array([1, 0, 0, 0], dtype=np.float64)
+    result.add_shot(probabilities=probs)
+    assert result.nshots == 1
+    np.testing.assert_allclose(result.decimal, [0])
+    np.testing.assert_allclose(result.binary, [[0, 0]])
+    probs = np.array([0, 0, 0, 1], dtype=np.float64)
+    result.add_shot(probabilities=probs)
+    assert result.nshots == 2
+    np.testing.assert_allclose(result.decimal, [0, 3])
+    np.testing.assert_allclose(result.binary, [[0, 0], [1, 1]])
+    qibo.set_backend(original_backend)
+
+
+def test_measurementresult_outcome(backend):
+    import collections
+    original_backend = qibo.get_backend()
+    qibo.set_backend(backend)
+    result = measurements.MeasurementResult((0,))
+    result.decimal = np.zeros(1, dtype=np.int64)
+    assert result.outcome() == 0
+    result.decimal = np.ones(1, dtype=np.int64)
+    assert result.outcome() == 1
+    qibo.set_backend(original_backend)
+
+
 @pytest.mark.parametrize("binary", [True, False])
 @pytest.mark.parametrize("dsamples,bsamples",
                          [([0, 3, 2, 3, 1],
@@ -152,57 +183,23 @@ def test_measurementresult_apply_bitflips_errors():
 
 
 def test_measurementsymbol_counter():
-    result1 = measurements.MeasurementSymbol((0, 1))
-    result2 = measurements.MeasurementSymbol((1, 3))
-    assert result1.qubits == (0, 1)
-    assert result2.qubits == (1, 3)
-    assert result1.name[0] == "m" # pylint: disable=E1101
-    assert result2.name[0] == "m" # pylint: disable=E1101
-    assert int(result1.name[1:]) + 1 == int(result2.name[1:]) # pylint: disable=E1101
-
-
-def test_measurementsymbol_add_shots(backend):
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
-    result = measurements.MeasurementSymbol((0, 1))
-    with pytest.raises(ValueError):
-        result.add_shot()
-    probs = np.array([1, 0, 0, 0], dtype=np.float64)
-    result.add_shot(probabilities=probs)
-    assert result.nshots == 1
-    np.testing.assert_allclose(result.decimal, [0])
-    np.testing.assert_allclose(result.binary, [[0, 0]])
-    probs = np.array([0, 0, 0, 1], dtype=np.float64)
-    result.add_shot(probabilities=probs)
-    assert result.nshots == 2
-    np.testing.assert_allclose(result.decimal, [0, 3])
-    np.testing.assert_allclose(result.binary, [[0, 0], [1, 1]])
-    qibo.set_backend(original_backend)
-
-
-def test_measurementsymbol_outcome(backend):
-    import collections
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
-    result = measurements.MeasurementSymbol((0,))
-    result.decimal = np.zeros(1, dtype=np.int64)
-    assert result.outcome() == 0
-    result.decimal = np.ones(1, dtype=np.int64)
-    assert result.outcome() == 1
-    result = measurements.MeasurementSymbol((0, 1))
-    with pytest.raises(ValueError):
-        outcome = result.outcome()
-    qibo.set_backend(original_backend)
+    symbol1 = measurements.MeasurementSymbol(measurements.MeasurementResult((0, 1)))
+    symbol2 = measurements.MeasurementSymbol(measurements.MeasurementResult((1, 3)))
+    assert symbol1.result.qubits == (0, 1)
+    assert symbol2.result.qubits == (1, 3)
+    assert symbol1.name[0] == "m" # pylint: disable=E1101
+    assert symbol2.name[0] == "m" # pylint: disable=E1101
+    assert int(symbol1.name[1:]) + 1 == int(symbol2.name[1:]) # pylint: disable=E1101
 
 
 def test_measurementsymbol_evaluate(backend):
     original_backend = qibo.get_backend()
     qibo.set_backend(backend)
-    result = measurements.MeasurementSymbol((0, 1))
+    result = measurements.MeasurementSymbol(measurements.MeasurementResult((0, 1)))
     expr = 2 * result
     with pytest.raises(NotImplementedError):
         value = result.evaluate(expr)
-    result = measurements.MeasurementSymbol((0,))
+    result = measurements.MeasurementSymbol(measurements.MeasurementResult((0,)))
     result.set_probabilities(np.array([0., 1.]), nshots=1)
     expr = 2 * result
     value = result.evaluate(expr)

--- a/src/qibo/tests_new/test_core_measurements.py
+++ b/src/qibo/tests_new/test_core_measurements.py
@@ -13,16 +13,6 @@ def test_measurementresult_init():
     assert result.qubit_map == {0: 0, 1: 1}
 
 
-def test_measurementresult_counter():
-    result1 = measurements.MeasurementResult((0, 1))
-    result2 = measurements.MeasurementResult((1, 3))
-    assert result1.qubits == (0, 1)
-    assert result2.qubits == (1, 3)
-    assert result1.name[0] == "m" # pylint: disable=E1101
-    assert result2.name[0] == "m" # pylint: disable=E1101
-    assert int(result1.name[1:]) + 1 == int(result2.name[1:]) # pylint: disable=E1101
-
-
 def test_measurementresult_errors():
     """Try to sample shots and frequencies without probability distribution."""
     result = measurements.MeasurementResult((0, 1))
@@ -59,24 +49,6 @@ def test_measurementresult_conversions(backend, binary, dsamples, bsamples):
     qibo.set_backend(original_backend)
 
 
-def test_measurementresult_outcome(backend):
-    import collections
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
-    result = measurements.MeasurementResult((0,))
-    result.decimal = np.zeros(1, dtype=np.int64)
-    assert result.outcome() == 0
-    result.decimal = np.ones(1, dtype=np.int64)
-    assert result.outcome() == 1
-    result.decimal = np.ones(5, dtype=np.int64)
-    with pytest.raises(ValueError):
-        outcome = result.outcome()
-    result = measurements.MeasurementResult((0, 1))
-    with pytest.raises(ValueError):
-        outcome = result.outcome()
-    qibo.set_backend(original_backend)
-
-
 def test_measurementresult_frequencies(backend):
     import collections
     original_backend = qibo.get_backend()
@@ -88,24 +60,6 @@ def test_measurementresult_frequencies(backend):
               "101": 3, "110": 2}
     assert result.frequencies(binary=True) == bfreqs
     assert result.frequencies(binary=False) == dfreqs
-    qibo.set_backend(original_backend)
-
-
-def test_measurementresult_evaluate(backend):
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
-    result = measurements.MeasurementResult((0, 1))
-    expr = 2 * result
-    with pytest.raises(NotImplementedError):
-        value = result.evaluate(expr)
-    result = measurements.MeasurementResult((0,))
-    result.set_probabilities(np.array([1., 0.]), nshots=10)
-    expr = 2 * result
-    with pytest.raises(NotImplementedError):
-        value = result.evaluate(expr)
-    result.set_probabilities(np.array([0., 1.]), nshots=1)
-    value = result.evaluate(expr)
-    assert value == 2
     qibo.set_backend(original_backend)
 
 
@@ -195,6 +149,52 @@ def test_measurementresult_apply_bitflips_errors():
     # Passing negative bitflip probability
     with pytest.raises(ValueError):
         noisy_result = result.apply_bitflips(-0.4)
+
+
+def test_measurementsymbol_counter():
+    result1 = measurements.MeasurementSymbol((0, 1))
+    result2 = measurements.MeasurementSymbol((1, 3))
+    assert result1.qubits == (0, 1)
+    assert result2.qubits == (1, 3)
+    assert result1.name[0] == "m" # pylint: disable=E1101
+    assert result2.name[0] == "m" # pylint: disable=E1101
+    assert int(result1.name[1:]) + 1 == int(result2.name[1:]) # pylint: disable=E1101
+
+
+def test_measurementsymbol_outcome(backend):
+    import collections
+    original_backend = qibo.get_backend()
+    qibo.set_backend(backend)
+    result = measurements.MeasurementSymbol((0,))
+    result.decimal = np.zeros(1, dtype=np.int64)
+    assert result.outcome() == 0
+    result.decimal = np.ones(1, dtype=np.int64)
+    assert result.outcome() == 1
+    result.decimal = np.ones(5, dtype=np.int64)
+    with pytest.raises(ValueError):
+        outcome = result.outcome()
+    result = measurements.MeasurementSymbol((0, 1))
+    with pytest.raises(ValueError):
+        outcome = result.outcome()
+    qibo.set_backend(original_backend)
+
+
+def test_measurementsymbol_evaluate(backend):
+    original_backend = qibo.get_backend()
+    qibo.set_backend(backend)
+    result = measurements.MeasurementSymbol((0, 1))
+    expr = 2 * result
+    with pytest.raises(NotImplementedError):
+        value = result.evaluate(expr)
+    result = measurements.MeasurementSymbol((0,))
+    result.set_probabilities(np.array([1., 0.]), nshots=10)
+    expr = 2 * result
+    with pytest.raises(NotImplementedError):
+        value = result.evaluate(expr)
+    result.set_probabilities(np.array([0., 1.]), nshots=1)
+    value = result.evaluate(expr)
+    assert value == 2
+    qibo.set_backend(original_backend)
 
 
 def test_measurementregistersresult_samples(backend):

--- a/src/qibo/tests_new/test_core_measurements.py
+++ b/src/qibo/tests_new/test_core_measurements.py
@@ -161,6 +161,23 @@ def test_measurementsymbol_counter():
     assert int(result1.name[1:]) + 1 == int(result2.name[1:]) # pylint: disable=E1101
 
 
+def test_measurementsymbol_add_shots(backend):
+    original_backend = qibo.get_backend()
+    qibo.set_backend(backend)
+    result = measurements.MeasurementSymbol((0, 1))
+    probs = np.array([1, 0, 0, 0], dtype=np.float64)
+    result.add_shot(probabilities=probs)
+    assert result.nshots == 1
+    np.testing.assert_allclose(result.decimal, [0])
+    np.testing.assert_allclose(result.binary, [[0, 0]])
+    probs = np.array([0, 0, 0, 1], dtype=np.float64)
+    result.add_shot(probabilities=probs)
+    assert result.nshots == 2
+    np.testing.assert_allclose(result.decimal, [0, 3])
+    np.testing.assert_allclose(result.binary, [[0, 0], [1, 1]])
+    qibo.set_backend(original_backend)
+
+
 def test_measurementsymbol_outcome(backend):
     import collections
     original_backend = qibo.get_backend()

--- a/src/qibo/tests_new/test_core_measurements.py
+++ b/src/qibo/tests_new/test_core_measurements.py
@@ -187,9 +187,6 @@ def test_measurementsymbol_outcome(backend):
     assert result.outcome() == 0
     result.decimal = np.ones(1, dtype=np.int64)
     assert result.outcome() == 1
-    result.decimal = np.ones(5, dtype=np.int64)
-    with pytest.raises(ValueError):
-        outcome = result.outcome()
     result = measurements.MeasurementSymbol((0, 1))
     with pytest.raises(ValueError):
         outcome = result.outcome()
@@ -204,11 +201,8 @@ def test_measurementsymbol_evaluate(backend):
     with pytest.raises(NotImplementedError):
         value = result.evaluate(expr)
     result = measurements.MeasurementSymbol((0,))
-    result.set_probabilities(np.array([1., 0.]), nshots=10)
-    expr = 2 * result
-    with pytest.raises(NotImplementedError):
-        value = result.evaluate(expr)
     result.set_probabilities(np.array([0., 1.]), nshots=1)
+    expr = 2 * result
     value = result.evaluate(expr)
     assert value == 2
     qibo.set_backend(original_backend)

--- a/src/qibo/tests_new/test_core_measurements.py
+++ b/src/qibo/tests_new/test_core_measurements.py
@@ -165,6 +165,8 @@ def test_measurementsymbol_add_shots(backend):
     original_backend = qibo.get_backend()
     qibo.set_backend(backend)
     result = measurements.MeasurementSymbol((0, 1))
+    with pytest.raises(ValueError):
+        result.add_shot()
     probs = np.array([1, 0, 0, 0], dtype=np.float64)
     result.add_shot(probabilities=probs)
     assert result.nshots == 1

--- a/src/qibo/tests_new/test_measurement_gate_collapse.py
+++ b/src/qibo/tests_new/test_measurement_gate_collapse.py
@@ -143,9 +143,9 @@ def test_measurement_result_parameters_repeated_execution(backend, accelerators,
         final_states = c(initial_state=np.copy(initial_state), nshots=20)
 
     K.set_seed(123)
-    collapse = gates.M(1, collapse=True)
     target_states = []
     for _ in range(20):
+        collapse = gates.M(1, collapse=True)
         target_state = collapse(np.copy(initial_state))
         if int(collapse.result.outcome()):
             target_state = gates.RX(2, theta=np.pi / 4)(target_state)
@@ -169,15 +169,14 @@ def test_measurement_result_parameters_repeated_execution_final_measurements(bac
     result = c(initial_state=np.copy(initial_state), nshots=30)
 
     K.set_seed(123)
-    collapse = gates.M(1, collapse=True)
-    measurement = gates.M(0, 1, 2, 3)
     target_samples = []
     for _ in range(30):
+        collapse = gates.M(1, collapse=True)
         target_state = collapse(np.copy(initial_state))
         if int(collapse.result.outcome()):
             target_state = gates.RY(0, theta=np.pi / 3)(target_state)
             target_state = gates.RY(2, theta=np.pi / 4)(target_state)
-        target_result = measurement(target_state)
+        target_result = gates.M(0, 1, 2, 3)(target_state)
         target_samples.append(target_result.decimal[0])
     np.testing.assert_allclose(result.samples(binary=False), target_samples)
     qibo.set_backend(original_backend)

--- a/src/qibo/tests_new/test_measurement_gate_collapse.py
+++ b/src/qibo/tests_new/test_measurement_gate_collapse.py
@@ -80,6 +80,9 @@ def test_measurement_collapse_bitflip_noise(backend, accelerators):
         target_samples = [3, 3, 0, 3, 2, 0, 1, 2, 2, 2, 2, 0, 0, 2, 0,
                           2, 3, 1, 1, 0]
     np.testing.assert_allclose(output.samples(binary=False), target_samples)
+    _, target_frequencies = np.unique(target_samples, return_counts=True)
+    target_frequencies = {i: v for i, v in enumerate(target_frequencies)}
+    assert output.frequencies(binary=False) == target_frequencies
     qibo.set_backend(original_backend)
 
 

--- a/src/qibo/tests_new/test_measurement_gate_collapse.py
+++ b/src/qibo/tests_new/test_measurement_gate_collapse.py
@@ -117,7 +117,7 @@ def test_measurement_result_parameters_random(backend, accelerators):
     K.set_seed(123)
     collapse = gates.M(1, collapse=True)
     target_state = collapse(np.copy(initial_state))
-    if int(output.outcome()):
+    if int(collapse.result.outcome()):
         target_state = gates.RY(0, theta=np.pi / 5)(target_state)
         target_state = gates.RX(2, theta=np.pi / 4)(target_state)
     np.testing.assert_allclose(result, target_state)
@@ -179,4 +179,28 @@ def test_measurement_result_parameters_repeated_execution_final_measurements(bac
         target_result = gates.M(0, 1, 2, 3)(target_state)
         target_samples.append(target_result.decimal[0])
     np.testing.assert_allclose(result.samples(binary=False), target_samples)
+    qibo.set_backend(original_backend)
+
+
+def test_measurement_result_parameters_multiple_qubits(backend):
+    original_backend = qibo.get_backend()
+    qibo.set_backend(backend)
+    from qibo import K
+    from qibo.tests_new.test_core_gates import random_state
+    initial_state = random_state(4)
+    K.set_seed(123)
+    c = models.Circuit(4)
+    output = c.add(gates.M(0, 1, 2, collapse=True))
+    c.add(gates.RY(1, theta=np.pi * output[0] / 5))
+    c.add(gates.RX(3, theta=np.pi * output[2] / 3))
+    result = c(initial_state=np.copy(initial_state))
+
+    K.set_seed(123)
+    collapse = gates.M(0, 1, 2, collapse=True)
+    target_state = collapse(np.copy(initial_state))
+    if int(collapse.result.outcome(0)):
+        target_state = gates.RY(1, theta=np.pi / 5)(target_state)
+    if int(collapse.result.outcome(2)):
+        target_state = gates.RX(3, theta=np.pi / 3)(target_state)
+    np.testing.assert_allclose(result, target_state)
     qibo.set_backend(original_backend)

--- a/src/qibo/tests_new/test_measurement_gate_collapse.py
+++ b/src/qibo/tests_new/test_measurement_gate_collapse.py
@@ -65,6 +65,24 @@ def test_measurement_collapse_errors(backend):
     qibo.set_backend(original_backend)
 
 
+def test_measurement_collapse_bitflip_noise(backend, accelerators):
+    original_backend = qibo.get_backend()
+    qibo.set_backend(backend)
+    from qibo import K
+    K.set_seed(123)
+    c = models.Circuit(4, accelerators)
+    output = c.add(gates.M(0, 1, p0=0.2, collapse=True))
+    result = c(nshots=20)
+    if K.name == "tensorflow":
+        target_samples = [2, 2, 2, 1, 1, 0, 1, 2, 1, 2, 2, 3, 3, 0, 3,
+                          0, 0, 3, 0, 1]
+    elif K.name == "numpy":
+        target_samples = [3, 3, 0, 3, 2, 0, 1, 2, 2, 2, 2, 0, 0, 2, 0,
+                          2, 3, 1, 1, 0]
+    np.testing.assert_allclose(output.samples(binary=False), target_samples)
+    qibo.set_backend(original_backend)
+
+
 @pytest.mark.parametrize("effect", [False, True])
 def test_measurement_result_parameters(backend, accelerators, effect):
     original_backend = qibo.get_backend()


### PR DESCRIPTION
Implements the second question/point analyzed in #352 to allow performing multiple `collapse=True` shots using a single circuit call. The usage is the following:

```Python
c = Circuit(1)
c.add(gates.H(0))
output = c.add(gates.M(0, collapse=True))
result = c(nshots=100)
```
will perform 100 measurements by repeating the circuit execution. The samples are accessible via the `output` object, that is `output.samples()` will return a `(100, 1)` tensor. Note that execution with repetition is equivalent to:
```Python
samples = []
for _ in range(100):
    c()
    samples.append(output.samples())
```

It is also possible to use `output` to parametrize other gates:
```Python
c = Circuit(2)
c.add(gates.H(0))
output = c.add(gates.M(0, collapse=True))
c.add(gates.RX(1, theta=np.pi * output / 4))
result = c(nshots=100)
```
In this case the latest measurement outcome will be used to control subsequent gates in each repetition.

Normal measurement gates can also be used at the end of the circuit:
```Python
c = Circuit(2)
c.add(gates.H(0))
output = c.add(gates.M(0, collapse=True))
c.add(gates.RX(1, theta=np.pi * output / 4))
c.add(gates.M(0, 1))
result = c(nshots=100)
```
In this case `output.samples()` will have shape `(100, 1)` containing the results of the first (collapse) measurement, while `result.samples()` will have shape `(100, 2)` with the results of the second (non-collapse) measurement.