### PR TITLE
Simplify backend switch

### DIFF
--- a/src/qibo/backends/__init__.py
+++ b/src/qibo/backends/__init__.py
@@ -5,71 +5,114 @@ from qibo.backends.numpy import NumpyDefaultEinsumBackend, NumpyMatmulEinsumBack
 from qibo.backends.tensorflow import TensorflowCustomBackend, TensorflowDefaultEinsumBackend, TensorflowMatmulEinsumBackend
 
 
-AVAILABLE_BACKENDS = {
-    "custom": TensorflowCustomBackend,
-    "tensorflow": TensorflowCustomBackend,
-    "defaulteinsum": TensorflowDefaultEinsumBackend,
-    "matmuleinsum": TensorflowMatmulEinsumBackend,
-    "tensorflow_defaulteinsum": TensorflowDefaultEinsumBackend,
-    "tensorflow_matmuleinsum": TensorflowMatmulEinsumBackend,
-    "numpy": NumpyDefaultEinsumBackend,
-    "numpy_defaulteinsum": NumpyDefaultEinsumBackend,
-    "numpy_matmuleinsum": NumpyMatmulEinsumBackend
-}
+class Backend:
 
-_CONSTRUCTED_BACKENDS = {}
-def _construct_backend(name):
-    if name not in _CONSTRUCTED_BACKENDS:
-        if name not in AVAILABLE_BACKENDS:
-            available = ", ".join(list(AVAILABLE_BACKENDS.keys()))
-            raise_error(ValueError, "Unknown backend {}. Please select one of "
-                                    "the available backends: {}."
-                                    "".format(name, available))
-        _CONSTRUCTED_BACKENDS[name] = AVAILABLE_BACKENDS.get(name)()
-    return _CONSTRUCTED_BACKENDS.get(name)
+    def __init__(self):
+        self.available_backends = {
+            "custom": TensorflowCustomBackend,
+            "tensorflow": TensorflowCustomBackend,
+            "defaulteinsum": TensorflowDefaultEinsumBackend,
+            "matmuleinsum": TensorflowMatmulEinsumBackend,
+            "tensorflow_defaulteinsum": TensorflowDefaultEinsumBackend,
+            "tensorflow_matmuleinsum": TensorflowMatmulEinsumBackend,
+            "numpy": NumpyDefaultEinsumBackend,
+            "numpy_defaulteinsum": NumpyDefaultEinsumBackend,
+            "numpy_matmuleinsum": NumpyMatmulEinsumBackend
+        }
 
-numpy_backend = _construct_backend("numpy_defaulteinsum")
-numpy_matrices = numpy_backend.matrices
+        self.constructed_backends = {}
+        self.qnp = self.construct_backend("numpy_defaulteinsum")
+        self._active_backend = None
+        # Create the default active backend
+        if "QIBO_BACKEND" in os.environ: # pragma: no cover
+            self.initialize_from_env_variable(os.environ.get("QIBO_BACKEND"))
+        try:
+            self.initialize_tensorflow()
+        except ModuleNotFoundError: # pragma: no cover
+            self.initialize_numpy()
 
+    @property
+    def active_backend(self):
+        return self._active_backend
 
-# Select the default backend engine
-if "QIBO_BACKEND" in os.environ: # pragma: no cover
-    _BACKEND_NAME = os.environ.get("QIBO_BACKEND")
-    if _BACKEND_NAME not in AVAILABLE_BACKENDS: # pragma: no cover
-        _available_names = ", ".join(list(AVAILABLE_BACKENDS.keys()))
-        raise_error(ValueError, "Environment variable `QIBO_BACKEND` has "
-                                "unknown value {}. Please select one of {}."
-                                "".format(_BACKEND_NAME, _available_names))
-    K = AVAILABLE_BACKENDS.get(_BACKEND_NAME)()
-else:
-    try:
+    @active_backend.setter
+    def active_backend(self, name):
+        # TODO: Move `construct_backend` here
+        self._active_backend = self.construct_backend(name)
+
+    def construct_backend(self, name):
+        """Constructs and returns a backend.
+
+        If the backend already exists in previously constructed backends then
+        the existing object is returned.
+
+        Args:
+            name (str): Name of the backend to construct.
+                See ``available_backends`` for the list of supported names.
+
+        Returns:
+            Backend object.
+        """
+        if name not in self.constructed_backends:
+            if name not in self.available_backends:
+                available = ", ".join(list(self.available_backends.keys()))
+                raise_error(ValueError, "Unknown backend {}. Please select one of "
+                                        "the available backends: {}."
+                                        "".format(name, available))
+            self.constructed_backends[name] = self.available_backends.get(name)()
+        return self.constructed_backends.get(name)
+
+    def initialize_from_env_variable(self, name): # pragma: no cover
+        """Initializes active backend from environment variable name."""
+        if name not in self.available_backends: # pragma: no cover
+            _available_names = ", ".join(list(self.available_backends.keys()))
+            raise_error(ValueError, "Environment variable `QIBO_BACKEND` has "
+                                    "unknown value {}. Please select one of {}."
+                                    "".format(name, _available_names))
+        self.active_backend = name
+
+    def initialize_tensorflow(self):
+        """Initializes active Tensorflow backend (if available)."""
         os.environ["TF_CPP_MIN_LOG_LEVEL"] = str(config.LOG_LEVEL)
         import tensorflow as tf
         import qibo.tensorflow.custom_operators as op
         if not op._custom_operators_loaded: # pragma: no cover
             log.warning("Einsum will be used to apply gates with Tensorflow. "
                         "Removing custom operators from available backends.")
