### PR TITLE
Make matrices backend agnostic

### DIFF
--- a/src/qibo/backends/abstract.py
+++ b/src/qibo/backends/abstract.py
@@ -16,7 +16,7 @@ class AbstractBackend(ABC):
         self.gpu_devices = []
         self.default_device = None
 
-        self.matrices = None
+        self._matrices = None
         self.numeric_types = None
         self.tensor_types = None
         self.native_types = None
@@ -43,8 +43,6 @@ class AbstractBackend(ABC):
         else:
             raise_error(ValueError, f'dtype {dtype} not supported.')
         self.precision = dtype
-        if self.matrices is not None:
-            self.matrices.dtype = self.dtypes('DTYPECPX')
 
     def set_device(self, name):
         parts = name[1:].split(":")
@@ -79,6 +77,13 @@ class AbstractBackend(ABC):
             log.warn("Falling back to CPU because the GPU is out-of-memory.")
             with self.device(self.get_cpu()):
                 return func(*args)
+
+    @property
+    def matrices(self):
+        if self._matrices is None:
+            from qibo.backends.matrices import Matrices
+            self._matrices = Matrices(self)
+        return self._matrices
 
     @abstractmethod
     def cast(self, x, dtype='DTYPECPX'): # pragma: no cover

--- a/src/qibo/backends/matrices.py
+++ b/src/qibo/backends/matrices.py
@@ -1,12 +1,12 @@
 import numpy as np
 
 
-class NumpyMatrices:
+class Matrices:
 
     _NAMES = ["I", "H", "X", "Y", "Z", "CNOT", "CZ", "SWAP", "TOFFOLI"]
 
-    def __init__(self, dtype):
-        self._dtype = dtype
+    def __init__(self, backend):
+        self.backend = backend
         self._I = None
         self._H = None
         self._X = None
@@ -22,16 +22,9 @@ class NumpyMatrices:
         for name in self._NAMES:
             getattr(self, f"_set{name}")()
 
-    def cast(self, x):
-        return x.astype(self.dtype)
-
     @property
     def dtype(self):
-        return self._dtype
-
-    @dtype.setter
-    def dtype(self, dtype):
-        self._dtype = dtype
+        return self.backend._dtypes.get('DTYPECPX')
 
     @property
     def I(self):
@@ -70,69 +63,46 @@ class NumpyMatrices:
         return self._TOFFOLI
 
     def _setI(self):
-        self._I = self.cast(np.eye(2, dtype=self.dtype))
+        self._I = self.backend.cast(np.eye(2, dtype=self.dtype))
 
     def _setH(self):
         m = np.ones((2, 2), dtype=self.dtype)
         m[1, 1] = -1
-        self._H = self.cast(m / np.sqrt(2))
+        self._H = self.backend.cast(m / np.sqrt(2))
 
     def _setX(self):
         m = np.zeros((2, 2), dtype=self.dtype)
         m[0, 1], m[1, 0] = 1, 1
-        self._X = self.cast(m)
+        self._X = self.backend.cast(m)
 
     def _setY(self):
         m = np.zeros((2, 2), dtype=self.dtype)
         m[0, 1], m[1, 0] = -1j, 1j
-        self._Y = self.cast(m)
+        self._Y = self.backend.cast(m)
 
     def _setZ(self):
         m = np.eye(2, dtype=self.dtype)
         m[1, 1] = -1
-        self._Z = self.cast(m)
+        self._Z = self.backend.cast(m)
 
     def _setCNOT(self):
         m = np.eye(4, dtype=self.dtype)
         m[2, 2], m[2, 3] = 0, 1
         m[3, 2], m[3, 3] = 1, 0
-        self._CNOT = self.cast(m)
+        self._CNOT = self.backend.cast(m)
 
     def _setCZ(self):
         m = np.diag([1, 1, 1, -1])
-        self._CZ = self.cast(m)
+        self._CZ = self.backend.cast(m)
 
     def _setSWAP(self):
         m = np.eye(4, dtype=self.dtype)
         m[1, 1], m[1, 2] = 0, 1
         m[2, 1], m[2, 2] = 1, 0
-        self._SWAP = self.cast(m)
+        self._SWAP = self.backend.cast(m)
 
     def _setTOFFOLI(self):
         m = np.eye(8, dtype=self.dtype)
         m[-2, -2], m[-2, -1] = 0, 1
         m[-1, -2], m[-1, -1] = 1, 0
