### PR TITLE
Update semiclassical Shor example to use measurements with collapse

### DIFF
--- a/examples/shor/functions.py
+++ b/examples/shor/functions.py
@@ -383,7 +383,6 @@ def quantum_order_finding_semiclassical(N, a):
     for i in range(1, 2*n):
         # reset measured qubit to |0>
         circuit.add(gates.RX(q_reg, theta=np.pi * results[-1]))
-
         circuit.add(gates.H(q_reg))
         #a_i = (a**(2**(2*n - 1 - i)))
         circuit.add(c_U(q_reg, x, b, exponents[-1-i], N, ancilla, n))

--- a/examples/test_examples.py
+++ b/examples/test_examples.py
@@ -233,7 +233,7 @@ def test_ef_qae(layers, autoencoder, example):
 @pytest.mark.parametrize("N", [15, 21])
 @pytest.mark.parametrize("times", [2, 10])
 @pytest.mark.parametrize("A", [None])
-@pytest.mark.parametrize("semiclassical", [False])
+@pytest.mark.parametrize("semiclassical", [True, False])
 @pytest.mark.parametrize("enhance", [True, False])
 def test_shor(N, times, A, semiclassical, enhance):
     if "functions" in sys.modules:


### PR DESCRIPTION
Updates the semiclassical version of the Shor example to use the collapse and gate conditioned on measurement outcome functionality implemented in #352. The whole procedure can now implemented using a single circuit, without requiring to recreate a new one after each measurement.

Note that measured qubits are reset to |0> using an RX gate conditioned on the measurement outcome, like the following example:
```Python
results.append(c.add(gates.M(0, collapse=True)))
c.add(gates.RX(0, theta=np.pi * results[-1]))
```

We may substitute this by the `Reset` gate in the future, once we know how this is implemented experimentally.