-            AVAILABLE_BACKENDS.pop("custom")
-            AVAILABLE_BACKENDS["tensorflow"] = TensorflowDefaultEinsumBackend
-        K = AVAILABLE_BACKENDS.get("tensorflow")()
-    except ModuleNotFoundError: # pragma: no cover
+            self.available_backends.pop("custom")
+            self.available_backends["tensorflow"] = TensorflowDefaultEinsumBackend
+        self.active_backend = "tensorflow"
+
+    def initialize_numpy(self): # pragma: no cover
+        """Initializes active numpy backend (if Tensorflow is not available)."""
         # case not tested because CI has tf installed
         log.warning("Tensorflow is not installed. Falling back to numpy. "
                     "Numpy does not support Qibo custom operators and GPU. "
                     "Einsum will be used to apply gates on CPU.")
         # remove Tensorflow backends
-        AVAILABLE_BACKENDS.pop("custom")
-        AVAILABLE_BACKENDS.pop("tensorflow")
-        AVAILABLE_BACKENDS.pop("tensorflow_defaulteinsum")
-        AVAILABLE_BACKENDS.pop("tensorflow_matmuleinsum")
+        self.available_backends.pop("custom")
+        self.available_backends.pop("tensorflow")
+        self.available_backends.pop("tensorflow_defaulteinsum")
+        self.available_backends.pop("tensorflow_matmuleinsum")
         # use numpy for defaulteinsum and matmuleinsum backends
-        AVAILABLE_BACKENDS["defaulteinsum"] = NumpyDefaultEinsumBackend
-        AVAILABLE_BACKENDS["matmuleinsum"] = NumpyMatmulEinsumBackend
-        K = AVAILABLE_BACKENDS.get("numpy")()
+        self.available_backends["defaulteinsum"] = NumpyDefaultEinsumBackend
+        self.available_backends["matmuleinsum"] = NumpyMatmulEinsumBackend
+        self.active_backend = "numpy"
+
+    def __getattr__(self, x):
+        return getattr(self.active_backend, x)
+
+    def __str__(self):
+        return self.active_backend.name
+
+    def __repr__(self):
+        return str(self)
 
 
-K.qnp = numpy_backend
-_BACKEND_NAME = K.name
+K = Backend()
+numpy_matrices = K.qnp.matrices
+
+
 def set_backend(backend="custom"):
     """Sets backend used for mathematical operations and applying gates.
 
@@ -83,12 +126,10 @@ def set_backend(backend="custom"):
     Args:
         backend (str): A backend from the above options.
     """
-    bk = _construct_backend(backend)
     if not config.ALLOW_SWITCHERS and backend != K.name:
         warnings.warn("Backend should not be changed after allocating gates.",
                       category=RuntimeWarning)
-    K.assign(bk)
-    K.qnp = numpy_backend
+    K.active_backend = backend
 
 
 def get_backend():
@@ -110,8 +151,7 @@ def set_precision(dtype='double'):
     if not config.ALLOW_SWITCHERS and dtype != K.precision:
         warnings.warn("Precision should not be changed after allocating gates.",
                       category=RuntimeWarning)
-    K.set_precision(dtype)
-    for bk in _CONSTRUCTED_BACKENDS.values():
+    for bk in K.constructed_backends.values():
         bk.set_precision(dtype)
         bk.matrices.allocate_matrices()
 
@@ -136,8 +176,7 @@ def set_device(name):
     if not config.ALLOW_SWITCHERS and name != K.default_device:
         warnings.warn("Device should not be changed after allocating gates.",
                       category=RuntimeWarning)
-    K.set_device(name)
-    for bk in _CONSTRUCTED_BACKENDS.values():
+    for bk in K.constructed_backends.values():
         if bk.default_device is not None:
             bk.set_device(name)
             with bk.device(bk.default_device):

--- a/src/qibo/backends/__init__.py
+++ b/src/qibo/backends/__init__.py
@@ -57,8 +57,11 @@ else:
         log.warning("Tensorflow is not installed. Falling back to numpy. "
                     "Numpy does not support Qibo custom operators and GPU. "
                     "Einsum will be used to apply gates on CPU.")
-        AVAILABLE_BACKENDS = {k: v for k, v in AVAILABLE_BACKENDS.items()
-                              if "numpy" in k}
+        # remove Tensorflow backends
+        AVAILABLE_BACKENDS.pop("custom")
+        AVAILABLE_BACKENDS.pop("tensorflow")
+        AVAILABLE_BACKENDS.pop("tensorflow_defaulteinsum")
+        AVAILABLE_BACKENDS.pop("tensorflow_matmuleinsum")
         # use numpy for defaulteinsum and matmuleinsum backends
         AVAILABLE_BACKENDS["defaulteinsum"] = NumpyDefaultEinsumBackend
         AVAILABLE_BACKENDS["matmuleinsum"] = NumpyMatmulEinsumBackend

--- a/src/qibo/backends/__init__.py
+++ b/src/qibo/backends/__init__.py
@@ -39,7 +39,7 @@ if "QIBO_BACKEND" in os.environ: # pragma: no cover
         _available_names = ", ".join(list(AVAILABLE_BACKENDS.keys()))
         raise_error(ValueError, "Environment variable `QIBO_BACKEND` has "
                                 "unknown value {}. Please select one of {}."
-                                "".format(_available_names))
+                                "".format(_BACKEND_NAME, _available_names))
     K = AVAILABLE_BACKENDS.get(_BACKEND_NAME)()
 else:
     try:

--- a/src/qibo/backends/__init__.py
+++ b/src/qibo/backends/__init__.py
@@ -25,7 +25,7 @@ class Backend:
         self.qnp = self.construct_backend("numpy_defaulteinsum")
         # Create the default active backend
         if "QIBO_BACKEND" in os.environ: # pragma: no cover
-            self.initialize_from_env_variable(os.environ.get("QIBO_BACKEND"))
+            self.active_backend = os.environ.get("QIBO_BACKEND")
         try:
             self.initialize_tensorflow()
         except ModuleNotFoundError: # pragma: no cover
