### PR TITLE
Fix variational classifier

### DIFF
--- a/examples/variational_classifier/README.md
+++ b/examples/variational_classifier/README.md
@@ -4,7 +4,7 @@ Code at: [https://github.com/Quantum-TII/qibo/tree/master/examples/variational_c
 
 ## Problem overview
 
-We want to perform a supervised classification task with a [variational quantum classifer](https://arxiv.org/abs/2001.03622). The classifier is trained to minimize a local loss function given by the quadratic deviation of the classifier's predictions from the actual labels of the examples in the training set. A variational quantum circuit is employed to perform the classification.
+We want to perform a supervised classification task with a [variational quantum classifer](https://arxiv.org/abs/1802.06002). The classifier is trained to minimize a local loss function given by the quadratic deviation of the classifier's predictions from the actual labels of the examples in the training set. A variational quantum circuit is employed to perform the classification.
 
 ## Implementing the solution
 
@@ -42,4 +42,4 @@ Note that nclases must be 3 and cannot be changed in this example, because we ar
 
 ## Results
 
-The classification accuracy for the training and test sets is found to be around 70% and 67%, respectively.
+The classification accuracy for the training and test sets is found to be around 70% and 73%, respectively.

--- a/examples/variational_classifier/main.py
+++ b/examples/variational_classifier/main.py
@@ -77,7 +77,7 @@ def main(nclasses, nqubits, nlayers, nshots, training, RxRzRx, method):
             np.save('data/optimal_angles_rxrzrx_{}q_{}l.npy'.format(nqubits,nlayers), optimal_angles)
         
     # We define our test set (both kets and labels)
-    data_test = np.concatenate((data[35:49], data[85:99], data[135:149]))  
+    data_test = np.concatenate((data[35:50], data[85:100], data[135:150]))  
     labels_test = [[1,1]]*15 + [[1,-1]]*15 + [[-1,1]]*15
     
     # We run an accuracy check for the training and the test sets


### PR DESCRIPTION
This PR fixes an error in the definition of the test set for the `variational classifier` example, described in #367 .

It also updates the README file accordingly to include the new test accuracy.

The arXiv reference for the variational classifier in the README file has also been modified.