-        self._TOFFOLI = self.cast(m)
-
-
-class TensorflowMatrices(NumpyMatrices):
-
-    def __init__(self, dtype):
-        import tensorflow as tf
-        self.tf = tf
-        self.tftype = dtype
-        if dtype == tf.complex128:
-            super().__init__(np.complex128)
-        elif dtype == tf.complex64:
-            super().__init__(np.complex64)
-
-    @NumpyMatrices.dtype.setter
-    def dtype(self, dtype):
-        self.tftype = dtype
-        if dtype == self.tf.complex128:
-            self._dtype = np.complex128
-        elif dtype == self.tf.complex64:
-            self._dtype = np.complex64
-
-    def cast(self, x):
-        return self.tf.cast(x, dtype=self.tftype)
+        self._TOFFOLI = self.backend.cast(m)

--- a/src/qibo/backends/numpy.py
+++ b/src/qibo/backends/numpy.py
@@ -14,8 +14,6 @@ class NumpyBackend(abstract.AbstractBackend):
         self.name = "numpy"
         self.np = np
 
-        from qibo.backends import matrices
-        self.matrices = matrices.NumpyMatrices(self.dtypes('DTYPECPX'))
         self.numeric_types = (np.int, np.float, np.complex, np.int32,
                               np.int64, np.float32, np.float64,
                               np.complex64, np.complex128)

--- a/src/qibo/backends/tensorflow.py
+++ b/src/qibo/backends/tensorflow.py
@@ -33,9 +33,6 @@ class TensorflowBackend(numpy.NumpyBackend):
             # case not tested by GitHub workflows because it requires no device
             raise_error(RuntimeError, "Unable to find Tensorflow devices.")
 
-        from qibo.backends import matrices
-        self.matrices = matrices.TensorflowMatrices(self.dtypes('DTYPECPX'))
-
         self.tensor_types = (self.np.ndarray, tf.Tensor, tf.Variable)
         self.native_types = (tf.Tensor, tf.Variable)
         self.Tensor = tf.Tensor

--- a/src/qibo/core/hamiltonians.py
+++ b/src/qibo/core/hamiltonians.py
@@ -221,11 +221,13 @@ class SymbolicHamiltonian:
         term_dict = self.symbolic.as_coefficients_dict()
         self.constant = 0
         if 1 in term_dict:
-            self.constant = self.matrices.dtype(term_dict.pop(1))
+            dtype = getattr(K.np, self.matrices.dtype)
+            self.constant = dtype(term_dict.pop(1))
         self.terms = dict()
         target_ids = set()
         for term, coeff in term_dict.items():
-            targets, matrices = [], [self.matrices.dtype(coeff)]
+            dtype = getattr(K.np, self.matrices.dtype)
+            targets, matrices = [], [dtype(coeff)]
             for factor in term.as_ordered_factors():
                 if factor.is_symbol:
                     self._check_symbolmap(factor)

--- a/src/qibo/tests_new/conftest.py
+++ b/src/qibo/tests_new/conftest.py
@@ -91,10 +91,6 @@ def pytest_generate_tests(metafunc):
         if metafunc.module.__name__ in tests_to_skip:
             pytest.skip("Custom operator tests require Tensorflow engine.")
 
-    # for `test_backends_matrices.py`
-    if "engine" in metafunc.fixturenames:
-        metafunc.parametrize("engine", engines)
-
     # for `test_backends_agreement.py`
     if "tested_backend" in metafunc.fixturenames:
         target = metafunc.config.option.target_backend

--- a/src/qibo/tests_new/test_backends_init.py
+++ b/src/qibo/tests_new/test_backends_init.py
@@ -79,14 +79,14 @@ def test_set_precision_matrices(backend, precision):
     backends.set_backend(backend)
     backends.set_precision(precision)
     if precision == "single":
-        assert matrices.dtype == np.complex64
+        assert matrices.dtype == "complex64"
         assert matrices.H.dtype == np.complex64
-        assert K.matrices.dtype == K.backend.complex64
+        assert K.matrices.dtype == "complex64"
         assert K.matrices.X.dtype == K.backend.complex64
     else:
-        assert matrices.dtype == np.complex128
+        assert matrices.dtype == "complex128"
         assert matrices.H.dtype == np.complex128
-        assert K.matrices.dtype == K.backend.complex128
+        assert K.matrices.dtype == "complex128"
         assert K.matrices.X.dtype == K.backend.complex128
     backends.set_precision(original_precision)
     backends.set_backend(original_backend)

--- a/src/qibo/tests_new/test_backends_matrices.py
+++ b/src/qibo/tests_new/test_backends_matrices.py
@@ -1,44 +1,38 @@
 import pytest