@@ -54,9 +54,11 @@ class Backend:
         """
         if name not in self.constructed_backends:
             if name not in self.available_backends:
-                available = ", ".join(list(self.available_backends.keys()))
+                available = [" - {}: {}".format(n, b.description)
+                             for n, b in self.available_backends.items()]
+                available = "\n".join(available)
                 raise_error(ValueError, "Unknown backend {}. Please select one of "
-                                        "the available backends: {}."
+                                        "the available backends:\n{}."
                                         "".format(name, available))
             new_backend = self.available_backends.get(name)()
             if self.active_backend is not None:
@@ -65,15 +67,6 @@ class Backend:
                     new_backend.set_device(self.active_backend.default_device)
             self.constructed_backends[name] = new_backend
         return self.constructed_backends.get(name)
-
-    def initialize_from_env_variable(self, name): # pragma: no cover
-        """Initializes active backend from environment variable name."""
-        if name not in self.available_backends: # pragma: no cover
-            _available_names = ", ".join(list(self.available_backends.keys()))
-            raise_error(ValueError, "Environment variable `QIBO_BACKEND` has "
-                                    "unknown value {}. Please select one of {}."
-                                    "".format(name, _available_names))
-        self.active_backend = name
 
     def initialize_tensorflow(self):
         """Initializes active Tensorflow backend (if available)."""

--- a/src/qibo/backends/__init__.py
+++ b/src/qibo/backends/__init__.py
@@ -181,10 +181,9 @@ def set_device(name):
         warnings.warn("Device should not be changed after allocating gates.",
                       category=RuntimeWarning)
     for bk in K.constructed_backends.values():
-        if bk.default_device is not None:
-            bk.set_device(name)
-            with bk.device(bk.default_device):
-                bk.matrices.allocate_matrices()
+        bk.set_device(name)
+        with bk.device(bk.default_device):
+            bk.matrices.allocate_matrices()
 
 
 def get_device():

--- a/src/qibo/backends/__init__.py
+++ b/src/qibo/backends/__init__.py
@@ -59,6 +59,9 @@ else:
                     "Einsum will be used to apply gates on CPU.")
         AVAILABLE_BACKENDS = {k: v for k, v in AVAILABLE_BACKENDS.items()
                               if "numpy" in k}
+        # use numpy for defaulteinsum and matmuleinsum backends
+        AVAILABLE_BACKENDS["defaulteinsum"] = NumpyDefaultEinsumBackend
+        AVAILABLE_BACKENDS["matmuleinsum"] = NumpyMatmulEinsumBackend
         K = AVAILABLE_BACKENDS.get("numpy")()
 
 

--- a/src/qibo/backends/abstract.py
+++ b/src/qibo/backends/abstract.py
@@ -4,16 +4,11 @@ from qibo.config import raise_error, log
 
 class AbstractBackend(ABC):
 
-    base_methods = {"assign", "set_gates", "dtypes",
-                    "set_precision"}
+    base_methods = {"assign", "dtypes", "set_precision"}
 
     def __init__(self):
         self.backend = None
         self.name = "base"
-
-        self.gates = "custom"
-        self.custom_gates = True
-        self.custom_einsum = None
 
         self.precision = 'double'
         self._dtypes = {'DTYPEINT': 'int64', 'DTYPE': 'float64',
@@ -31,7 +26,6 @@ class AbstractBackend(ABC):
         self.newaxis = None
         self.oom_error = None
         self.optimization = None
-        self.op = None
 
     def __str__(self):
         return self.name
@@ -53,22 +47,6 @@ class AbstractBackend(ABC):
         self.newaxis = backend.newaxis
         self.oom_error = backend.oom_error
         self.optimization = backend.optimization
-        self.op = backend.op
-
-    def set_gates(self, name):
-        if name == 'custom':
-            self.custom_gates = True
-            self.custom_einsum = None
-        elif name == 'defaulteinsum':
-            self.custom_gates = False
-            self.custom_einsum = "DefaultEinsum"
-        elif name == 'matmuleinsum':
-            self.custom_gates = False
-            self.custom_einsum = "MatmulEinsum"
-        else: # pragma: no cover
-            # this case is captured by `backends.__init__.set_backend` checks
-            raise_error(ValueError, f"Gate backend '{name}' not supported.")
-        self.gates = name
 
     def dtypes(self, name):
         if name in self._dtypes:

--- a/src/qibo/backends/abstract.py
+++ b/src/qibo/backends/abstract.py
@@ -4,8 +4,6 @@ from qibo.config import raise_error, log
 
 class AbstractBackend(ABC):
 
-    base_methods = {"assign", "dtypes", "set_precision"}
-
     def __init__(self):
         self.backend = None
         self.name = "base"
@@ -26,27 +24,6 @@ class AbstractBackend(ABC):
         self.newaxis = None
         self.oom_error = None
         self.optimization = None
-
-    def __str__(self):
-        return self.name
-
-    def __repr__(self):
-        return "{}Backend".format(self.name.capitalize())
-
-    def assign(self, backend):
-        """Assigns backend's methods."""
-        for method in dir(backend):
-            if method[:2] != "__" and method not in self.base_methods:
-                setattr(self, method, getattr(backend, method))
-        self.name = backend.name
-        self.matrices = backend.matrices
-        self.numeric_types = backend.numeric_types
-        self.tensor_types = backend.tensor_types
-        self.Tensor = backend.Tensor
-        self.random = backend.random
-        self.newaxis = backend.newaxis
-        self.oom_error = backend.oom_error
-        self.optimization = backend.optimization
 
     def dtypes(self, name):
         if name in self._dtypes:

--- a/src/qibo/backends/numpy.py
+++ b/src/qibo/backends/numpy.py
@@ -4,6 +4,8 @@ from qibo.config import raise_error, log
 
 class NumpyBackend(abstract.AbstractBackend):
 
