### PR TITLE
Fix CPU custom operators for more than 32 qubits

### DIFF
--- a/src/qibo/tensorflow/custom_operators/cc/kernels/apply_gate_kernels.cc
+++ b/src/qibo/tensorflow/custom_operators/cc/kernels/apply_gate_kernels.cc
@@ -37,15 +37,15 @@ struct BaseOneQubitGateFunctor<CPUDevice, T> {
     // Apply gate
     if (ncontrols == 0) {
       #pragma omp parallel for
-      for (long g = 0; g < nstates; g += 1) {
-        long i = ((int64)((int64)g >> m) << (m + 1)) + (g & (tk - 1));
+      for (int64 g = 0; g < nstates; g += 1) {
+        int64 i = ((int64)((int64)g >> m) << (m + 1)) + (g & (tk - 1));
         apply(state[i], state[i + tk], gate);
       }
     } else {
       const int N = ncontrols + 1;
       #pragma omp parallel for
-      for (long g = 0; g < nstates; g += 1) {
-        long i = g;
+      for (int64 g = 0; g < nstates; g += 1) {
+        int64 i = g;
         for (auto iq = 0; iq < N; iq++) {
           const auto n = qubits[iq];
           int64 k = (int64)1 << n;
@@ -125,16 +125,16 @@ struct BaseTwoQubitGateFunctor<CPUDevice, T> {
 
     if (ncontrols == 0) {
       #pragma omp parallel for
-      for (long g = 0; g < nstates; g += 1) {
-        long i = ((int64)((int64)g >> m1) << (m1 + 1)) + (g & (tk1 - 1));
+      for (int64 g = 0; g < nstates; g += 1) {
+        int64 i = ((int64)((int64)g >> m1) << (m1 + 1)) + (g & (tk1 - 1));
         i = ((int64)((int64)i >> m2) << (m2 + 1)) + (i & (tk2 - 1));
         apply(state, i, targetk1, targetk2, gate);
       }
     } else {
       const int N = ncontrols + 2;
       #pragma omp parallel for
-      for (long g = 0; g < nstates; g += 1) {
-        long i = g;
+      for (int64 g = 0; g < nstates; g += 1) {
+        int64 i = g;
         for (auto iq = 0; iq < N; iq++) {
           const auto m = qubits[iq];
           int64 k = (int64)1 << m;
@@ -217,8 +217,8 @@ struct CollapseStateFunctor<CPUDevice, T, NormType> {
 
     NormType norms = 0;
     #pragma omp parallel for shared(state) reduction(+: norms)
-    for (long g = 0; g < nstates; g++) {
-      for (long h = 0; h < res; h++) {
+    for (int64 g = 0; g < nstates; g++) {
+      for (int64 h = 0; h < res; h++) {
         state[GetIndex(g, h)] = 0;
       }
       auto x = state[GetIndex(g, res)];
@@ -234,7 +234,7 @@ struct CollapseStateFunctor<CPUDevice, T, NormType> {
         x = T(x.real() / norm, x.imag() / norm);
       };
       #pragma omp parallel for
-      for (long g = 0; g < nstates; g++) {
+      for (int64 g = 0; g < nstates; g++) {
         NormalizeComponent(state[GetIndex(g, res)]);
       }
     }

--- a/src/qibo/tensorflow/custom_operators/cc/kernels/apply_gate_kernels.cc
+++ b/src/qibo/tensorflow/custom_operators/cc/kernels/apply_gate_kernels.cc
@@ -37,14 +37,14 @@ struct BaseOneQubitGateFunctor<CPUDevice, T> {
     // Apply gate
     if (ncontrols == 0) {
       #pragma omp parallel for
-      for (auto g = 0; g < nstates; g += 1) {
+      for (int64 g = 0; g < nstates; g += 1) {
         int64 i = ((int64)((int64)g >> m) << (m + 1)) + (g & (tk - 1));
         apply(state[i], state[i + tk], gate);
       }
     } else {
       const int N = ncontrols + 1;
       #pragma omp parallel for
-      for (auto g = 0; g < nstates; g += 1) {
+      for (int64 g = 0; g < nstates; g += 1) {
         int64 i = g;
         for (auto iq = 0; iq < N; iq++) {
           const auto n = qubits[iq];
@@ -125,7 +125,7 @@ struct BaseTwoQubitGateFunctor<CPUDevice, T> {
 
     if (ncontrols == 0) {
       #pragma omp parallel for
-      for (auto g = 0; g < nstates; g += 1) {
+      for (int64 g = 0; g < nstates; g += 1) {
         int64 i = ((int64)((int64)g >> m1) << (m1 + 1)) + (g & (tk1 - 1));
         i = ((int64)((int64)i >> m2) << (m2 + 1)) + (i & (tk2 - 1));
         apply(state, i, targetk1, targetk2, gate);
@@ -133,7 +133,7 @@ struct BaseTwoQubitGateFunctor<CPUDevice, T> {
     } else {
       const int N = ncontrols + 2;
       #pragma omp parallel for
-      for (auto g = 0; g < nstates; g += 1) {
+      for (int64 g = 0; g < nstates; g += 1) {
         int64 i = g;
         for (auto iq = 0; iq < N; iq++) {
           const auto m = qubits[iq];
@@ -234,7 +234,7 @@ struct CollapseStateFunctor<CPUDevice, T, NormType> {
         x = T(x.real() / norm, x.imag() / norm);
       };
       #pragma omp parallel for
-      for (auto g = 0; g < nstates; g++) {
+      for (int64 g = 0; g < nstates; g++) {
         NormalizeComponent(state[GetIndex(g, res)]);
       }
     }

--- a/src/qibo/tensorflow/custom_operators/cc/kernels/apply_gate_kernels.cc
+++ b/src/qibo/tensorflow/custom_operators/cc/kernels/apply_gate_kernels.cc
@@ -37,15 +37,15 @@ struct BaseOneQubitGateFunctor<CPUDevice, T> {
     // Apply gate
     if (ncontrols == 0) {
       #pragma omp parallel for
-      for (int64 g = 0; g < nstates; g += 1) {
-        int64 i = ((int64)((int64)g >> m) << (m + 1)) + (g & (tk - 1));
+      for (long g = 0; g < nstates; g += 1) {
+        long i = ((int64)((int64)g >> m) << (m + 1)) + (g & (tk - 1));
         apply(state[i], state[i + tk], gate);
       }
     } else {
       const int N = ncontrols + 1;
       #pragma omp parallel for
-      for (int64 g = 0; g < nstates; g += 1) {
-        int64 i = g;
+      for (long g = 0; g < nstates; g += 1) {
+        long i = g;
         for (auto iq = 0; iq < N; iq++) {
           const auto n = qubits[iq];
           int64 k = (int64)1 << n;
@@ -125,16 +125,16 @@ struct BaseTwoQubitGateFunctor<CPUDevice, T> {
 
     if (ncontrols == 0) {
       #pragma omp parallel for
-      for (int64 g = 0; g < nstates; g += 1) {
-        int64 i = ((int64)((int64)g >> m1) << (m1 + 1)) + (g & (tk1 - 1));
+      for (long g = 0; g < nstates; g += 1) {
+        long i = ((int64)((int64)g >> m1) << (m1 + 1)) + (g & (tk1 - 1));
         i = ((int64)((int64)i >> m2) << (m2 + 1)) + (i & (tk2 - 1));
         apply(state, i, targetk1, targetk2, gate);
       }
     } else {
       const int N = ncontrols + 2;
       #pragma omp parallel for
-      for (int64 g = 0; g < nstates; g += 1) {
-        int64 i = g;
+      for (long g = 0; g < nstates; g += 1) {
+        long i = g;
         for (auto iq = 0; iq < N; iq++) {
           const auto m = qubits[iq];
           int64 k = (int64)1 << m;
@@ -217,8 +217,8 @@ struct CollapseStateFunctor<CPUDevice, T, NormType> {
 
     NormType norms = 0;
     #pragma omp parallel for shared(state) reduction(+: norms)
-    for (auto g = 0; g < nstates; g++) {
-      for (auto h = 0; h < res; h++) {
+    for (long g = 0; g < nstates; g++) {
+      for (long h = 0; h < res; h++) {
         state[GetIndex(g, h)] = 0;
       }
       auto x = state[GetIndex(g, res)];
@@ -234,7 +234,7 @@ struct CollapseStateFunctor<CPUDevice, T, NormType> {
         x = T(x.real() / norm, x.imag() / norm);
       };
       #pragma omp parallel for
-      for (int64 g = 0; g < nstates; g++) {
+      for (long g = 0; g < nstates; g++) {
         NormalizeComponent(state[GetIndex(g, res)]);
       }
     }

--- a/src/qibo/tensorflow/custom_operators/cc/kernels/transpose_state.cc
+++ b/src/qibo/tensorflow/custom_operators/cc/kernels/transpose_state.cc
@@ -21,7 +21,7 @@ struct TransposeStateFunctor<CPUDevice, T> {
     }
 
     #pragma omp parallel for
-    for (auto g = 0; g < nstates; g++) {
+    for (int64 g = 0; g < nstates; g++) {
       int64 k = 0;
       for (int q = 0; q < nqubits; q++) {
         if ((g >> q) % 2) k += qubit_exponents[q];
@@ -41,7 +41,7 @@ struct SwapPiecesFunctor<CPUDevice, T> {
     const int64 nstates = (int64)1 << (nqubits - 1);
 
     #pragma omp parallel for
-    for (auto g = 0; g < nstates; g++) {
+    for (int64 g = 0; g < nstates; g++) {
       int64 i = ((int64)((int64)g >> m) << (m + 1)) + (g & (tk - 1));
       std::swap(piece0[i + tk], piece1[i]);
     }


### PR DESCRIPTION
Based on the answer of [https://stackoverflow.com/questions/31465893/using-unsigned-long-long-as-iteration-range-in-for-loop-using-openmp](https://stackoverflow.com/questions/31465893/using-unsigned-long-long-as-iteration-range-in-for-loop-using-openmp), I think OpenMP doesn't like the `auto` option in parallelized for loops when this refers to an int64 integer.

Here I replace `auto` with `long` and this seems to fix the issue of not applying gates on CPU for more than 32 qubits.