### PR TITLE
removing undesired prints

### DIFF
--- a/src/qibo/core/gates.py
+++ b/src/qibo/core/gates.py
@@ -327,16 +327,12 @@ class RZ(MatrixGate, abstract_gates.RZ):
         abstract_gates.RZ.__init__(self, q, theta, trainable)
 
     def construct_unitary(self):
-        print(self.parameters)
         if isinstance(self.parameters, K.native_types): # pragma: no cover
             p = K
             theta = K.cast(self.parameters)
-            print(theta)
         else:
             p = K.qnp
             theta = self.parameters
-        print(theta)
-        print(p)
         phase = p.exp(1j * theta / 2.0)
         return K.cast(p.diag([p.conj(phase), phase]))
 

--- a/src/qibo/tests_new/test_tensorflow_custom_operators.py
+++ b/src/qibo/tests_new/test_tensorflow_custom_operators.py
@@ -327,7 +327,6 @@ def test_collapse_state(nqubits, targets, results, dtype):
     b2d = 2 ** np.arange(len(results) - 1, -1, -1)
     result = np.array(results).dot(b2d)
     state = K.op.collapse_state(state, qubits, result, nqubits)
-    print((np.abs(state.numpy()) ** 2).sum())
     np.testing.assert_allclose(state, target_state, atol=atol)
 
 


### PR DESCRIPTION
Closes #386. I don't think there is some simple way to catch prints from pytest but let me know.