+    description = "Base class for numpy backends"
+
     def __init__(self):
         super().__init__()
         import numpy as np
@@ -236,6 +238,9 @@ class NumpyBackend(abstract.AbstractBackend):
 
 class NumpyDefaultEinsumBackend(NumpyBackend):
 
+    description = "Uses `np.einsum` to apply gates to states via matrix " \
+                  "multiplication."
+
     def __init__(self):
         super().__init__()
         self.name = "numpy_defaulteinsum"
@@ -244,6 +249,9 @@ class NumpyDefaultEinsumBackend(NumpyBackend):
 
 
 class NumpyMatmulEinsumBackend(NumpyBackend):
+
+    description = "Uses `np.matmul` as well as transpositions and reshapes " \
+                  "to apply gates to states via matrix multiplication."
 
     def __init__(self):
         super().__init__()

--- a/src/qibo/backends/numpy.py
+++ b/src/qibo/backends/numpy.py
@@ -232,3 +232,21 @@ class NumpyBackend(abstract.AbstractBackend):
 
     def set_seed(self, seed):
         self.backend.random.seed(seed)
+
+
+class NumpyDefaultEinsumBackend(NumpyBackend):
+
+    def __init__(self):
+        super().__init__()
+        self.name = "numpy_defaulteinsum"
+        self.custom_gates = False
+        self.custom_einsum = "DefaultEinsum"
+
+
+class NumpyMatmulEinsumBackend(NumpyBackend):
+
+    def __init__(self):
+        super().__init__()
+        self.name = "numpy_matmuleinsum"
+        self.custom_gates = False
+        self.custom_einsum = "MatmulEinsum"

--- a/src/qibo/backends/tensorflow.py
+++ b/src/qibo/backends/tensorflow.py
@@ -1,6 +1,6 @@
 import os
 from qibo.backends import abstract, numpy
-from qibo.config import raise_error, log, LOG_LEVEL
+from qibo.config import raise_error, LOG_LEVEL
 
 
 class Optimization:
@@ -13,6 +13,8 @@ class Optimization:
 
 
 class TensorflowBackend(numpy.NumpyBackend):
+
+    description = "Base class for Tensorflow backends."
 
     def __init__(self):
         super().__init__()
@@ -191,6 +193,9 @@ class TensorflowBackend(numpy.NumpyBackend):
 
 class TensorflowCustomBackend(TensorflowBackend):
 
+    description = "Uses precompiled primitives to apply gates to states. " \
+                  "This is the fastest simulation engine."
+
     def __init__(self):
         from qibo.tensorflow import custom_operators as op
         if not op._custom_operators_loaded: # pragma: no cover
@@ -234,6 +239,9 @@ class TensorflowCustomBackend(TensorflowBackend):
 
 class TensorflowDefaultEinsumBackend(TensorflowBackend):
 
+    description = "Uses `tf.einsum` to apply gates to states via matrix " \
+                  "multiplication."
+
     def __init__(self):
         super().__init__()
         self.name = "tensorflow_defaulteinsum"
@@ -242,6 +250,9 @@ class TensorflowDefaultEinsumBackend(TensorflowBackend):
 
 
 class TensorflowMatmulEinsumBackend(TensorflowBackend):
+
+    description = "Uses `tf.matmul` as well as transpositions and reshapes " \
+                  "to apply gates to states via matrix multiplication."
 
     def __init__(self):
         super().__init__()

--- a/src/qibo/backends/tensorflow.py
+++ b/src/qibo/backends/tensorflow.py
@@ -193,8 +193,11 @@ class TensorflowCustomBackend(TensorflowBackend):
 
     def __init__(self):
         from qibo.tensorflow import custom_operators as op
-        if not op._custom_operators_loaded:
-            raise_error(RuntimeError)
+        if not op._custom_operators_loaded: # pragma: no cover
+            # CI can compile custom operators so this case is not tested
+            raise_error(RuntimeError, "Cannot initialize Tensorflow custom "
+                                      "backend if custom operators are not "
+                                      "compiled.")
 
         super().__init__()
         self.name = "custom"

--- a/src/qibo/backends/tensorflow.py
+++ b/src/qibo/backends/tensorflow.py
@@ -1,6 +1,6 @@
 import os
 from qibo.backends import abstract, numpy
-from qibo.config import raise_error, LOG_LEVEL
+from qibo.config import raise_error, log, LOG_LEVEL
 
 
 class Optimization:
@@ -42,11 +42,6 @@ class TensorflowBackend(numpy.NumpyBackend):
         from tensorflow.python.framework import errors_impl # pylint: disable=E0611
         self.oom_error = errors_impl.ResourceExhaustedError
         self.optimization = Optimization()
-
-        from qibo.tensorflow import custom_operators as op
-        self.op = None
-        if op._custom_operators_loaded:
-            self.op = op
 
         # seed to use in the measurement frequency custom op
         self._seed = None
@@ -145,29 +140,18 @@ class TensorflowBackend(numpy.NumpyBackend):
     def gather_nd(self, x, indices):
         return self.backend.gather_nd(x, indices)
 
-    def initial_state(self, nqubits, is_matrix=False):
-        if self.op is None: # pragma: no cover
-            dim = 1 + is_matrix
-            shape = dim * (2 ** nqubits,)
-            idx = self.backend.constant([dim * [0]], dtype=self.dtypes('DTYPEINT'))
-            state = self.backend.zeros(shape, dtype=self.dtypes('DTYPECPX'))
-            update = self.backend.constant([1], dtype=self.dtypes('DTYPECPX'))
-            state = self.backend.tensor_scatter_nd_update(state, idx, update)
-            return state
-        else:
-            from qibo.config import get_threads
-            return self.op.initial_state(nqubits, self.dtypes('DTYPECPX'),
-                                        is_matrix=is_matrix,
-                                        omp_num_threads=get_threads())
+    def initial_state(self, nqubits, is_matrix=False): # pragma: no cover
+        dim = 1 + is_matrix
+        shape = dim * (2 ** nqubits,)
+        idx = self.backend.constant([dim * [0]], dtype=self.dtypes('DTYPEINT'))
+        state = self.backend.zeros(shape, dtype=self.dtypes('DTYPECPX'))
+        update = self.backend.constant([1], dtype=self.dtypes('DTYPECPX'))
+        state = self.backend.tensor_scatter_nd_update(state, idx, update)
+        return state
 