+import qibo
 import numpy as np
-from qibo.backends import matrices
-from qibo.config import raise_error
-
-TARGET_MATRICES = {
-    "I": np.array([[1, 0], [0, 1]]),
-    "H": np.array([[1, 1], [1, -1]]) / np.sqrt(2),
-    "X": np.array([[0, 1], [1, 0]]),
-    "Y": np.array([[0, -1j], [1j, 0]]),
-    "Z": np.array([[1, 0], [0, -1]]),
-    "CNOT": np.array([[1, 0, 0, 0], [0, 1, 0, 0],
-                      [0, 0, 0, 1], [0, 0, 1, 0]]),
-    "CZ": np.array([[1, 0, 0, 0], [0, 1, 0, 0],
-                    [0, 0, 1, 0], [0, 0, 0, -1]]),
-    "SWAP": np.array([[1, 0, 0, 0], [0, 0, 1, 0],
-                      [0, 1, 0, 0], [0, 0, 0, 1]]),
-    "TOFFOLI": np.array([[1, 0, 0, 0, 0, 0, 0, 0],
-                         [0, 1, 0, 0, 0, 0, 0, 0],
-                         [0, 0, 1, 0, 0, 0, 0, 0],
-                         [0, 0, 0, 1, 0, 0, 0, 0],
-                         [0, 0, 0, 0, 1, 0, 0, 0],
-                         [0, 0, 0, 0, 0, 1, 0, 0],
-                         [0, 0, 0, 0, 0, 0, 0, 1],
-                         [0, 0, 0, 0, 0, 0, 1, 0]])
-}
 
 
 @pytest.mark.parametrize("dtype", ["complex64", "complex128"])
-def test_matrices(engine, dtype):
-    if engine == "numpy":
-        mobj = matrices.NumpyMatrices(getattr(np, dtype))
-    elif engine == "tensorflow":
-        import tensorflow as tf
-        mobj = matrices.TensorflowMatrices(getattr(tf, dtype))
-    else: # pragma: no cover
-        # this case exists only for test consistency checking and
-        # should never execute
-        raise_error(ValueError, "Unknown engine {}.".format(engine))
-    for matrixname, target in TARGET_MATRICES.items():
+def test_matrices(backend, dtype):
+    from qibo.backends.matrices import Matrices
+    original_backend = qibo.get_backend()
+    qibo.set_backend(backend)
+    mobj = Matrices(qibo.K)
+    target_matrices = {
+        "I": np.array([[1, 0], [0, 1]]),
+        "H": np.array([[1, 1], [1, -1]]) / np.sqrt(2),
+        "X": np.array([[0, 1], [1, 0]]),
+        "Y": np.array([[0, -1j], [1j, 0]]),
+        "Z": np.array([[1, 0], [0, -1]]),
+        "CNOT": np.array([[1, 0, 0, 0], [0, 1, 0, 0],
+                          [0, 0, 0, 1], [0, 0, 1, 0]]),
+        "CZ": np.array([[1, 0, 0, 0], [0, 1, 0, 0],
+                        [0, 0, 1, 0], [0, 0, 0, -1]]),
+        "SWAP": np.array([[1, 0, 0, 0], [0, 0, 1, 0],
+                          [0, 1, 0, 0], [0, 0, 0, 1]]),
+        "TOFFOLI": np.array([[1, 0, 0, 0, 0, 0, 0, 0],
+                             [0, 1, 0, 0, 0, 0, 0, 0],
+                             [0, 0, 1, 0, 0, 0, 0, 0],
+                             [0, 0, 0, 1, 0, 0, 0, 0],
+                             [0, 0, 0, 0, 1, 0, 0, 0],
+                             [0, 0, 0, 0, 0, 1, 0, 0],
+                             [0, 0, 0, 0, 0, 0, 0, 1],
+                             [0, 0, 0, 0, 0, 0, 1, 0]])
+    }
+    for matrixname, target in target_matrices.items():
         np.testing.assert_allclose(getattr(mobj, matrixname), target)
+    qibo.set_backend(original_backend)
 
 
 def test_modifying_matrices_error():


### PR DESCRIPTION
Simplifies the mechanism that creates `qibo.matrices` so that we don't need a separate matrix class for each backend. Hopefully fixes the issue described in #400.

@scarrazza I opened this PR with master as base because this simplification is independent of qibo_sim but if you prefer I can rebase it for `simtfrename` in order to merge there and check if the pylint issue is fixed.