-    def transpose_state(self, pieces, state, nqubits, order):
-        if self.op is None: # pragma: no cover
-            pieces = self.reshape(self.backend.stack(pieces), nqubits * (2,))
-            return self.reshape(self.transpose(pieces, order), state.shape)
-        else:
-            from qibo.config import get_threads
-            return self.op.transpose_state(pieces, state, nqubits, order,
-                                           get_threads())
+    def transpose_state(self, pieces, state, nqubits, order): # pragma: no cover
+        pieces = self.reshape(self.backend.stack(pieces), nqubits * (2,))
+        return self.reshape(self.transpose(pieces, order), state.shape)
 
     def random_uniform(self, shape, dtype='DTYPE'):
         return self.backend.random.uniform(shape, dtype=self.dtypes(dtype))
@@ -184,24 +168,11 @@ class TensorflowBackend(numpy.NumpyBackend):
         return self.concatenate(samples, axis=0)
 
     def sample_frequencies(self, probs, nshots):
-        from qibo.config import SHOT_CUSTOM_OP_THREASHOLD
-        if self.op is None or nshots < SHOT_CUSTOM_OP_THREASHOLD:
-            logits = self.log(probs)[self.newaxis]
-            samples = self.random.categorical(logits, nshots, dtype=self.dtypes('DTYPEINT'))[0]
-            res, counts = self.unique(samples, return_counts=True)
-            frequencies = self.zeros(int(probs.shape[0]), dtype=self.dtypes('DTYPEINT'))
-            frequencies = self.backend.tensor_scatter_nd_add(frequencies, res[:, self.newaxis], counts)
-        else:
-            from qibo.config import get_threads
-            # Generate random seed using tf
-            dtype = self.dtypes('DTYPEINT')
-            seed = self.backend.random.uniform(
-                shape=tuple(), maxval=int(1e8), dtype=dtype)
-            nqubits = int(self.np.log2(tuple(probs.shape)[0]))
-            shape = self.cast(2 ** nqubits, dtype='DTYPEINT')
-            frequencies = self.zeros(shape, dtype='DTYPEINT')
-            frequencies = self.op.measure_frequencies(
-                frequencies, probs, nshots, nqubits, seed, get_threads())
+        logits = self.log(probs)[self.newaxis]
+        samples = self.random.categorical(logits, nshots, dtype=self.dtypes('DTYPEINT'))[0]
+        res, counts = self.unique(samples, return_counts=True)
+        frequencies = self.zeros(int(probs.shape[0]), dtype=self.dtypes('DTYPEINT'))
+        frequencies = self.backend.tensor_scatter_nd_add(frequencies, res[:, self.newaxis], counts)
         return frequencies
 
     def compile(self, func):
@@ -216,3 +187,61 @@ class TensorflowBackend(numpy.NumpyBackend):
     def set_seed(self, seed):
         self._seed = seed
         self.backend.random.set_seed(seed)
+
+
+class TensorflowCustomBackend(TensorflowBackend):
+
+    def __init__(self):
+        from qibo.tensorflow import custom_operators as op
+        if not op._custom_operators_loaded:
+            raise_error(RuntimeError)
+
+        super().__init__()
+        self.name = "custom"
+        self.custom_gates = True
+        self.custom_einsum = None
+        self.op = op
+        from qibo.config import get_threads
+        self.get_threads = get_threads
+
+    def initial_state(self, nqubits, is_matrix=False):
+        return self.op.initial_state(nqubits, self.dtypes('DTYPECPX'),
+                                    is_matrix=is_matrix,
+                                    omp_num_threads=self.get_threads())
+
+    def transpose_state(self, pieces, state, nqubits, order):
+        return self.op.transpose_state(pieces, state, nqubits, order,
+                                       self.get_threads())
+
+    def sample_frequencies(self, probs, nshots):
+        from qibo.config import SHOT_CUSTOM_OP_THREASHOLD
+        if nshots < SHOT_CUSTOM_OP_THREASHOLD:
+            return super().sample_frequencies(probs, nshots)
+        # Generate random seed using tf
+        dtype = self.dtypes('DTYPEINT')
+        seed = self.backend.random.uniform(
+            shape=tuple(), maxval=int(1e8), dtype=dtype)
+        nqubits = int(self.np.log2(tuple(probs.shape)[0]))
+        shape = self.cast(2 ** nqubits, dtype='DTYPEINT')
+        frequencies = self.zeros(shape, dtype='DTYPEINT')
+        frequencies = self.op.measure_frequencies(
+            frequencies, probs, nshots, nqubits, seed, self.get_threads())
+        return frequencies
+
+
+class TensorflowDefaultEinsumBackend(TensorflowBackend):
+
+    def __init__(self):
+        super().__init__()
+        self.name = "tensorflow_defaulteinsum"
+        self.custom_gates = False
+        self.custom_einsum = "DefaultEinsum"
+
+
+class TensorflowMatmulEinsumBackend(TensorflowBackend):
+
+    def __init__(self):
+        super().__init__()
+        self.name = "tensorflow_matmuleinsum"
+        self.custom_gates = False
+        self.custom_einsum = "MatmulEinsum"

--- a/src/qibo/core/states.py
+++ b/src/qibo/core/states.py
@@ -19,13 +19,10 @@ class VectorState(AbstractState):
         if not isinstance(x, K.tensor_types):
             raise_error(TypeError, "Initial state type {} is not recognized."
                                     "".format(type(x)))
-        try:
-            shape = tuple(x.shape)
-            if self._nqubits is None:
-                self.nqubits = int(K.np.log2(shape[0]))
-        except ValueError: # happens when using TensorFlow compiled mode
-            shape = None
-        if shape is not None and shape != self.shape:
+        shape = tuple(x.shape)
+        if self._nqubits is None:
+            self.nqubits = int(K.np.log2(shape[0]))
+        if shape != self.shape:
             raise_error(ValueError, "Invalid tensor shape {} for state of {} "
                                     "qubits.".format(shape, self.nqubits))
         self._tensor = K.cast(x)

--- a/src/qibo/tests/conftest.py
+++ b/src/qibo/tests/conftest.py
@@ -25,9 +25,9 @@ def pytest_configure(config):
 
 
 def pytest_generate_tests(metafunc):
-    from qibo.backends import AVAILABLE_BACKENDS
+    from qibo import K
     if "accelerators" in metafunc.fixturenames:
-        if "custom" in AVAILABLE_BACKENDS:
+        if "custom" in K.available_backends:
             accelerators = [None, {"/GPU:0": 1, "/GPU:1": 1}]
         else: # pragma: no cover
             accelerators = [None]
@@ -35,14 +35,14 @@ def pytest_generate_tests(metafunc):
 
     if "backend" in metafunc.fixturenames:
         backends = ["custom", "defaulteinsum", "matmuleinsum"]
-        if "custom" not in AVAILABLE_BACKENDS: # pragma: no cover
+        if "custom" not in K.available_backends: # pragma: no cover
             backends.remove("custom")
         metafunc.parametrize("backend", backends)
 
     # skip distributed tests if "custom" backend is not available
     module_name = "qibo.tests.test_distributed"
     if metafunc.module.__name__ == module_name:
-        if "custom" not in AVAILABLE_BACKENDS: # pragma: no cover
+        if "custom" not in K.available_backends: # pragma: no cover
             pytest.skip("Distributed circuits require custom operators.")
 
     # skip parallel tests on Windows

--- a/src/qibo/tests/test_variational.py
+++ b/src/qibo/tests/test_variational.py
@@ -115,8 +115,7 @@ def test_vqe(method, options, compile, filename):
 def test_vqe_custom_gates_errors():
     """Check that ``RuntimeError``s is raised when using custom gates."""
     import qibo
-    from qibo.backends import AVAILABLE_BACKENDS
-    if "custom" not in AVAILABLE_BACKENDS: # pragma: no cover
+    if "custom" not in qibo.K.available_backends: # pragma: no cover
         pytest.skip("Custom backend not available.")
 
     original_backend = qibo.get_backend()

--- a/src/qibo/tests_new/test_backends_agreement.py
+++ b/src/qibo/tests_new/test_backends_agreement.py
@@ -1,6 +1,6 @@
 import pytest
 import numpy as np
-from qibo import backends
+from qibo import K
 from numpy.random import random as rand
 
 
@@ -53,8 +53,8 @@ METHODS = [
 ]
 @pytest.mark.parametrize("method,kwargs", METHODS)
 def test_backend_methods(tested_backend, target_backend, method, kwargs):
-    tested_backend = backends._construct_backend(tested_backend)
-    target_backend = backends._construct_backend(target_backend)
+    tested_backend = K.construct_backend(tested_backend)
+    target_backend = K.construct_backend(target_backend)
     tested_func = getattr(tested_backend, method)
     target_func = getattr(target_backend, method)
     if isinstance(kwargs, dict):
@@ -68,8 +68,8 @@ def test_backend_methods(tested_backend, target_backend, method, kwargs):
 
 
 def test_backend_eigh(tested_backend, target_backend):
-    tested_backend = backends._construct_backend(tested_backend)
-    target_backend = backends._construct_backend(target_backend)
+    tested_backend = K.construct_backend(tested_backend)
+    target_backend = K.construct_backend(target_backend)
     m = rand((5, 5))
     eigvals1, eigvecs1 = tested_backend.eigh(m)
     eigvals2, eigvecs2 = target_backend.eigh(m)
@@ -78,8 +78,8 @@ def test_backend_eigh(tested_backend, target_backend):
 
 
 def test_backend_compile(tested_backend, target_backend):
-    tested_backend = backends._construct_backend(tested_backend)
-    target_backend = backends._construct_backend(target_backend)
+    tested_backend = K.construct_backend(tested_backend)
+    target_backend = K.construct_backend(target_backend)
     func = lambda x: x + 1
     x = rand(5)
     cfunc1 = tested_backend.compile(func)
@@ -88,8 +88,8 @@ def test_backend_compile(tested_backend, target_backend):
 
 
 def test_backend_gather(tested_backend, target_backend):
-    tested_backend = backends._construct_backend(tested_backend)
-    target_backend = backends._construct_backend(target_backend)
+    tested_backend = K.construct_backend(tested_backend)
+    target_backend = K.construct_backend(target_backend)
     x = rand(5)
     target_result = target_backend.gather(x, indices=[0, 1, 3])
     test_result = tested_backend.gather(x, indices=[0, 1, 3])
@@ -111,8 +111,8 @@ def test_backend_gather(tested_backend, target_backend):
 
 @pytest.mark.parametrize("return_counts", [False, True])
 def test_backend_unique(tested_backend, target_backend, return_counts):
-    tested_backend = backends._construct_backend(tested_backend)
-    target_backend = backends._construct_backend(target_backend)
+    tested_backend = K.construct_backend(tested_backend)
+    target_backend = K.construct_backend(target_backend)
     x = np.random.randint(10, size=(10,))
     target_result = target_backend.unique(x, return_counts=return_counts)
     test_result = tested_backend.unique(x, return_counts=return_counts)

--- a/src/qibo/tests_new/test_backends_agreement.py
+++ b/src/qibo/tests_new/test_backends_agreement.py
@@ -60,7 +60,7 @@ def test_backend_methods(tested_backend, target_backend, method, kwargs):
     if isinstance(kwargs, dict):
         np.testing.assert_allclose(tested_func(**kwargs), target_func(**kwargs))
     else:
-        if method in {"kron", "inv"} and tested_backend.name == "tensorflow":
+        if method in {"kron", "inv"} and "numpy" not in tested_backend.name:
             with pytest.raises(NotImplementedError):
                 tested_func(*kwargs)
         else:

--- a/src/qibo/tests_new/test_backends_init.py
+++ b/src/qibo/tests_new/test_backends_init.py
@@ -16,6 +16,15 @@ def test_set_backend(backend):
     """Check ``set_backend`` for switching gate backends."""
     original_backend = backends.get_backend()
     backends.set_backend(backend)
+    if backend == "defaulteinsum":
+        target_name = "tensorflow_defaulteinsum"
+    elif backend == "matmuleinsum":
+        target_name = "tensorflow_matmuleinsum"
+    else:
+        target_name = backend
+    assert K.name == target_name
+    assert str(K) == target_name
+
     if backend == "custom":
         assert K.custom_gates
         assert K.custom_einsum is None

--- a/src/qibo/tests_new/test_backends_init.py
+++ b/src/qibo/tests_new/test_backends_init.py
@@ -2,9 +2,12 @@ import pytest
 from qibo import K, backends, models, gates
 
 
-def test_construct_backend(engine):
-    backend = backends._construct_backend(engine)
-    assert backend.name == engine
+def test_construct_backend(backend):
+    bk = backends._construct_backend(backend)
+    try:
+        assert bk.name == backend
+    except AssertionError:
+        assert bk.name.split("_")[-1] == backend
     with pytest.raises(ValueError):
         bk = backends._construct_backend("test")
 
@@ -13,13 +16,6 @@ def test_set_backend(backend):
     """Check ``set_backend`` for switching gate backends."""
     original_backend = backends.get_backend()
     backends.set_backend(backend)
-    assert backends.get_backend() == backend
-
-    target_name = "numpy" if "numpy" in backend else "tensorflow"
-    assert K.name == target_name
-    assert str(K) == target_name
-    assert K.__repr__() == "{}Backend".format(target_name.capitalize())
-
     if backend == "custom":
         assert K.custom_gates
         assert K.custom_einsum is None

--- a/src/qibo/tests_new/test_backends_init.py
+++ b/src/qibo/tests_new/test_backends_init.py
@@ -24,6 +24,7 @@ def test_set_backend(backend):
         target_name = backend
     assert K.name == target_name
     assert str(K) == target_name
+    assert K.executing_eagerly()
 
     if backend == "custom":
         assert K.custom_gates

--- a/src/qibo/tests_new/test_backends_init.py
+++ b/src/qibo/tests_new/test_backends_init.py
@@ -24,6 +24,7 @@ def test_set_backend(backend):
         target_name = backend
     assert K.name == target_name
     assert str(K) == target_name
+    assert repr(K) == target_name
     assert K.executing_eagerly()
 
     if backend == "custom":
@@ -100,14 +101,17 @@ def test_set_precision_matrices(backend, precision):
     backends.set_backend(original_backend)
 
 
-def test_set_precision_errors():
+def test_set_precision_errors(backend):
+    original_backend = backends.get_backend()
     original_precision = backends.get_precision()
+    backends.set_backend(backend)
     gate = gates.H(0)
     with pytest.warns(RuntimeWarning):
         backends.set_precision("single")
     with pytest.raises(ValueError):
         backends.set_precision("test")
     backends.set_precision(original_precision)
+    backends.set_backend(original_backend)
 
 
 def test_set_device(backend):
@@ -119,6 +123,7 @@ def test_set_device(backend):
             backends.set_device("/CPU:0")
     else:
         backends.set_device("/CPU:0")
+        assert backends.get_device() == "/CPU:0"
         with pytest.raises(ValueError):
             backends.set_device("test")
         with pytest.raises(ValueError):

--- a/src/qibo/tests_new/test_backends_init.py
+++ b/src/qibo/tests_new/test_backends_init.py
@@ -53,7 +53,7 @@ def test_set_backend_errors():
         backends.set_backend("numpy_badgates")
     h = gates.H(0)
     with pytest.warns(RuntimeWarning):
-        backends.set_backend("numpy_defaulteinsum")
+        backends.set_backend("numpy_matmuleinsum")
     backends.set_backend(original_backend)
 
 

--- a/src/qibo/tests_new/test_backends_init.py
+++ b/src/qibo/tests_new/test_backends_init.py
@@ -3,13 +3,13 @@ from qibo import K, backends, models, gates
 
 
 def test_construct_backend(backend):
-    bk = backends._construct_backend(backend)
+    bk = K.construct_backend(backend)
     try:
         assert bk.name == backend
     except AssertionError:
         assert bk.name.split("_")[-1] == backend
     with pytest.raises(ValueError):
-        bk = backends._construct_backend("test")
+        bk = K.construct_backend("test")
 
 
 def test_set_backend(backend):

--- a/src/qibo/tests_new/test_core_circuit_backpropagation.py
+++ b/src/qibo/tests_new/test_core_circuit_backpropagation.py
@@ -11,7 +11,7 @@ def test_variable_backpropagation(backend):
         pytest.skip("Custom gates do not support automatic differentiation.")
     original_backend = qibo.get_backend()
     qibo.set_backend(backend)
-    if K.name != "tensorflow":
+    if "numpy" in K.name:
         qibo.set_backend(original_backend)
         pytest.skip("Backpropagation is not supported by {}.".format(K.name))
 
@@ -38,7 +38,7 @@ def test_two_variables_backpropagation(backend):
         pytest.skip("Custom gates do not support automatic differentiation.")
     original_backend = qibo.get_backend()
     qibo.set_backend(backend)
-    if K.name != "tensorflow":
+    if "numpy" in K.name:
         qibo.set_backend(original_backend)
         pytest.skip("Backpropagation is not supported by {}.".format(K.name))
 

--- a/src/qibo/tests_new/test_measurement_gate_collapse.py
+++ b/src/qibo/tests_new/test_measurement_gate_collapse.py
@@ -73,12 +73,12 @@ def test_measurement_collapse_bitflip_noise(backend, accelerators):
     c = models.Circuit(4, accelerators)
     output = c.add(gates.M(0, 1, p0=0.2, collapse=True))
     result = c(nshots=20)
-    if K.name == "tensorflow":
-        target_samples = [2, 2, 2, 1, 1, 0, 1, 2, 1, 2, 2, 3, 3, 0, 3,
-                          0, 0, 3, 0, 1]
-    elif K.name == "numpy":
+    if "numpy" in K.name:
         target_samples = [3, 3, 0, 3, 2, 0, 1, 2, 2, 2, 2, 0, 0, 2, 0,
                           2, 3, 1, 1, 0]
+    else:
+        target_samples = [2, 2, 2, 1, 1, 0, 1, 2, 1, 2, 2, 3, 3, 0, 3,
+                          0, 0, 3, 0, 1]
     np.testing.assert_allclose(output.samples(binary=False), target_samples)
     _, target_frequencies = np.unique(target_samples, return_counts=True)
     target_frequencies = {i: v for i, v in enumerate(target_frequencies)}

--- a/src/qibo/tests_new/test_measurement_gate_probabilistic.py
+++ b/src/qibo/tests_new/test_measurement_gate_probabilistic.py
@@ -27,14 +27,14 @@ def test_probabilistic_measurement(backend, accelerators, use_samples):
         _ = result.samples()
 
     # update reference values based on backend and device
-    if K.name == "tensorflow":
+    if "numpy" in K.name:
+        decimal_frequencies = {0: 249, 1: 231, 2: 253, 3: 267}
+    else:
         if K.gpu_devices: # pragma: no cover
             # CI does not use GPU
             decimal_frequencies = {0: 273, 1: 233, 2: 242, 3: 252}
         else:
             decimal_frequencies = {0: 271, 1: 239, 2: 242, 3: 248}
-    elif K.name == "numpy":
-        decimal_frequencies = {0: 249, 1: 231, 2: 253, 3: 267}
     assert sum(result.frequencies().values()) == 1000
     assert_result(result, decimal_frequencies=decimal_frequencies)
     qibo.set_backend(original_backend)
@@ -60,14 +60,14 @@ def test_unbalanced_probabilistic_measurement(backend, use_samples):
         # otherwise it uses the frequency-only calculation
         _ = result.samples()
     # update reference values based on backend and device
-    if K.name == "tensorflow":
+    if "numpy" in K.name:
+        decimal_frequencies = {0: 171, 1: 148, 2: 161, 3: 520}
+    else:
         if K.gpu_devices: # pragma: no cover
             # CI does not use GPU
             decimal_frequencies = {0: 196, 1: 153, 2: 156, 3: 495}
         else:
             decimal_frequencies = {0: 168, 1: 188, 2: 154, 3: 490}
-    elif K.name == "numpy":
-        decimal_frequencies = {0: 171, 1: 148, 2: 161, 3: 520}
     assert sum(result.frequencies().values()) == 1000
     assert_result(result, decimal_frequencies=decimal_frequencies)
     qibo.set_backend(original_backend)
@@ -118,12 +118,12 @@ def test_post_measurement_bitflips_on_circuit(backend, accelerators, i, probs):
     c.add(gates.M(0, 1, p0={0: probs[0], 1: probs[1]}))
     c.add(gates.M(3, p0=probs[2]))
     result = c(nshots=30).frequencies(binary=False)
-    if K.name == "tensorflow":
-        targets = [{5: 30}, {5: 16, 7: 10, 6: 2, 3: 1, 4: 1},
-                   {3: 6, 5: 6, 7: 5, 2: 4, 4: 3, 0: 2, 1: 2, 6: 2}]
-    elif K.name == "numpy":
+    if "numpy" in K.name:
         targets = [{5: 30}, {5: 18, 4: 5, 7: 4, 1: 2, 6: 1},
                    {4: 8, 2: 6, 5: 5, 1: 3, 3: 3, 6: 2, 7: 2, 0: 1}]
+    else:
+        targets = [{5: 30}, {5: 16, 7: 10, 6: 2, 3: 1, 4: 1},
+                   {3: 6, 5: 6, 7: 5, 2: 4, 4: 3, 0: 2, 1: 2, 6: 2}]
     assert result == targets[i]
     qibo.set_backend(original_backend)
 


### PR DESCRIPTION
Simplifies the backend switching mechanism by creating a seperate backend class for each of the einsum backends. For example currently we have a single `NumpyBackend` class that handles both `numpy_defaulteinsum` and `numpy_matmuleinsum`. In this PR I seperate the backends by create different classes `NumpyDefaultEinsumBackend` and  `NumpyMatmulEinsumBackend`. I believe this allows a cleaner switching function and may be easier to maintain if we add more backends either for simulation or hardware.

There is no change from the user perspective, that is the user can still switch the backends using `qibo.set_backend("custom")`, `qibo.set_backend("defaulteinsum")`, `qibo.set_backend("numpy_defaulteinsum")`, etc..