### PR TITLE
Set test backend in conftest

### DIFF
--- a/src/qibo/tests/test_abstract_circuit_qasm.py
+++ b/src/qibo/tests/test_abstract_circuit_qasm.py
@@ -348,8 +348,6 @@ test q[2];
 
 
 def test_from_qasm_measurements(backend):
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     target = """OPENQASM 2.0;
 include "qelib1.inc";
 qreg q[5];
@@ -366,12 +364,9 @@ measure q[3] -> b[1];"""
     assert isinstance(c.queue[0], gates.X)
     assert isinstance(c.measurement_gate, gates.M)
     assert c.measurement_tuples == {"a": (0, 2, 4), "b": (1, 3)}
-    qibo.set_backend(original_backend)
 
 
 def test_from_qasm_measurements_order(backend):
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     target = """OPENQASM 2.0;
 include "qelib1.inc";
 qreg q[5];
@@ -385,12 +380,9 @@ measure q[0] -> b[0];
 """
     c = Circuit.from_qasm(target)
     assert c.measurement_tuples == {"a": (4, 3, 1), "b": (0, 2)}
-    qibo.set_backend(original_backend)
 
 
 def test_from_qasm_invalid_measurements(backend):
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     # Undefined qubit
     target = """OPENQASM 2.0;
 qreg q[2];
@@ -443,7 +435,6 @@ creg a[2];
 measure q[0] -> a[1] -> a[0];"""
     with pytest.raises(ValueError):
         c = Circuit.from_qasm(target)
-    qibo.set_backend(original_backend)
 
 
 def test_from_qasm_invalid_parametrized_gates():
@@ -481,8 +472,6 @@ rx(0.123)(0.25)(0) q[0];
 
 
 def test_from_qasm_empty_spaces(backend):
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     target = """OPENQASM 2.0; qreg q[2];
 creg a[2]; h q[0];x q[1]; cx q[0], q[1];
 measure q[0] -> a[0];measure q[1]->a[1]"""
@@ -493,4 +482,3 @@ measure q[0] -> a[0];measure q[1]->a[1]"""
     assert isinstance(c.queue[1], gates.X)
     assert isinstance(c.queue[2], gates.CNOT)
     assert c.measurement_tuples == {"a": (0, 1)}
-    qibo.set_backend(original_backend)

--- a/src/qibo/tests/test_backends_init.py
+++ b/src/qibo/tests/test_backends_init.py
@@ -2,23 +2,23 @@ import pytest
 from qibo import K, backends, models, gates
 
 
-def test_construct_backend(backend):
-    bk = K.construct_backend(backend)
-    assert bk.name == backend
+def test_construct_backend(backend_name):
+    bk = K.construct_backend(backend_name)
+    assert bk.name == backend_name
     with pytest.raises(ValueError):
         bk = K.construct_backend("test")
 
 
-def test_set_backend(backend):
+def test_set_backend(backend_name):
     """Check ``set_backend`` for switching gate backends."""
     original_backend = backends.get_backend()
-    backends.set_backend(backend)
-    assert K.name == backend
-    assert str(K) == backend
-    assert repr(K) == backend
+    backends.set_backend(backend_name)
+    assert K.name == backend_name
+    assert str(K) == backend_name
+    assert repr(K) == backend_name
     assert K.executing_eagerly()
     h = gates.H(0)
-    if backend == "qibotf":
+    if backend_name == "qibotf":
         assert h.gate_op
     else:
         assert h.gate_op is None
@@ -38,9 +38,7 @@ def test_set_backend_errors():
 
 @pytest.mark.parametrize("precision", ["single", "double"])
 def test_set_precision(backend, precision):
-    original_backend = backends.get_backend()
     original_precision = backends.get_precision()
-    backends.set_backend(backend)
     backends.set_precision(precision)
     if precision == "single":
         expected_dtype = K.backend.complex64
@@ -54,16 +52,13 @@ def test_set_precision(backend, precision):
     final_state = circuit()
     assert final_state.dtype == expected_dtype
     backends.set_precision(original_precision)
-    backends.set_backend(original_backend)
 
 
 @pytest.mark.parametrize("precision", ["single", "double"])
 def test_set_precision_matrices(backend, precision):
     import numpy as np
     from qibo import matrices
-    original_backend = backends.get_backend()
     original_precision = backends.get_precision()
-    backends.set_backend(backend)
     backends.set_precision(precision)
     if precision == "single":
         assert matrices.dtype == "complex64"
@@ -76,27 +71,21 @@ def test_set_precision_matrices(backend, precision):
         assert K.matrices.dtype == "complex128"
         assert K.matrices.X.dtype == K.backend.complex128
     backends.set_precision(original_precision)
-    backends.set_backend(original_backend)
 
 
 def test_set_precision_errors(backend):
-    original_backend = backends.get_backend()
     original_precision = backends.get_precision()
-    backends.set_backend(backend)
     gate = gates.H(0)
     with pytest.warns(RuntimeWarning):
         backends.set_precision("single")
     with pytest.raises(ValueError):
         backends.set_precision("test")
     backends.set_precision(original_precision)
-    backends.set_backend(original_backend)
 
 
 def test_set_device(backend):
-    original_backend = backends.get_backend()
     original_device = backends.get_device()
-    backends.set_backend(backend)
-    if "numpy" in backend:
+    if backends.get_backend() == "numpy":
         with pytest.warns(RuntimeWarning):
             backends.set_device("/CPU:0")
     else:
@@ -110,8 +99,8 @@ def test_set_device(backend):
             backends.set_device("/gpu:10")
         with pytest.raises(ValueError):
             backends.set_device("/GPU:10")
-    backends.set_device(original_device)
-    backends.set_backend(original_backend)
+    if original_device:
+        backends.set_device(original_device)
 
 
 def test_set_shot_batch_size():

--- a/src/qibo/tests/test_backends_matrices.py
+++ b/src/qibo/tests/test_backends_matrices.py
@@ -6,8 +6,6 @@ import numpy as np
 @pytest.mark.parametrize("dtype", ["complex64", "complex128"])
 def test_matrices(backend, dtype):
     from qibo.backends.matrices import Matrices
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     mobj = Matrices(qibo.K)
     target_matrices = {
         "I": np.array([[1, 0], [0, 1]]),
@@ -32,7 +30,6 @@ def test_matrices(backend, dtype):
     }
     for matrixname, target in target_matrices.items():
         np.testing.assert_allclose(getattr(mobj, matrixname), target)
-    qibo.set_backend(original_backend)
 
 
 def test_modifying_matrices_error():

--- a/src/qibo/tests/test_cirq.py
+++ b/src/qibo/tests/test_cirq.py
@@ -2,7 +2,6 @@
 import numpy as np
 import cirq
 import pytest
-import qibo
 from qibo import models, gates, K
 from qibo.tests.utils import random_state
 
@@ -130,13 +129,10 @@ def test_x_decompose_with_cirq(target, controls, free):
                           ("Y", 1, None), ("Z", 1, None)])
 def test_one_qubit_gates(backend, gate_name, nqubits, ndevices):
     """Check simple one-qubit gates."""
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     targets = random_active_qubits(nqubits, nactive=1)
     qibo_gate = getattr(gates, gate_name)(*targets)
     cirq_gate = [(getattr(cirq, gate_name), targets)]
     assert_gates_equivalent(qibo_gate, cirq_gate, nqubits, ndevices)
-    qibo.set_backend(original_backend)
 
 
 @pytest.mark.parametrize(("gate_name", "nqubits", "ndevices"),
@@ -145,28 +141,22 @@ def test_one_qubit_gates(backend, gate_name, nqubits, ndevices):
                           ("RZ", 1, None)])
 def test_one_qubit_parametrized_gates(backend, gate_name, nqubits, ndevices):
     """Check parametrized one-qubit rotations."""
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     theta = 0.1234
     targets = random_active_qubits(nqubits, nactive=1)
     qibo_gate = getattr(gates, gate_name)(*targets, theta)
     cirq_gate = [(getattr(cirq, gate_name.lower())(theta), targets)]
     assert_gates_equivalent(qibo_gate, cirq_gate, nqubits, ndevices)
-    qibo.set_backend(original_backend)
 
 
 @pytest.mark.parametrize(("nqubits", "ndevices"),
                          [(2, None), (3, 4), (2, 2)])
 def test_u1_gate(backend, nqubits, ndevices):
     """Check U1 gate."""
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     theta = 0.1234
     targets = random_active_qubits(nqubits, nactive=1)
     qibo_gate = gates.U1(*targets, theta)
     cirq_gate = [(cirq.ZPowGate(exponent=theta / np.pi), targets)]
     assert_gates_equivalent(qibo_gate, cirq_gate, nqubits, ndevices)
-    qibo.set_backend(original_backend)
 
 
 @pytest.mark.parametrize("gate_name", ["CNOT", "SWAP", "CZ"])
@@ -174,13 +164,10 @@ def test_u1_gate(backend, nqubits, ndevices):
 @pytest.mark.parametrize("ndevices", [None, 2])
 def test_two_qubit_gates(backend, gate_name, nqubits, ndevices):
     """Check two-qubit gates."""
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     targets = random_active_qubits(nqubits, nactive=2)
     qibo_gate = getattr(gates, gate_name)(*targets)
     cirq_gate = [(getattr(cirq, gate_name), targets)]
     assert_gates_equivalent(qibo_gate, cirq_gate, nqubits, ndevices)
-    qibo.set_backend(original_backend)
 
 
 @pytest.mark.parametrize(("nqubits", "ndevices"),
@@ -188,8 +175,6 @@ def test_two_qubit_gates(backend, gate_name, nqubits, ndevices):
                           (7, None), (7, 4)])
 def test_two_qubit_parametrized_gates(backend, nqubits, ndevices):
     """Check ``CU1`` and ``fSim`` gate."""
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     theta = 0.1234
     phi = 0.4321
 
@@ -202,7 +187,6 @@ def test_two_qubit_parametrized_gates(backend, nqubits, ndevices):
     qibo_gate = gates.fSim(*targets, theta, phi)
     cirq_gate = [(cirq.FSimGate(theta=theta, phi=phi), targets)]
     assert_gates_equivalent(qibo_gate, cirq_gate, nqubits, ndevices)
-    qibo.set_backend(original_backend)
 
 
 @pytest.mark.parametrize(("nqubits", "ndevices"),
@@ -210,8 +194,6 @@ def test_two_qubit_parametrized_gates(backend, nqubits, ndevices):
                           (5, 2), (6, 4), (9, 8)])
 def test_unitary_matrix_gate(backend, nqubits, ndevices):
     """Check arbitrary unitary gate."""
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     matrix = random_unitary_matrix(1)
     targets = random_active_qubits(nqubits, nactive=1)
     qibo_gate = gates.Unitary(matrix, *targets)
@@ -224,7 +206,6 @@ def test_unitary_matrix_gate(backend, nqubits, ndevices):
         qibo_gate = gates.Unitary(matrix, *targets)
         cirq_gate = [(cirq.MatrixGate(matrix), targets)]
         assert_gates_equivalent(qibo_gate, cirq_gate, nqubits, ndevices)
-    qibo.set_backend(original_backend)
 
 
 @pytest.mark.parametrize(("gate_name", "nqubits", "ndevices"),
@@ -233,15 +214,12 @@ def test_unitary_matrix_gate(backend, nqubits, ndevices):
                           ("Y", 12, 16)])
 def test_one_qubit_gates_controlled_by(backend, gate_name, nqubits, ndevices):
     """Check one-qubit gates controlled on arbitrary number of qubits."""
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     all_qubits = np.arange(nqubits)
     for _ in range(5):
         activeq = random_active_qubits(nqubits, nmin=1)
         qibo_gate = getattr(gates, gate_name)(activeq[-1]).controlled_by(*activeq[:-1])
         cirq_gate = [(getattr(cirq, gate_name).controlled(len(activeq) - 1), activeq)]
         assert_gates_equivalent(qibo_gate, cirq_gate, nqubits, ndevices)
-    qibo.set_backend(original_backend)
 
 
 @pytest.mark.parametrize(("nqubits", "ndevices"),
@@ -250,8 +228,6 @@ def test_one_qubit_gates_controlled_by(backend, gate_name, nqubits, ndevices):
                           (6, 2), (9, 2), (11, 4), (13, 8), (14, 16)])
 def test_two_qubit_gates_controlled_by(backend, nqubits, ndevices):
     """Check ``SWAP`` and ``fSim`` gates controlled on arbitrary number of qubits."""
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     all_qubits = np.arange(nqubits)
     for _ in range(5):
         activeq = random_active_qubits(nqubits, nmin=2)
@@ -264,7 +240,6 @@ def test_two_qubit_gates_controlled_by(backend, nqubits, ndevices):
         qibo_gate = gates.fSim(*activeq[-2:], theta, phi).controlled_by(*activeq[:-2])
         cirq_gate = [(cirq.FSimGate(theta, phi).controlled(len(activeq) - 2), activeq)]
         assert_gates_equivalent(qibo_gate, cirq_gate, nqubits, ndevices)
-    qibo.set_backend(original_backend)
 
 
 @pytest.mark.parametrize("nqubits", [5, 12, 13, 14])
@@ -272,8 +247,6 @@ def test_two_qubit_gates_controlled_by(backend, nqubits, ndevices):
 @pytest.mark.parametrize("ndevices", [None, 2, 8])
 def test_unitary_matrix_gate_controlled_by(backend, nqubits, ntargets, ndevices):
     """Check arbitrary unitary gate controlled on arbitrary number of qubits."""
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     all_qubits = np.arange(nqubits)
     for _ in range(10):
         activeq = random_active_qubits(nqubits, nactive=5)
@@ -281,17 +254,13 @@ def test_unitary_matrix_gate_controlled_by(backend, nqubits, ntargets, ndevices)
         qibo_gate = gates.Unitary(matrix, *activeq[-ntargets:]).controlled_by(*activeq[:-ntargets])
         cirq_gate = [(cirq.MatrixGate(matrix).controlled(len(activeq) - ntargets), activeq)]
         assert_gates_equivalent(qibo_gate, cirq_gate, nqubits, ndevices)
-    qibo.set_backend(original_backend)
 
 
 @pytest.mark.parametrize("nqubits", [5, 6, 7, 11, 12])
 def test_qft(backend, accelerators, nqubits):
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     c = models.QFT(nqubits, accelerators=accelerators)
     initial_state = random_state(nqubits)
     final_state = c(np.copy(initial_state))
     cirq_gates = [(cirq.qft, list(range(nqubits)))]
     target_state, _ = execute_cirq(cirq_gates, nqubits, np.copy(initial_state))
     np.testing.assert_allclose(target_state, final_state, atol=1e-6)
-    qibo.set_backend(original_backend)

--- a/src/qibo/tests/test_core_callbacks.py
+++ b/src/qibo/tests/test_core_callbacks.py
@@ -1,7 +1,6 @@
 """Test methods defined in `qibo/core/callbacks.py`."""
 import pytest
 import numpy as np
-import qibo
 from qibo.models import Circuit, AdiabaticEvolution
 from qibo import gates, callbacks
 from qibo.config import EIGVAL_CUTOFF
@@ -12,8 +11,6 @@ _atol = 1e-8
 
 
 def test_getitem_bad_indexing(backend):
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     entropy = callbacks.EntanglementEntropy([0])
     c = Circuit(2)
     c.add(gates.RY(0, 0.1234))
@@ -25,25 +22,19 @@ def test_getitem_bad_indexing(backend):
         entropy[1]
     with pytest.raises(IndexError):
         entropy["a"]
-    qibo.set_backend(original_backend)
 
 
 def test_entropy_product_state(backend):
     """Check that the |++> state has zero entropy."""
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     entropy = callbacks.EntanglementEntropy()
     state = np.ones(4) / 2.0
 
     result = entropy(state)
     np.testing.assert_allclose(result, 0, atol=_atol)
-    qibo.set_backend(original_backend)
 
 
 def test_entropy_singlet_state(backend):
     """Check that the singlet state has maximum entropy."""
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     from qibo import K
     entropy = callbacks.EntanglementEntropy([0])
     state = np.zeros(4)
@@ -51,22 +42,16 @@ def test_entropy_singlet_state(backend):
     state = K.cast(state / np.sqrt(2))
     result = entropy(state)
     np.testing.assert_allclose(result, 1.0)
-    qibo.set_backend(original_backend)
 
 
 def test_entropy_bad_state_type(backend):
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     entropy = callbacks.EntanglementEntropy([0])
     with pytest.raises(TypeError):
         _ = entropy("test")
-    qibo.set_backend(original_backend)
 
 
 def test_entropy_random_state(backend):
     """Check that entropy calculation agrees with numpy."""
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     # Generate a random positive and hermitian density matrix
     rho = np.random.random((8, 8)) + 1j * np.random.random((8, 8))
     rho = rho + rho.conj().T
@@ -84,13 +69,10 @@ def test_entropy_random_state(backend):
     masked_eigvals = ref_eigvals[np.where(ref_eigvals > EIGVAL_CUTOFF)]
     ref_spectrum = - np.log(masked_eigvals)
     np.testing.assert_allclose(callback.spectrum[0], ref_spectrum)
-    qibo.set_backend(original_backend)
 
 
 def test_entropy_switch_partition(backend):
     """Check that partition is switched to the largest counterpart."""
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     entropy = callbacks.EntanglementEntropy([0])
     # Prepare ghz state of 5 qubits
     state = np.zeros(2 ** 5)
@@ -99,13 +81,10 @@ def test_entropy_switch_partition(backend):
 
     result = entropy(state)
     np.testing.assert_allclose(result, 1.0)
-    qibo.set_backend(original_backend)
 
 
 def test_entropy_numerical(backend):
     """Check that entropy calculation does not fail for tiny eigenvalues."""
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     from qibo import K
     eigvals = np.array([-1e-10, -1e-15, -2e-17, -1e-18, -5e-60, 1e-48, 4e-32,
                         5e-14, 1e-14, 9.9e-13, 9e-13, 5e-13, 1e-13, 1e-12,
@@ -118,14 +97,11 @@ def test_entropy_numerical(backend):
     target = - (eigvals[mask] * np.log2(eigvals[mask])).sum()
 
     np.testing.assert_allclose(result, target)
-    qibo.set_backend(original_backend)
 
 
 @pytest.mark.parametrize("density_matrix", [False, True])
 def test_entropy_in_circuit(backend, density_matrix):
     """Check that entropy calculation works in circuit."""
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     entropy = callbacks.EntanglementEntropy([0], compute_spectrum=True)
     c = Circuit(2, density_matrix=density_matrix)
     c.add(gates.CallbackGate(entropy))
@@ -141,7 +117,6 @@ def test_entropy_in_circuit(backend, density_matrix):
     target_spectrum = [0, 0, np.log(2), np.log(2)]
     entropy_spectrum = np.concatenate(entropy.spectrum).ravel().tolist()
     np.testing.assert_allclose(entropy_spectrum, target_spectrum, atol=_atol)
-    qibo.set_backend(original_backend)
 
 
 @pytest.mark.parametrize("gateconf,target_entropy",
@@ -153,8 +128,6 @@ def test_entropy_in_circuit(backend, density_matrix):
                           (["entropy", "H", "entropy", "CNOT"], [0.0, 0.0])])
 def test_entropy_in_distributed_circuit(backend, accelerators, gateconf, target_entropy):
     """Check that various entropy configurations work in distributed circuit."""
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     target_c = Circuit(4)
     target_c.add([gates.H(0), gates.CNOT(0, 1)])
     target_state = target_c()
@@ -171,13 +144,10 @@ def test_entropy_in_distributed_circuit(backend, accelerators, gateconf, target_
     final_state = c()
     np.testing.assert_allclose(final_state, target_state)
     np.testing.assert_allclose(entropy[:], target_entropy, atol=_atol)
-    qibo.set_backend(original_backend)
 
 
 def test_entropy_in_compiled_circuit(backend):
     """Check that entropy calculation works when circuit is compiled."""
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     entropy = callbacks.EntanglementEntropy([0])
     c = Circuit(2)
     c.add(gates.CallbackGate(entropy))
@@ -192,13 +162,10 @@ def test_entropy_in_compiled_circuit(backend):
         c.compile()
         final_state = c()
         np.testing.assert_allclose(entropy[:], [0, 0, 1.0], atol=_atol)
-    qibo.set_backend(original_backend)
 
 
 def test_entropy_multiple_executions(backend, accelerators):
     """Check entropy calculation when the callback is used in multiple executions."""
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     target_c = Circuit(4)
     target_c.add([gates.RY(0, 0.1234), gates.CNOT(0, 1)])
     target_state = target_c()
@@ -231,13 +198,10 @@ def test_entropy_multiple_executions(backend, accelerators):
 
     target = [0, target_entropy(0.1234), 0, target_entropy(0.4321)]
     np.testing.assert_allclose(entropy[:], target, atol=_atol)
-    qibo.set_backend(original_backend)
 
 
 def test_entropy_large_circuit(backend, accelerators):
     """Check that entropy calculation works for variational like circuit."""
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     thetas = np.pi * np.random.random((3, 8))
     target_entropy = callbacks.EntanglementEntropy([0, 2, 4, 5])
     c1 = Circuit(8)
@@ -276,13 +240,10 @@ def test_entropy_large_circuit(backend, accelerators):
 
     np.testing.assert_allclose(state3, state)
     np.testing.assert_allclose(entropy[:], [0, e1, e2, e3])
-    qibo.set_backend(original_backend)
 
 
 def test_entropy_density_matrix(backend):
     from qibo.tests.utils import random_density_matrix
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     rho = random_density_matrix(4)
     # this rho is not always positive. Make rho positive for this application
     _, u = np.linalg.eigh(rho)
@@ -301,15 +262,11 @@ def test_entropy_density_matrix(backend):
     mask = eigvals > 0
     target_ent = - (eigvals[mask] * np.log2(eigvals[mask])).sum()
     np.testing.assert_allclose(final_ent, target_ent)
-    qibo.set_backend(original_backend)
 
 
 @pytest.mark.parametrize("density_matrix", [False, True])
 def test_norm(backend, density_matrix):
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     norm = callbacks.Norm()
-
     if density_matrix:
         norm.density_matrix = True
         state = np.random.random((2, 2)) + 1j * np.random.random((2, 2))
@@ -319,14 +276,10 @@ def test_norm(backend, density_matrix):
         target_norm = np.sqrt((np.abs(state) ** 2).sum())
 
     np.testing.assert_allclose(norm(state), target_norm)
-    qibo.set_backend(original_backend)
 
 
 @pytest.mark.parametrize("density_matrix", [False, True])
 def test_overlap(backend, density_matrix):
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
-
     state0 = np.random.random(4) + 1j * np.random.random(4)
     state1 = np.random.random(4) + 1j * np.random.random(4)
     overlap = callbacks.Overlap(state0)
@@ -337,13 +290,10 @@ def test_overlap(backend, density_matrix):
     else:
         target_overlap = np.abs((state0.conj() * state1).sum())
         np.testing.assert_allclose(overlap(state1), target_overlap)
-    qibo.set_backend(original_backend)
 
 
 @pytest.mark.parametrize("density_matrix", [False, True])
 def test_energy(backend, density_matrix):
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     from qibo import hamiltonians
     ham = hamiltonians.TFIM(4, h=1.0)
     energy = callbacks.Energy(ham)
@@ -356,14 +306,11 @@ def test_energy(backend, density_matrix):
         state = np.random.random(16) + 1j * np.random.random(16)
         target_energy = state.conj().dot(matrix.dot(state))
     np.testing.assert_allclose(energy(state), target_energy)
-    qibo.set_backend(original_backend)
 
 
 @pytest.mark.parametrize("trotter", [False, True])
 @pytest.mark.parametrize("check_degenerate", [False, True])
 def test_gap(backend, trotter, check_degenerate):
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     from qibo import hamiltonians
     h0 = hamiltonians.X(4, trotter=trotter)
     if check_degenerate:
@@ -391,7 +338,6 @@ def test_gap(backend, trotter, check_degenerate):
     np.testing.assert_allclose(ground[:], targets["ground"])
     np.testing.assert_allclose(excited[:], targets["excited"])
     np.testing.assert_allclose(gap[:], targets["gap"])
-    qibo.set_backend(original_backend)
 
 
 def test_gap_errors():

--- a/src/qibo/tests/test_core_callbacks.py
+++ b/src/qibo/tests/test_core_callbacks.py
@@ -148,6 +148,7 @@ def test_entropy_in_distributed_circuit(backend, accelerators, gateconf, target_
 
 def test_entropy_in_compiled_circuit(backend):
     """Check that entropy calculation works when circuit is compiled."""
+    from qibo import get_backend
     entropy = callbacks.EntanglementEntropy([0])
     c = Circuit(2)
     c.add(gates.CallbackGate(entropy))
@@ -155,7 +156,7 @@ def test_entropy_in_compiled_circuit(backend):
     c.add(gates.CallbackGate(entropy))
     c.add(gates.CNOT(0, 1))
     c.add(gates.CallbackGate(entropy))
-    if backend == "qibotf":
+    if get_backend() == "qibotf":
         with pytest.raises(RuntimeError):
             c.compile()
     else:

--- a/src/qibo/tests/test_core_circuit.py
+++ b/src/qibo/tests/test_core_circuit.py
@@ -23,8 +23,6 @@ def test_set_nqubits(backend):
 
 @pytest.mark.parametrize("nqubits", [5, 6])
 def test_circuit_add_layer(backend, nqubits, accelerators):
-
-
     c = Circuit(nqubits, accelerators)
     qubits = list(range(nqubits))
     pairs = [(2 * i, 2 * i + 1) for i in range(nqubits // 2)]
@@ -38,8 +36,6 @@ def test_circuit_add_layer(backend, nqubits, accelerators):
 # TODO: Test `fuse`
 
 def test_eager_execute(backend, accelerators):
-
-
     c = Circuit(4, accelerators)
     c.add((gates.H(i) for i in range(4)))
     target_state = np.ones(16) / 4.0
@@ -47,8 +43,6 @@ def test_eager_execute(backend, accelerators):
 
 
 def test_compiled_execute(backend):
-
-
     def create_circuit(theta = 0.1234):
         c = Circuit(2)
         c.add(gates.X(0))
@@ -78,12 +72,11 @@ def test_compiled_execute(backend):
         np.testing.assert_allclose(r1, r2)
 
 
-def test_compiling_twice_exception():
+def test_compiling_twice_exception(backend):
     """Check that compiling a circuit a second time raises error."""
     from qibo import K
     if K.name != "tensorflow": # pragma: no cover
         pytest.skip("Skipping compilation test because Tensorflow is not available.")
-    qibo.set_backend("tensorflow")
     c = Circuit(2)
     c.add([gates.H(0), gates.H(1)])
     c.compile()

--- a/src/qibo/tests/test_core_circuit_backpropagation.py
+++ b/src/qibo/tests/test_core_circuit_backpropagation.py
@@ -1,18 +1,12 @@
 """Tests Tensorflow's backpropagation when using `tf.Variable` parameters."""
 import numpy as np
 import pytest
-import qibo
 from qibo import K, gates
 from qibo.models import Circuit
 
 
 def test_variable_backpropagation(backend):
-    if backend == "qibotf":
-        pytest.skip("Custom gates do not support automatic differentiation.")
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
-    if "numpy" in K.name:
-        qibo.set_backend(original_backend)
+    if K.name != "tensorflow":
         pytest.skip("Backpropagation is not supported by {}.".format(K.name))
 
     theta = K.optimization.Variable(0.1234, dtype=K.dtypes('DTYPE'))
@@ -30,16 +24,10 @@ def test_variable_backpropagation(backend):
 
     target_grad = - np.sin(theta / 2.0) / 2.0
     np.testing.assert_allclose(grad, target_grad)
-    qibo.set_backend(original_backend)
 
 
 def test_two_variables_backpropagation(backend):
-    if backend == "qibotf":
-        pytest.skip("Custom gates do not support automatic differentiation.")
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
-    if "numpy" in K.name:
-        qibo.set_backend(original_backend)
+    if K.name != "tensorflow":
         pytest.skip("Backpropagation is not supported by {}.".format(K.name))
 
     theta = K.optimization.Variable([0.1234, 0.4321], dtype=K.dtypes('DTYPE'))
@@ -60,4 +48,3 @@ def test_two_variables_backpropagation(backend):
     target_grad2 = - np.cos(t[0]) * np.sin(t[1])
     target_grad = np.array([target_grad1, target_grad2]) / 2.0
     np.testing.assert_allclose(grad, target_grad)
-    qibo.set_backend(original_backend)

--- a/src/qibo/tests/test_core_circuit_features.py
+++ b/src/qibo/tests/test_core_circuit_features.py
@@ -1,7 +1,6 @@
 """Test how features defined in :class:`qibo.abstractions.circuit.AbstractCircuit` work during circuit execution."""
 import numpy as np
 import pytest
-import qibo
 from qibo import gates
 from qibo.models import Circuit
 
@@ -10,8 +9,6 @@ from qibo.models import Circuit
 def test_circuit_vs_gate_execution(backend, compile):
     """Check consistency between executing circuit and stand alone gates."""
     from qibo import K
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     theta = 0.1234
     target_c = Circuit(2)
     target_c.add(gates.X(0))
@@ -38,12 +35,9 @@ def test_circuit_vs_gate_execution(backend, compile):
     else:
         result = c(initial_state, theta)
         np.testing.assert_allclose(result, target_result)
-    qibo.set_backend(original_backend)
 
 
 def test_circuit_addition_execution(backend, accelerators):
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     c1 = Circuit(4, accelerators)
     c1.add(gates.H(0))
     c1.add(gates.H(1))
@@ -60,16 +54,12 @@ def test_circuit_addition_execution(backend, accelerators):
     c.add(gates.CNOT(0, 1))
     c.add(gates.CZ(2, 3))
     np.testing.assert_allclose(c3(), c())
-    qibo.set_backend(original_backend)
 
 
 @pytest.mark.parametrize("deep", [False, True])
 def test_copied_circuit_execution(backend, accelerators, deep):
     """Check that circuit copy execution is equivalent to original circuit."""
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     theta = 0.1234
-
     c1 = Circuit(4, accelerators)
     c1.add([gates.X(0), gates.X(1), gates.CU1(0, 1, theta)])
     c1.add([gates.H(2), gates.H(3), gates.CU1(2, 3, theta)])
@@ -79,14 +69,10 @@ def test_copied_circuit_execution(backend, accelerators, deep):
     else:
         c2 = c1.copy(deep)
         np.testing.assert_allclose(c2(), c1())
-    qibo.set_backend(original_backend)
 
 
 @pytest.mark.parametrize("fuse", [False, True])
 def test_inverse_circuit_execution(backend, accelerators, fuse):
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
-
     c = Circuit(4, accelerators)
     c.add(gates.RX(0, theta=0.1))
     c.add(gates.U2(1, phi=0.2, lam=0.3))
@@ -101,12 +87,9 @@ def test_inverse_circuit_execution(backend, accelerators, fuse):
     target_state = np.ones(2 ** 4) / 4
     final_state = invc(c(np.copy(target_state)))
     np.testing.assert_allclose(final_state, target_state)
-    qibo.set_backend(original_backend)
 
 
 def test_circuit_invert_and_addition_execution(backend, accelerators):
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     subroutine = Circuit(6)
     subroutine.add([gates.RX(i, theta=0.1) for i in range(5)])
     subroutine.add([gates.CZ(i, i + 1) for i in range(0, 5, 2)])
@@ -123,14 +106,10 @@ def test_circuit_invert_and_addition_execution(backend, accelerators):
 
     assert c.depth == circuit.depth
     np.testing.assert_allclose(circuit(), c())
-    qibo.set_backend(original_backend)
 
 
 @pytest.mark.parametrize("distribute_small", [False, True])
 def test_circuit_on_qubits_execution(backend, accelerators, distribute_small):
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
-
     if distribute_small:
         smallc = Circuit(3, accelerators=accelerators)
     else:
@@ -148,14 +127,10 @@ def test_circuit_on_qubits_execution(backend, accelerators, distribute_small):
     targetc.add((gates.CNOT(1, 3), gates.CZ(3, 5)))
     assert largec.depth == targetc.depth
     np.testing.assert_allclose(largec(), targetc())
-    qibo.set_backend(original_backend)
 
 
 @pytest.mark.parametrize("distribute_small", [False, True])
 def test_circuit_on_qubits_double_execution(backend, accelerators, distribute_small):
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
-
     if distribute_small:
         smallc = Circuit(3, accelerators=accelerators)
     else:
@@ -178,13 +153,9 @@ def test_circuit_on_qubits_double_execution(backend, accelerators, distribute_sm
         targetc.add((gates.CNOT(1, 3), gates.CZ(3, 5)))
         assert largec.depth == targetc.depth
         np.testing.assert_allclose(largec(), targetc())
-    qibo.set_backend(original_backend)
 
 
 def test_circuit_on_qubits_controlled_by_execution(backend, accelerators):
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
-
     smallc = Circuit(3)
     smallc.add(gates.RX(0, theta=0.1).controlled_by(1, 2))
     smallc.add(gates.RY(1, theta=0.2).controlled_by(0))
@@ -204,14 +175,10 @@ def test_circuit_on_qubits_controlled_by_execution(backend, accelerators):
 
     assert largec.depth == targetc.depth
     np.testing.assert_allclose(largec(), targetc())
-    qibo.set_backend(original_backend)
 
 
 @pytest.mark.parametrize("controlled", [False, True])
 def test_circuit_on_qubits_with_unitary_execution(backend, accelerators, controlled):
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
-
     unitaries = np.random.random((2, 2, 2))
     smallc = Circuit(2)
     if controlled:
@@ -243,13 +210,9 @@ def test_circuit_on_qubits_with_unitary_execution(backend, accelerators, control
     targetc.add(gates.CNOT(3, 0))
     assert largec.depth == targetc.depth
     np.testing.assert_allclose(largec(), targetc())
-    qibo.set_backend(original_backend)
 
 
 def test_circuit_on_qubits_with_varlayer_execution(backend, accelerators):
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
-
     thetas = np.random.random([2, 4])
     smallc = Circuit(4)
     smallc.add(gates.VariationalLayer(range(4), [(0, 1), (2, 3)],
@@ -271,12 +234,9 @@ def test_circuit_on_qubits_with_varlayer_execution(backend, accelerators):
                                        thetas[1]))
     assert largec.depth == targetc.depth
     np.testing.assert_allclose(largec(), targetc())
-    qibo.set_backend(original_backend)
 
 
 def test_circuit_decompose_execution(backend):
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     c = Circuit(6)
     c.add(gates.RX(0, 0.1234))
     c.add(gates.RY(1, 0.4321))
@@ -285,12 +245,9 @@ def test_circuit_decompose_execution(backend):
     c.add(gates.X(3).controlled_by(0, 1, 2, 4))
     decomp_c = c.decompose(5)
     np.testing.assert_allclose(c(), decomp_c(), atol=1e-6)
-    qibo.set_backend(original_backend)
 
 
 def test_repeated_execute_pauli_noise_channel(backend):
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     thetas = np.random.random(4)
     c = Circuit(4)
     c.add((gates.RY(i, t) for i, t in enumerate(thetas)))
@@ -314,12 +271,9 @@ def test_repeated_execute_pauli_noise_channel(backend):
         target_state.append(noiseless_c())
     target_state = np.stack(target_state)
     np.testing.assert_allclose(final_state, target_state)
-    qibo.set_backend(original_backend)
 
 
 def test_repeated_execute_with_noise(backend):
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     thetas = np.random.random(4)
     c = Circuit(4)
     c.add((gates.RY(i, t) for i, t in enumerate(thetas)))
@@ -340,4 +294,3 @@ def test_repeated_execute_with_noise(backend):
         target_state.append(noiseless_c())
     target_state = np.stack(target_state)
     np.testing.assert_allclose(final_state, target_state)
-    qibo.set_backend(original_backend)

--- a/src/qibo/tests/test_core_circuit_features.py
+++ b/src/qibo/tests/test_core_circuit_features.py
@@ -29,7 +29,7 @@ def test_circuit_vs_gate_execution(backend, compile):
     else:
         c = custom_circuit
 
-    if backend == "qibotf" and compile:
+    if K.name == "qibotf" and compile:
         with pytest.raises(NotImplementedError):
             result = c(initial_state, theta)
     else:

--- a/src/qibo/tests/test_core_circuit_noise.py
+++ b/src/qibo/tests/test_core_circuit_noise.py
@@ -8,8 +8,6 @@ from qibo.models import Circuit
 
 def test_pauli_noise_channel(backend):
     from qibo import matrices
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     c = Circuit(2, density_matrix=True)
     c.add(gates.H(0))
     c.add(gates.H(1))
@@ -26,12 +24,9 @@ def test_pauli_noise_channel(backend):
     m2 = np.kron(matrices.I, matrices.Z)
     rho = 0.6 * rho + 0.1 * m1.dot(rho.dot(m1)) + 0.3 * m2.dot(rho.dot(m2))
     np.testing.assert_allclose(final_rho, rho)
-    qibo.set_backend(original_backend)
 
 
 def test_noisy_circuit_reexecution(backend):
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     c = Circuit(2, density_matrix=True)
     c.add(gates.H(0))
     c.add(gates.H(1))
@@ -40,7 +35,6 @@ def test_noisy_circuit_reexecution(backend):
     final_rho = c().state()
     final_rho2 = c().state()
     np.testing.assert_allclose(final_rho, final_rho2)
-    qibo.set_backend(original_backend)
 
 
 def test_circuit_with_noise_gates():
@@ -54,8 +48,6 @@ def test_circuit_with_noise_gates():
 
 
 def test_circuit_with_noise_execution(backend):
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     c = Circuit(2, density_matrix=True)
     c.add([gates.H(0), gates.H(1)])
     noisy_c = c.with_noise((0.1, 0.2, 0.3))
@@ -68,12 +60,9 @@ def test_circuit_with_noise_execution(backend):
     target_c.add(gates.PauliNoiseChannel(1, 0.1, 0.2, 0.3))
     target_state = target_c()
     np.testing.assert_allclose(final_state, target_state)
-    qibo.set_backend(original_backend)
 
 
 def test_circuit_with_noise_measurements(backend):
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     c = Circuit(2, density_matrix=True)
     c.add([gates.H(0), gates.H(1)])
     c.add(gates.M(0))
@@ -87,12 +76,9 @@ def test_circuit_with_noise_measurements(backend):
     target_c.add(gates.PauliNoiseChannel(1, 0.1, 0.1, 0.1))
     target_state = target_c()
     np.testing.assert_allclose(final_state, target_state)
-    qibo.set_backend(original_backend)
 
 
 def test_circuit_with_noise_noise_map(backend):
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     noise_map = {0: (0.1, 0.2, 0.1), 1: (0.2, 0.3, 0.0),
                  2: (0.0, 0.0, 0.0)}
 
@@ -109,9 +95,7 @@ def test_circuit_with_noise_noise_map(backend):
     target_c.add(gates.PauliNoiseChannel(1, 0.2, 0.3, 0.0))
     target_c.add(gates.X(2))
     target_state = target_c()
-
     np.testing.assert_allclose(final_state, target_state)
-    qibo.set_backend(original_backend)
 
 
 def test_circuit_with_noise_errors():
@@ -135,8 +119,6 @@ def test_density_matrix_circuit_measurement(backend):
     """Check measurement gate on density matrices using circuit."""
     from qibo.tests.test_measurement_gate import assert_result
     from qibo.tests.test_measurement_gate_registers import assert_register_result
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     state = np.zeros(16)
     state[0] = 1
     init_rho = np.outer(state, state.conj())
@@ -167,7 +149,6 @@ def test_density_matrix_circuit_measurement(backend):
     target["decimal_frequencies"] = {"A": {1: 100}, "B": {2: 100}}
     target["binary_frequencies"] = {"A": {"01": 100}, "B": {"10": 100}}
     assert_register_result(result, **target)
-    qibo.set_backend(original_backend)
 
 
 def test_density_matrix_circuit_errors():

--- a/src/qibo/tests/test_core_circuit_parametrized.py
+++ b/src/qibo/tests/test_core_circuit_parametrized.py
@@ -9,8 +9,6 @@ from qibo.models import Circuit
 @pytest.mark.parametrize("trainable", [True, False])
 def test_set_parameters_with_list(backend, trainable):
     """Check updating parameters of circuit with list."""
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     params = [0.123, 0.456, (0.789, 0.321)]
     c = Circuit(3)
     if trainable:
@@ -41,14 +39,11 @@ def test_set_parameters_with_list(backend, trainable):
     target_params = [new_params[0], new_params[1], (new_params[2], new_params[3])]
     target_c.set_parameters(target_params)
     np.testing.assert_allclose(c(), target_c())
-    qibo.set_backend(original_backend)
 
 
 @pytest.mark.parametrize("trainable", [True, False])
 def test_circuit_set_parameters_ungates(backend, trainable, accelerators):
     """Check updating parameters of circuit with list."""
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     params = [0.1, 0.2, 0.3, (0.4, 0.5), (0.6, 0.7, 0.8)]
     if trainable:
         trainable_params = list(params)
@@ -98,17 +93,12 @@ def test_circuit_set_parameters_ungates(backend, trainable, accelerators):
     target_c.add(gates.U3(1, *npparams[5:]))
     c.set_parameters(trainable_params)
     np.testing.assert_allclose(c(), target_c())
-    qibo.set_backend(original_backend)
 
 
 @pytest.mark.parametrize("trainable", [True, False])
 def test_circuit_set_parameters_with_unitary(backend, trainable, accelerators):
     """Check updating parameters of circuit that contains ``Unitary`` gate."""
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
-
     params = [0.1234, np.random.random((4, 4))]
-
     c = Circuit(4, accelerators)
     c.add(gates.RX(0, theta=0))
     if trainable:
@@ -137,15 +127,11 @@ def test_circuit_set_parameters_with_unitary(backend, trainable, accelerators):
     target_c.add(gates.RX(0, theta=new_params[0]))
     target_c.add(gates.Unitary(new_params[1:].reshape((4, 4)), 1, 2))
     np.testing.assert_allclose(c(), target_c())
-    qibo.set_backend(original_backend)
 
 
 @pytest.mark.parametrize("nqubits", [4, 5])
 def test_set_parameters_with_variationallayer(backend, nqubits, accelerators):
     """Check updating parameters of variational layer."""
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
-
     theta = np.random.random(nqubits)
     c = Circuit(nqubits, accelerators)
     pairs = [(i, i + 1) for i in range(0, nqubits - 1, 2)]
@@ -168,16 +154,12 @@ def test_set_parameters_with_variationallayer(backend, nqubits, accelerators):
     c.set_parameters(np.copy(new_theta))
     target_c.set_parameters(np.copy(new_theta))
     np.testing.assert_allclose(c(), target_c())
-    qibo.set_backend(original_backend)
 
 
 @pytest.mark.parametrize("nqubits", [4, 5])
 @pytest.mark.parametrize("trainable", [True, False])
 def test_set_parameters_with_double_variationallayer(backend, nqubits, trainable, accelerators):
     """Check updating parameters of variational layer."""
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
-
     theta = np.random.random((3, nqubits))
     c = Circuit(nqubits, accelerators)
     pairs = [(i, i + 1) for i in range(0, nqubits - 1, 2)]
@@ -202,15 +184,11 @@ def test_set_parameters_with_double_variationallayer(backend, nqubits, trainable
         new_theta[:2 * nqubits] = theta[:2].ravel()
     target_c.set_parameters(np.copy(new_theta))
     np.testing.assert_allclose(c(), target_c())
-    qibo.set_backend(original_backend)
 
 
 @pytest.mark.parametrize("trainable", [True, False])
 def test_set_parameters_with_gate_fusion(backend, trainable, accelerators):
     """Check updating parameters of fused circuit."""
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
-
     params = np.random.random(9)
     c = Circuit(5, accelerators)
     c.add(gates.RX(0, theta=params[0], trainable=trainable))
@@ -241,20 +219,15 @@ def test_set_parameters_with_gate_fusion(backend, trainable, accelerators):
     c.set_parameters(new_params_list)
     fused_c.set_parameters(new_params_list)
     np.testing.assert_allclose(c(), fused_c())
-    qibo.set_backend(original_backend)
 
 
 def test_variable_theta(backend):
     """Check that parametrized gates accept `tf.Variable` parameters."""
-    if "numpy" in backend:
+    if "numpy" in qibo.get_backend():
         pytest.skip("Numpy backends do not support variable parameters.")
-
     from qibo import K
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     theta1 = K.optimization.Variable(0.1234, dtype=K.dtypes('DTYPE'))
     theta2 = K.optimization.Variable(0.4321, dtype=K.dtypes('DTYPE'))
-
     cvar = Circuit(2)
     cvar.add(gates.RX(0, theta1))
     cvar.add(gates.RY(1, theta2))
@@ -265,4 +238,3 @@ def test_variable_theta(backend):
     c.add(gates.RY(1, 0.4321))
     target_state = c()
     np.testing.assert_allclose(final_state, target_state)
-    qibo.set_backend(original_backend)

--- a/src/qibo/tests/test_core_circuit_qasm.py
+++ b/src/qibo/tests/test_core_circuit_qasm.py
@@ -21,8 +21,8 @@ h q[2];
 h q[3];
 h q[4];"""
     import qibo
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
+
+
     c = Circuit.from_qasm(target, accelerators)
     assert c.nqubits == 5
     assert c.depth == 1
@@ -31,13 +31,9 @@ h q[4];"""
         assert gate.qubits == (i,)
     target_state = np.ones(32) / np.sqrt(32)
     np.testing.assert_allclose(c(), target_state)
-    qibo.set_backend(original_backend)
 
 
 def test_simple_cirq(backend):
-    import qibo
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     c1 = Circuit(2)
     c1.add(gates.H(0))
     c1.add(gates.H(1))
@@ -53,13 +49,9 @@ def test_simple_cirq(backend):
     assert c3.depth == c2depth
     final_state_c3 = c3()
     np.testing.assert_allclose(final_state_c3, final_state_c2, atol=_atol)
-    qibo.set_backend(original_backend)
 
 
 def test_multiqubit_gates_cirq(backend):
-    import qibo
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     c1 = Circuit(2)
     c1.add(gates.H(0))
     c1.add(gates.CNOT(0, 1))
@@ -78,13 +70,9 @@ def test_multiqubit_gates_cirq(backend):
     assert c3.depth == c2depth
     final_state_c3 = c3()
     np.testing.assert_allclose(final_state_c3, final_state_c2, atol=_atol)
-    qibo.set_backend(original_backend)
 
 
 def test_toffoli_cirq(backend):
-    import qibo
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     c1 = Circuit(3)
     c1.add(gates.Y(0))
     c1.add(gates.TOFFOLI(0, 1, 2))
@@ -104,13 +92,9 @@ def test_toffoli_cirq(backend):
     assert c3.depth == c2depth
     final_state_c3 = c3()
     np.testing.assert_allclose(final_state_c3, final_state_c2, atol=_atol)
-    qibo.set_backend(original_backend)
 
 
 def test_parametrized_gate_cirq(backend):
-    import qibo
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     c1 = Circuit(2)
     c1.add(gates.Y(0))
     c1.add(gates.RY(1, 0.1234))
@@ -125,7 +109,6 @@ def test_parametrized_gate_cirq(backend):
     c3 = Circuit.from_qasm(c2.to_qasm())
     final_state_c3 = c3()
     np.testing.assert_allclose(final_state_c3, final_state_c2, atol=_atol)
-    qibo.set_backend(original_backend)
 
 
 def test_cu1_cirq():
@@ -139,9 +122,6 @@ def test_cu1_cirq():
 
 
 def test_ugates_cirq(backend):
-    import qibo
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     c1 = Circuit(3)
     c1.add(gates.RX(0, 0.1))
     c1.add(gates.RZ(1, 0.4))
@@ -167,7 +147,6 @@ def test_ugates_cirq(backend):
     # catches unknown gate "cu3"
     with pytest.raises(exception.QasmException):
         c2 = circuit_from_qasm(c1.to_qasm())
-    qibo.set_backend(original_backend)
 
 
 def test_crotations_cirq():
@@ -182,9 +161,6 @@ def test_crotations_cirq():
 
 
 def test_from_qasm_evaluation(backend):
-    import qibo
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     import numpy as np
     target = f"""OPENQASM 2.0;
 include "qelib1.inc";
@@ -194,4 +170,3 @@ h q[1];"""
     c = Circuit.from_qasm(target)
     target_state = np.ones(4) / 2.0
     np.testing.assert_allclose(c(), target_state)
-    qibo.set_backend(original_backend)

--- a/src/qibo/tests/test_core_distcircuit.py
+++ b/src/qibo/tests/test_core_distcircuit.py
@@ -54,14 +54,11 @@ def test_distributed_circuit_various_errors():
 
 
 def test_distributed_circuit_fusion(backend, accelerators):
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     c = DistributedCircuit(4, accelerators)
     c.add((gates.H(i) for i in range(4)))
     final_state = c()
     with pytest.raises(RuntimeError):
         fused_c = c.fuse()
-    qibo.set_backend(original_backend)
 
 
 def test_distributed_circuit_set_gates():
@@ -103,20 +100,15 @@ def test_distributed_circuit_set_gates_controlled():
 
 
 def test_distributed_circuit_get_initial_state_default(backend, accelerators):
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     c = DistributedCircuit(6, accelerators)
     c.queues.qubits = DistributedQubits(range(c.nglobal), c.nqubits)
     final_state = c.get_initial_state()
     target_state = np.zeros_like(final_state)
     target_state[0] = 1
     np.testing.assert_allclose(final_state, target_state)
-    qibo.set_backend(original_backend)
 
 
 def test_distributed_circuit_get_initial_state_random(backend, accelerators):
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     import itertools
     from qibo.tests.utils import random_state
     target_state = random_state(5)
@@ -129,12 +121,9 @@ def test_distributed_circuit_get_initial_state_random(backend, accelerators):
     for i, s in enumerate(itertools.product([0, 1], repeat=c.nglobal)):
         target_piece = target_state[s].flatten()
         np.testing.assert_allclose(target_piece.ravel(), state.pieces[i])
-    qibo.set_backend(original_backend)
 
 
 def test_distributed_circuit_get_initial_state_bad_type(backend, accelerators):
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     import itertools
     from qibo.tests.utils import random_state
     target_state = random_state(5)
@@ -142,7 +131,6 @@ def test_distributed_circuit_get_initial_state_bad_type(backend, accelerators):
     c.queues.qubits = DistributedQubits(range(c.nglobal), c.nqubits)
     with pytest.raises(TypeError):
         c.get_initial_state("test")
-    qibo.set_backend(original_backend)
 
 
 @pytest.mark.parametrize("nqubits", [28, 29, 30, 31, 32, 33, 34])

--- a/src/qibo/tests/test_core_distcircuit_execution.py
+++ b/src/qibo/tests/test_core_distcircuit_execution.py
@@ -1,7 +1,6 @@
 """Test functions defined in `qibo/core/distcircuit.py`."""
 import pytest
 import numpy as np
-import qibo
 from qibo import gates
 from qibo.models import Circuit
 from qibo.core.distcircuit import DistributedCircuit
@@ -10,8 +9,6 @@ from qibo.tests.utils import random_state
 
 @pytest.mark.parametrize("use_global_qubits", [False, True])
 def test_distributed_circuit_execution(backend, accelerators, use_global_qubits):
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     dist_c = DistributedCircuit(6, accelerators)
     c = Circuit(6)
     if use_global_qubits:
@@ -26,12 +23,9 @@ def test_distributed_circuit_execution(backend, accelerators, use_global_qubits)
     final_state = dist_c(np.copy(initial_state))
     target_state = c(np.copy(initial_state))
     np.testing.assert_allclose(target_state, final_state)
-    qibo.set_backend(original_backend)
 
 
 def test_distributed_circuit_execution_pretransformed(backend, accelerators):
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     dist_c = DistributedCircuit(4, accelerators)
     dist_c.add((gates.H(i) for i in range(dist_c.nglobal, 4)))
     dist_c.add(gates.SWAP(0, 2))
@@ -46,12 +40,9 @@ def test_distributed_circuit_execution_pretransformed(backend, accelerators):
     final_state = dist_c(np.copy(initial_state))
     target_state = c(np.copy(initial_state))
     np.testing.assert_allclose(target_state, final_state)
-    qibo.set_backend(original_backend)
 
 
 def test_distributed_circuit_execution_with_swap(backend, accelerators):
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     dist_c = DistributedCircuit(6, accelerators)
     dist_c.add((gates.H(i) for i in range(6)))
     dist_c.add((gates.SWAP(i, i + 1) for i in range(5)))
@@ -65,12 +56,9 @@ def test_distributed_circuit_execution_with_swap(backend, accelerators):
     final_state = dist_c(np.copy(initial_state))
     target_state = c(np.copy(initial_state))
     np.testing.assert_allclose(target_state, final_state)
-    qibo.set_backend(original_backend)
 
 
 def test_distributed_circuit_execution_special_gate(backend, accelerators):
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     dist_c = DistributedCircuit(6, accelerators)
     initial_state = random_state(dist_c.nqubits)
     dist_c.add(gates.Flatten(np.copy(initial_state)))
@@ -80,12 +68,9 @@ def test_distributed_circuit_execution_special_gate(backend, accelerators):
     c.add(gates.Flatten(np.copy(initial_state)))
     c.add((gates.H(i) for i in range(dist_c.nlocal)))
     np.testing.assert_allclose(dist_c(), c())
-    qibo.set_backend(original_backend)
 
 
 def test_distributed_circuit_execution_controlled_gate(backend, accelerators):
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     dist_c = DistributedCircuit(4, accelerators)
     dist_c.add((gates.H(i) for i in range(dist_c.nglobal, 4)))
     dist_c.add(gates.CNOT(0, 2))
@@ -97,12 +82,9 @@ def test_distributed_circuit_execution_controlled_gate(backend, accelerators):
     final_state = dist_c(np.copy(initial_state))
     target_state = c(np.copy(initial_state))
     np.testing.assert_allclose(target_state, final_state)
-    qibo.set_backend(original_backend)
 
 
 def test_distributed_circuit_execution_controlled_by_gates(backend, accelerators):
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     dist_c = DistributedCircuit(6, accelerators)
     dist_c.add([gates.H(0), gates.H(2), gates.H(3)])
     dist_c.add(gates.CNOT(4, 5))
@@ -121,13 +103,10 @@ def test_distributed_circuit_execution_controlled_by_gates(backend, accelerators
     final_state = dist_c(np.copy(initial_state))
     target_state = c(np.copy(initial_state))
     np.testing.assert_allclose(target_state, final_state)
-    qibo.set_backend(original_backend)
 
 
 def test_distributed_circuit_execution_addition(backend, accelerators):
     # Attempt to add circuits with different devices
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     c1 = DistributedCircuit(6, {"/GPU:0": 2, "/GPU:1": 2})
     c2 = DistributedCircuit(6, {"/GPU:0": 2})
     with pytest.raises(ValueError):
@@ -146,4 +125,3 @@ def test_distributed_circuit_execution_addition(backend, accelerators):
     c.add([gates.Z(i) for i in range(6)])
     assert c.depth == dist_c.depth
     np.testing.assert_allclose(dist_c(), c())
-    qibo.set_backend(original_backend)

--- a/src/qibo/tests/test_core_distutils.py
+++ b/src/qibo/tests/test_core_distutils.py
@@ -1,7 +1,6 @@
 """Test functions defined in `qibo/core/distcircuit.py`."""
 import pytest
 import numpy as np
-import qibo
 from qibo import gates
 from qibo.core.distcircuit import DistributedCircuit
 from qibo.core.distutils import DistributedQubits
@@ -9,8 +8,6 @@ from qibo.tests.test_core_distcircuit import check_device_queues
 
 
 def test_transform_queue_simple(backend):
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     devices = {"/GPU:0": 1, "/GPU:1": 1}
     c = DistributedCircuit(4, devices)
     c.add((gates.H(i) for i in range(4)))
@@ -26,12 +23,9 @@ def test_transform_queue_simple(backend):
     assert tqueue[4].target_qubits == (1,)
     assert isinstance(tqueue[5], gates.SWAP)
     assert tqueue[5].target_qubits == (0, 1)
-    qibo.set_backend(original_backend)
 
 
 def test_transform_queue_more_gates(backend):
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     devices = {"/GPU:0": 2, "/GPU:1": 2}
     c = DistributedCircuit(4, devices)
     c.add(gates.H(0))
@@ -64,12 +58,9 @@ def test_transform_queue_more_gates(backend):
     assert set(tqueue[8].target_qubits) == {0, 2}
     assert isinstance(tqueue[9], gates.SWAP)
     assert set(tqueue[9].target_qubits) == {1, 3}
-    qibo.set_backend(original_backend)
 
 
 def test_create_queue_with_global_swap(backend):
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     devices = {"/GPU:0": 2, "/GPU:1": 2}
     c = DistributedCircuit(6, devices)
     c.add([gates.H(0), gates.H(2), gates.H(3)])
@@ -88,7 +79,6 @@ def test_create_queue_with_global_swap(backend):
         assert len(device_group) == 3
     for device_group in c.queues.queues[2]:
         assert len(device_group) == 2
-    qibo.set_backend(original_backend)
 
 
 def test_create_queue_errors():

--- a/src/qibo/tests/test_core_fusion.py
+++ b/src/qibo/tests/test_core_fusion.py
@@ -1,7 +1,6 @@
 """Test functions defined in `qibo/core/fusion.py`."""
 import numpy as np
 import pytest
-import qibo
 from qibo import gates
 from qibo.core import fusion
 from qibo.models import Circuit
@@ -71,8 +70,6 @@ def test_fusion_group_add():
 
 
 def test_fusion_group_calculate(backend):
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     queue = [gates.H(0), gates.H(1), gates.CNOT(0, 1),
              gates.X(0), gates.X(1)]
     group = fusion.FusionGroup.from_queue(queue)
@@ -92,13 +89,10 @@ def test_fusion_group_calculate(backend):
     group = fusion.FusionGroup()
     with pytest.raises(RuntimeError):
         group.calculate()
-    qibo.set_backend(original_backend)
 
 
 def test_fuse_circuit_two_qubit_only(backend):
     """Check gate fusion in circuit with two-qubit gates only."""
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     c = Circuit(2)
     c.add(gates.CNOT(0, 1))
     c.add(gates.RX(0, theta=0.1234).controlled_by(1))
@@ -107,15 +101,12 @@ def test_fuse_circuit_two_qubit_only(backend):
     c.add(gates.RY(1, theta=0.1234).controlled_by(0))
     fused_c = c.fuse()
     np.testing.assert_allclose(fused_c(), c())
-    qibo.set_backend(original_backend)
 
 
 @pytest.mark.parametrize("nqubits", [4, 5, 10, 11])
 @pytest.mark.parametrize("nlayers", [1, 2])
 def test_variational_layer_fusion(backend, accelerators, nqubits, nlayers):
     """Check fused variational layer execution."""
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     theta = 2 * np.pi * np.random.random((2 * nlayers * nqubits,))
     theta_iter = iter(theta)
 
@@ -129,15 +120,12 @@ def test_variational_layer_fusion(backend, accelerators, nqubits, nlayers):
 
     fused_c = c.fuse()
     np.testing.assert_allclose(fused_c(), c())
-    qibo.set_backend(original_backend)
 
 
 @pytest.mark.parametrize("nqubits", [4, 5])
 @pytest.mark.parametrize("ngates", [10, 20])
 def test_random_circuit_fusion(backend, accelerators, nqubits, ngates):
     """Check gate fusion in randomly generated circuits."""
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     one_qubit_gates = [gates.RX, gates.RY, gates.RZ]
     two_qubit_gates = [gates.CNOT, gates.CZ, gates.SWAP]
     thetas = np.pi * np.random.random((ngates,))
@@ -154,13 +142,10 @@ def test_random_circuit_fusion(backend, accelerators, nqubits, ngates):
 
     fused_c = c.fuse()
     np.testing.assert_allclose(fused_c(), c())
-    qibo.set_backend(original_backend)
 
 
 def test_controlled_by_gates_fusion(backend):
     """Check gate fusion in circuit that contains ``controlled_by`` gates."""
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     c = Circuit(4)
     c.add((gates.H(i) for i in range(4)))
     c.add(gates.RX(1, theta=0.1234).controlled_by(0))
@@ -170,13 +155,10 @@ def test_controlled_by_gates_fusion(backend):
     c.add(gates.RX(3, theta=0.4321).controlled_by(2))
     fused_c = c.fuse()
     np.testing.assert_allclose(fused_c(), c())
-    qibo.set_backend(original_backend)
 
 
 def test_callbacks_fusion(backend, accelerators):
     """Check entropy calculation in fused circuit."""
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     from qibo import callbacks
     entropy = callbacks.EntanglementEntropy([0])
     c = Circuit(5, accelerators)
@@ -189,13 +171,10 @@ def test_callbacks_fusion(backend, accelerators):
     np.testing.assert_allclose(fused_c(), c())
     target_entropy = [0.0, 1.0, 0.0, 1.0]
     np.testing.assert_allclose(entropy[:], target_entropy, atol=1e-7)
-    qibo.set_backend(original_backend)
 
 
 def test_set_parameters_fusion(backend):
     """Check gate fusion when ``circuit.set_parameters`` is used."""
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     c = Circuit(2)
     c.add(gates.RX(0, theta=0.1234))
     c.add(gates.RX(1, theta=0.1234))
@@ -208,4 +187,3 @@ def test_set_parameters_fusion(backend):
     c.set_parameters(4 * [0.4321])
     fused_c.set_parameters(4 * [0.4321])
     np.testing.assert_allclose(fused_c(), c())
-    qibo.set_backend(original_backend)

--- a/src/qibo/tests/test_core_gates.py
+++ b/src/qibo/tests/test_core_gates.py
@@ -1,7 +1,6 @@
 """Test gates defined in `qibo/core/cgates.py` and `qibo/core/gates.py`."""
 import pytest
 import numpy as np
-import qibo
 from qibo import gates
 from qibo.config import raise_error
 from qibo.tests.utils import random_state, random_density_matrix
@@ -29,8 +28,6 @@ def apply_gates(gatelist, nqubits=None, initial_state=None):
 
 
 def test_control_unitary(backend):
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     matrix = np.random.random((2, 2))
     gate = gates.Unitary(matrix, 0)
     unitary = np.array(gate.control_unitary(matrix))
@@ -39,52 +36,37 @@ def test_control_unitary(backend):
     np.testing.assert_allclose(unitary, target_unitary)
     with pytest.raises(ValueError):
         unitary = gate.control_unitary(np.random.random((16, 16)))
-    qibo.set_backend(original_backend)
 
 
 def test_h(backend):
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     final_state = apply_gates([gates.H(0), gates.H(1)], nqubits=2)
     target_state = np.ones_like(final_state) / 2
     np.testing.assert_allclose(final_state, target_state)
-    qibo.set_backend(original_backend)
 
 
 def test_x(backend):
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     final_state = apply_gates([gates.X(0)], nqubits=2)
     target_state = np.zeros_like(final_state)
     target_state[2] = 1.0
     np.testing.assert_allclose(final_state, target_state)
-    qibo.set_backend(original_backend)
 
 
 def test_y(backend):
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     final_state = apply_gates([gates.Y(1)], nqubits=2)
     target_state = np.zeros_like(final_state)
     target_state[1] = 1j
     np.testing.assert_allclose(final_state, target_state)
-    qibo.set_backend(original_backend)
 
 
 def test_z(backend):
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     final_state = apply_gates([gates.H(0), gates.H(1), gates.Z(0)], nqubits=2)
     target_state = np.ones_like(final_state) / 2.0
     target_state[2] *= -1.0
     target_state[3] *= -1.0
     np.testing.assert_allclose(final_state, target_state)
-    qibo.set_backend(original_backend)
 
 
 def test_identity(backend):
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     gatelist = [gates.H(0), gates.H(1), gates.I(0), gates.I(1)]
     final_state = apply_gates(gatelist, nqubits=2)
     target_state = np.ones_like(final_state) / 2.0
@@ -92,13 +74,10 @@ def test_identity(backend):
     gatelist = [gates.H(0), gates.H(1), gates.I(0, 1)]
     final_state = apply_gates(gatelist, nqubits=2)
     np.testing.assert_allclose(final_state, target_state)
-    qibo.set_backend(original_backend)
 
 # :class:`qibo.core.cgates.M` is tested seperately in `test_measurement_gate.py`
 
 def test_rx(backend):
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     theta = 0.1234
     final_state = apply_gates([gates.H(0), gates.RX(0, theta=theta)], nqubits=1)
     phase = np.exp(1j * theta / 2.0)
@@ -106,12 +85,9 @@ def test_rx(backend):
                     [-1j * phase.imag, phase.real]])
     target_state = gate.dot(np.ones(2)) / np.sqrt(2)
     np.testing.assert_allclose(final_state, target_state)
-    qibo.set_backend(original_backend)
 
 
 def test_ry(backend):
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     theta = 0.1234
     final_state = apply_gates([gates.H(0), gates.RY(0, theta=theta)], nqubits=1)
     phase = np.exp(1j * theta / 2.0)
@@ -119,13 +95,10 @@ def test_ry(backend):
                      [phase.imag, phase.real]])
     target_state = gate.dot(np.ones(2)) / np.sqrt(2)
     np.testing.assert_allclose(final_state, target_state)
-    qibo.set_backend(original_backend)
 
 
 @pytest.mark.parametrize("applyx", [True, False])
 def test_rz(backend, applyx):
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     theta = 0.1234
     if applyx:
         gatelist = [gates.X(0)]
@@ -137,23 +110,17 @@ def test_rz(backend, applyx):
     p = int(applyx)
     target_state[p] = np.exp((2 * p - 1) * 1j * theta / 2.0)
     np.testing.assert_allclose(final_state, target_state)
-    qibo.set_backend(original_backend)
 
 
 def test_u1(backend):
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     theta = 0.1234
     final_state = apply_gates([gates.X(0), gates.U1(0, theta)], nqubits=1)
     target_state = np.zeros_like(final_state)
     target_state[1] = np.exp(1j * theta)
     np.testing.assert_allclose(final_state, target_state)
-    qibo.set_backend(original_backend)
 
 
 def test_u2(backend):
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     phi = 0.1234
     lam = 0.4321
     initial_state = random_state(1)
@@ -162,12 +129,9 @@ def test_u2(backend):
                        [np.exp(1j * (phi - lam) / 2), np.exp(1j * (phi + lam) / 2)]])
     target_state = matrix.dot(initial_state) / np.sqrt(2)
     np.testing.assert_allclose(final_state, target_state)
-    qibo.set_backend(original_backend)
 
 
 def test_u3(backend):
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     theta = 0.1111
     phi = 0.1234
     lam = 0.4321
@@ -181,24 +145,18 @@ def test_u3(backend):
                        [em * sint, ep * cost]])
     target_state = matrix.dot(initial_state)
     np.testing.assert_allclose(final_state, target_state)
-    qibo.set_backend(original_backend)
 
 
 def test_zpow(backend):
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     theta = 0.1234
     final_state = apply_gates([gates.X(0), gates.ZPow(0, theta)], nqubits=1)
     target_state = np.zeros_like(final_state)
     target_state[1] = np.exp(1j * theta)
     np.testing.assert_allclose(final_state, target_state)
-    qibo.set_backend(original_backend)
 
 
 @pytest.mark.parametrize("applyx", [False, True])
 def test_cnot(backend, applyx):
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     if applyx:
         gatelist = [gates.X(0)]
     else:
@@ -208,13 +166,10 @@ def test_cnot(backend, applyx):
     target_state = np.zeros_like(final_state)
     target_state[3 * int(applyx)] = 1.0
     np.testing.assert_allclose(final_state, target_state)
-    qibo.set_backend(original_backend)
 
 
 @pytest.mark.parametrize("controlled_by", [False, True])
 def test_cz(backend, controlled_by):
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     initial_state = random_state(2)
     matrix = np.eye(4)
     matrix[3, 3] = -1
@@ -226,7 +181,6 @@ def test_cz(backend, controlled_by):
     final_state = apply_gates([gate], initial_state=initial_state)
     assert gate.name == "cz"
     np.testing.assert_allclose(final_state, target_state)
-    qibo.set_backend(original_backend)
 
 
 @pytest.mark.parametrize("name,params",
@@ -237,52 +191,38 @@ def test_cz(backend, controlled_by):
                           ("CU2", {"phi": 0.1, "lam": 0.2}),
                           ("CU3", {"theta": 0.1, "phi": 0.2, "lam": 0.3})])
 def test_cun(backend, name, params):
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     initial_state = random_state(2)
     gate = getattr(gates, name)(0, 1, **params)
     final_state = apply_gates([gate], initial_state=initial_state)
     target_state = np.dot(gate.unitary, initial_state)
     np.testing.assert_allclose(final_state, target_state)
-    qibo.set_backend(original_backend)
 
 
 def test_czpow(backend):
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     theta = 0.1234
     gatelist = [gates.X(0), gates.X(1), gates.CZPow(0, 1, theta)]
     final_state = apply_gates(gatelist, nqubits=2)
     target_state = np.zeros_like(final_state)
     target_state[-1] = np.exp(1j * theta)
     np.testing.assert_allclose(final_state, target_state)
-    qibo.set_backend(original_backend)
 
 
 def test_swap(backend):
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     final_state = apply_gates([gates.X(1), gates.SWAP(0, 1)], nqubits=2)
     target_state = np.zeros_like(final_state)
     target_state[2] = 1.0
     np.testing.assert_allclose(final_state, target_state)
-    qibo.set_backend(original_backend)
 
 
 def test_multiple_swap(backend):
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     gatelist = [gates.X(0), gates.X(2), gates.SWAP(0, 1), gates.SWAP(2, 3)]
     final_state = apply_gates(gatelist, nqubits=4)
     gatelist = [gates.X(1), gates.X(3)]
     target_state = apply_gates(gatelist, nqubits=4)
     np.testing.assert_allclose(final_state, target_state)
-    qibo.set_backend(original_backend)
 
 
 def test_fsim(backend):
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     theta = 0.1234
     phi = 0.4321
     gatelist = [gates.H(0), gates.H(1), gates.fSim(0, 1, theta, phi)]
@@ -295,12 +235,9 @@ def test_fsim(backend):
     matrix[3, 3] = np.exp(-1j * phi)
     target_state = matrix.dot(target_state)
     np.testing.assert_allclose(final_state, target_state)
-    qibo.set_backend(original_backend)
 
 
 def test_generalized_fsim(backend):
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     phi = np.random.random()
     rotation = np.random.random((2, 2)) + 1j * np.random.random((2, 2))
     gatelist = [gates.H(0), gates.H(1), gates.H(2)]
@@ -313,12 +250,9 @@ def test_generalized_fsim(backend):
     target_state[:4] = matrix.dot(target_state[:4])
     target_state[4:] = matrix.dot(target_state[4:])
     np.testing.assert_allclose(final_state, target_state)
-    qibo.set_backend(original_backend)
 
 
 def test_generalized_fsim_parameter_setter(backend):
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     phi = np.random.random()
     matrix = np.random.random((2, 2))
     gate = gates.GeneralizedfSim(0, 1, matrix, phi)
@@ -327,13 +261,10 @@ def test_generalized_fsim_parameter_setter(backend):
     matrix = np.random.random((4, 4))
     with pytest.raises(ValueError):
         gate = gates.GeneralizedfSim(0, 1, matrix, phi)
-    qibo.set_backend(original_backend)
 
 
 @pytest.mark.parametrize("applyx", [False, True])
 def test_toffoli(backend, applyx):
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     if applyx:
         gatelist = [gates.X(0), gates.X(1), gates.TOFFOLI(0, 1, 2)]
     else:
@@ -345,13 +276,10 @@ def test_toffoli(backend, applyx):
     else:
         target_state[2] = 1
     np.testing.assert_allclose(final_state, target_state)
-    qibo.set_backend(original_backend)
 
 
 @pytest.mark.parametrize("nqubits", [2, 3])
 def test_unitary(backend, nqubits):
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     initial_state = np.ones(2 ** nqubits) / np.sqrt(2 ** nqubits)
     matrix = np.random.random(2 * (2 ** (nqubits - 1),))
     target_state = np.kron(np.eye(2), matrix).dot(initial_state)
@@ -359,12 +287,9 @@ def test_unitary(backend, nqubits):
     gatelist.append(gates.Unitary(matrix, *range(1, nqubits), name="random"))
     final_state = apply_gates(gatelist, nqubits=nqubits)
     np.testing.assert_allclose(final_state, target_state)
-    qibo.set_backend(original_backend)
 
 
 def test_unitary_initialization(backend):
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     matrix = np.random.random((4, 4))
     gate = gates.Unitary(matrix, 0, 1)
     np.testing.assert_allclose(gate.parameters, matrix)
@@ -377,12 +302,9 @@ def test_unitary_initialization(backend):
     if K.op is not None:
         with pytest.raises(NotImplementedError):
             gate = gates.Unitary(matrix, 0, 1, 2)
-    qibo.set_backend(original_backend)
 
 
 def test_unitary_common_gates(backend):
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     target_state = apply_gates([gates.X(0), gates.H(1)], nqubits=2)
     gatelist = [gates.Unitary(np.array([[0, 1], [1, 0]]), 0),
                 gates.Unitary(np.array([[1, 1], [1, -1]]) / np.sqrt(2), 1)]
@@ -404,13 +326,10 @@ def test_unitary_common_gates(backend):
                 gates.Unitary(cnot, 0, 1)]
     final_state = apply_gates(gatelist, nqubits=2)
     np.testing.assert_allclose(final_state, target_state)
-    qibo.set_backend(original_backend)
 
 
 @pytest.mark.parametrize("nqubits", [5, 6])
 def test_variational_layer(backend, nqubits):
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     theta = 2 * np.pi * np.random.random(nqubits)
     gatelist = [gates.RY(i, t) for i, t in enumerate(theta)]
     gatelist.extend(gates.CZ(i, i + 1) for i in range(0, nqubits - 1, 2))
@@ -422,23 +341,17 @@ def test_variational_layer(backend, nqubits):
                                   theta)
     final_state = apply_gates([gate], nqubits=nqubits)
     np.testing.assert_allclose(target_state, final_state)
-    qibo.set_backend(original_backend)
 
 
 def test_variational_layer_construct_unitary(backend):
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     pairs = list((i, i + 1) for i in range(0, 5, 2))
     theta = 2 * np.pi * np.random.random(6)
     gate = gates.VariationalLayer(range(6), pairs, gates.RY, gates.CZ, theta)
     with pytest.raises(ValueError):
         gate.construct_unitary()
-    qibo.set_backend(original_backend)
 
 
 def test_flatten(backend):
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     target_state = np.ones(4) / 2.0
     final_state = apply_gates([gates.Flatten(target_state)], nqubits=2)
     np.testing.assert_allclose(final_state, target_state)
@@ -447,7 +360,6 @@ def test_flatten(backend):
     gate = gates.Flatten(target_state)
     with pytest.raises(ValueError):
         gate.construct_unitary()
-    qibo.set_backend(original_backend)
 
 
 def test_callback_gate_errors():
@@ -459,8 +371,6 @@ def test_callback_gate_errors():
 
 
 def test_general_channel(backend):
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     from qibo import K
     a1 = np.sqrt(0.4) * np.array([[0, 1], [1, 0]])
     a2 = np.sqrt(0.6) * np.array([[1, 0, 0, 0], [0, 1, 0, 0],
@@ -475,12 +385,9 @@ def test_general_channel(backend):
     target_rho = (m1.dot(initial_rho).dot(m1.conj().T) +
                   m2.dot(initial_rho).dot(m2.conj().T))
     np.testing.assert_allclose(final_rho, target_rho)
-    qibo.set_backend(original_backend)
 
 
 def test_krauss_channel_errors(backend):
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     # bad Kraus matrix shape
     a1 = np.sqrt(0.4) * np.array([[0, 1], [1, 0]])
     with pytest.raises(ValueError):
@@ -492,7 +399,6 @@ def test_krauss_channel_errors(backend):
     # Attempt to construct unitary for KrausChannel
     with pytest.raises(ValueError):
         channel.construct_unitary()
-    qibo.set_backend(original_backend)
 
 
 def test_controlled_by_channel_error():
@@ -506,10 +412,8 @@ def test_controlled_by_channel_error():
     with pytest.raises(ValueError):
         gates.KrausChannel(config).controlled_by(1)
 
-def test_unitary_channel(backend):
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
 
+def test_unitary_channel(backend):
     a1 = np.array([[0, 1], [1, 0]])
     a2 = np.array([[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 0, 1], [0, 0, 1, 0]])
     probs = [0.4, 0.3]
@@ -526,7 +430,6 @@ def test_unitary_channel(backend):
                     + 0.4 * ma1.dot(initial_state.dot(ma1))
                     + 0.3 * ma2.dot(initial_state.dot(ma2)))
     np.testing.assert_allclose(final_state, target_state)
-    qibo.set_backend(original_backend)
 
 
 def test_unitary_channel_errors():
@@ -547,8 +450,6 @@ def test_unitary_channel_errors():
 
 
 def test_pauli_noise_channel(backend):
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     initial_rho = random_density_matrix(2)
     gate = gates.PauliNoiseChannel(1, px=0.3)
     gate.density_matrix = True
@@ -558,12 +459,9 @@ def test_pauli_noise_channel(backend):
     target_rho = 0.3 * gate(np.copy(initial_rho))
     target_rho += 0.7 * initial_rho
     np.testing.assert_allclose(final_rho, target_rho)
-    qibo.set_backend(original_backend)
 
 
 def test_reset_channel(backend):
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     initial_rho = random_density_matrix(3)
     gate = gates.ResetChannel(0, p0=0.2, p1=0.2)
     gate.density_matrix = True
@@ -580,15 +478,12 @@ def test_reset_channel(backend):
     flipped_rho = mx.dot(collapsed_rho.dot(mx))
     target_rho = 0.6 * initial_rho + 0.2 * (collapsed_rho + flipped_rho)
     np.testing.assert_allclose(final_rho, target_rho)
-    qibo.set_backend(original_backend)
 
 
 @pytest.mark.parametrize("t1,t2,time,excpop",
                          [(0.8, 0.5, 1.0, 0.4), (0.5, 0.8, 1.0, 0.4)])
 def test_thermal_relaxation_channel(backend, t1, t2, time, excpop):
     """Check ``gates.ThermalRelaxationChannel`` on a 3-qubit random density matrix."""
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     initial_rho = random_density_matrix(3)
     gate = gates.ThermalRelaxationChannel(0, t1, t2, time=time,
         excited_population=excpop)
@@ -625,7 +520,6 @@ def test_thermal_relaxation_channel(backend, t1, t2, time, excpop):
     if t1 < t2:
         with pytest.raises(ValueError):
             gate.state_vector_call(initial_rho) # pylint: disable=no-member
-    qibo.set_backend(original_backend)
 
 
 @pytest.mark.parametrize("t1,t2,time,excpop",
@@ -633,9 +527,6 @@ def test_thermal_relaxation_channel(backend, t1, t2, time, excpop):
                           (1.0, -0.5, 1.5, 0.5), (-1.0, 0.5, 1.5, 0.5),
                           (1.0, 3.0, 1.5, 0.5)])
 def test_thermal_relaxation_channel_errors(backend, t1, t2, time, excpop):
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     with pytest.raises(ValueError):
         gate = gates.ThermalRelaxationChannel(
             0, t1, t2, time, excited_population=excpop)
-    qibo.set_backend(original_backend)

--- a/src/qibo/tests/test_core_gates_controlled.py
+++ b/src/qibo/tests/test_core_gates_controlled.py
@@ -1,7 +1,6 @@
 """Test execution of `controlled_by` gates."""
 import pytest
 import numpy as np
-import qibo
 from qibo import gates
 from qibo.models import Circuit
 from qibo.tests.utils import random_state

--- a/src/qibo/tests/test_core_gates_controlled.py
+++ b/src/qibo/tests/test_core_gates_controlled.py
@@ -8,8 +8,6 @@ from qibo.tests.utils import random_state
 
 
 def test_controlled_x(backend, accelerators):
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     c = Circuit(4, accelerators)
     c.add(gates.X(0))
     c.add(gates.X(1))
@@ -21,12 +19,9 @@ def test_controlled_x(backend, accelerators):
     target_c.add(gates.X(1))
     target_c.add(gates.X(3))
     np.testing.assert_allclose(c(), target_c())
-    qibo.set_backend(original_backend)
 
 
 def test_controlled_x_vs_cnot(backend):
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     c1 = Circuit(3)
     c1.add(gates.X(0))
     c1.add(gates.X(2).controlled_by(0))
@@ -34,12 +29,9 @@ def test_controlled_x_vs_cnot(backend):
     c2.add(gates.X(0))
     c2.add(gates.CNOT(0, 2))
     np.testing.assert_allclose(c1(), c2())
-    qibo.set_backend(original_backend)
 
 
 def test_controlled_x_vs_toffoli(backend):
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     c1 = Circuit(3)
     c1.add(gates.X(0))
     c1.add(gates.X(2))
@@ -49,13 +41,10 @@ def test_controlled_x_vs_toffoli(backend):
     c2.add(gates.X(2))
     c2.add(gates.TOFFOLI(0, 2, 1))
     np.testing.assert_allclose(c1(), c2())
-    qibo.set_backend(original_backend)
 
 
 @pytest.mark.parametrize("applyx", [False, True])
 def test_controlled_rx(backend, applyx):
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     theta = 0.1234
     c = Circuit(3)
     c.add(gates.X(0))
@@ -70,12 +59,9 @@ def test_controlled_rx(backend, applyx):
         c.add(gates.RX(2, theta))
     target_state = c.execute()
     np.testing.assert_allclose(final_state, target_state)
-    qibo.set_backend(original_backend)
 
 
 def test_controlled_u1(backend):
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     theta = 0.1234
     c = Circuit(3)
     c.add(gates.X(0))
@@ -90,12 +76,9 @@ def test_controlled_u1(backend):
     np.testing.assert_allclose(final_state, target_state)
     gate = gates.U1(0, theta).controlled_by(1)
     assert gate.__class__.__name__ == "CU1"
-    qibo.set_backend(original_backend)
 
 
 def test_controlled_u2(backend):
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     phi = 0.1234
     lam = 0.4321
 
@@ -115,12 +98,9 @@ def test_controlled_u2(backend):
     # for coverage
     gate = gates.CU2(0, 1, phi, lam)
     assert gate.parameters == (phi, lam)
-    qibo.set_backend(original_backend)
 
 
 def test_controlled_u3(backend):
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     theta, phi, lam = 0.1, 0.1234, 0.4321
     initial_state = random_state(2)
     c = Circuit(2)
@@ -136,14 +116,11 @@ def test_controlled_u3(backend):
     # for coverage
     gate = gates.U3(0, theta, phi, lam)
     assert gate.parameters == (theta, phi, lam)
-    qibo.set_backend(original_backend)
 
 
 @pytest.mark.parametrize("applyx", [False, True])
 @pytest.mark.parametrize("free_qubit", [False, True])
 def test_controlled_swap(backend, applyx, free_qubit):
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     f = int(free_qubit)
     c = Circuit(3 + f)
     if applyx:
@@ -160,13 +137,10 @@ def test_controlled_swap(backend, applyx, free_qubit):
         c.add(gates.SWAP(1 + f, 2 + f))
     target_state = c.execute()
     np.testing.assert_allclose(final_state, target_state)
-    qibo.set_backend(original_backend)
 
 
 @pytest.mark.parametrize("applyx", [False, True])
 def test_controlled_swap_double(backend, applyx):
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     c = Circuit(4)
     c.add(gates.X(0))
     if applyx:
@@ -184,12 +158,9 @@ def test_controlled_swap_double(backend, applyx):
         c.add(gates.SWAP(1, 2))
     target_state = c.execute()
     np.testing.assert_allclose(final_state, target_state)
-    qibo.set_backend(original_backend)
 
 
 def test_controlled_fsim(backend, accelerators):
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     theta, phi = 0.1234, 0.4321
     c = Circuit(6, accelerators)
     c.add((gates.H(i) for i in range(6)))
@@ -207,12 +178,9 @@ def test_controlled_fsim(backend, accelerators):
     ids = [58, 59, 62, 63]
     target_state[ids] = matrix.dot(target_state[ids])
     np.testing.assert_allclose(final_state, target_state)
-    qibo.set_backend(original_backend)
 
 
 def test_controlled_unitary(backend, accelerators):
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     matrix = np.random.random((2, 2))
     c = Circuit(2)
     c.add(gates.H(0))
@@ -232,12 +200,9 @@ def test_controlled_unitary(backend, accelerators):
     ids = [10, 11, 14, 15]
     target_state[ids] = matrix.dot(target_state[ids])
     np.testing.assert_allclose(final_state, target_state)
-    qibo.set_backend(original_backend)
 
 
 def test_controlled_unitary_matrix(backend):
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     initial_state = random_state(2)
     matrix = np.random.random((2, 2))
     gate = gates.Unitary(matrix, 1).controlled_by(0)
@@ -246,4 +211,3 @@ def test_controlled_unitary_matrix(backend):
     target_state = c(np.copy(initial_state))
     final_state = np.dot(gate.unitary, initial_state)
     np.testing.assert_allclose(final_state, target_state)
-    qibo.set_backend(original_backend)

--- a/src/qibo/tests/test_core_gates_density_matrix.py
+++ b/src/qibo/tests/test_core_gates_density_matrix.py
@@ -1,7 +1,6 @@
 """Test gates defined in `qibo/core/cgates.py` and `qibo/core/gates.py` for density matrices."""
 import pytest
 import numpy as np
-import qibo
 from qibo import gates
 from qibo.config import raise_error
 

--- a/src/qibo/tests/test_core_gates_density_matrix.py
+++ b/src/qibo/tests/test_core_gates_density_matrix.py
@@ -32,8 +32,6 @@ def random_density_matrix(nqubits):
 
 
 def test_hgate_density_matrix(backend):
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     initial_rho = random_density_matrix(2)
     gate = gates.H(1)
     gate.density_matrix = True
@@ -43,12 +41,9 @@ def test_hgate_density_matrix(backend):
     matrix = np.kron(np.eye(2), matrix)
     target_rho = matrix.dot(initial_rho).dot(matrix)
     np.testing.assert_allclose(final_rho, target_rho)
-    qibo.set_backend(original_backend)
 
 
 def test_rygate_density_matrix(backend):
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     theta = 0.1234
     initial_rho = random_density_matrix(1)
 
@@ -61,7 +56,6 @@ def test_rygate_density_matrix(backend):
     target_rho = matrix.dot(initial_rho).dot(matrix.T.conj())
 
     np.testing.assert_allclose(final_rho, target_rho, atol=_atol)
-    qibo.set_backend(original_backend)
 
 
 @pytest.mark.parametrize("gatename,gatekwargs",
@@ -73,8 +67,6 @@ def test_rygate_density_matrix(backend):
                           ("U3", {"theta": 0.123, "phi": 0.321, "lam": 0.123})])
 def test_one_qubit_gates(backend, gatename, gatekwargs):
     """Check applying one qubit gates to one qubit density matrix."""
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     initial_rho = random_density_matrix(1)
     gate = getattr(gates, gatename)(0, **gatekwargs)
     gate.density_matrix = True
@@ -83,13 +75,10 @@ def test_one_qubit_gates(backend, gatename, gatekwargs):
     matrix = np.array(gate.unitary)
     target_rho = np.einsum("ab,bc,cd->ad", matrix, initial_rho, matrix.conj().T)
     np.testing.assert_allclose(final_rho, target_rho)
-    qibo.set_backend(original_backend)
 
 
 @pytest.mark.parametrize("gatename", ["H", "X", "Y", "Z"])
 def test_controlled_by_one_qubit_gates(backend, gatename):
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     initial_rho = random_density_matrix(2)
     gate = getattr(gates, gatename)(1).controlled_by(0)
     gate.density_matrix = True
@@ -101,7 +90,6 @@ def test_controlled_by_one_qubit_gates(backend, gatename):
     cmatrix[2:, 2:] = matrix
     target_rho = np.einsum("ab,bc,cd->ad", cmatrix, initial_rho, cmatrix.conj().T)
     np.testing.assert_allclose(final_rho, target_rho)
-    qibo.set_backend(original_backend)
 
 
 @pytest.mark.parametrize("gatename,gatekwargs",
@@ -114,8 +102,6 @@ def test_controlled_by_one_qubit_gates(backend, gatename):
                           ("fSim", {"theta": 0.123, "phi": 0.543})])
 def test_two_qubit_gates(backend, gatename, gatekwargs):
     """Check applying two qubit gates to two qubit density matrix."""
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     initial_rho = random_density_matrix(2)
     gate = getattr(gates, gatename)(0, 1, **gatekwargs)
     gate.density_matrix = True
@@ -124,13 +110,10 @@ def test_two_qubit_gates(backend, gatename, gatekwargs):
     matrix = np.array(gate.unitary)
     target_rho = np.einsum("ab,bc,cd->ad", matrix, initial_rho, matrix.conj().T)
     np.testing.assert_allclose(final_rho, target_rho, atol=_atol)
-    qibo.set_backend(original_backend)
 
 
 def test_toffoli_gate(backend):
     """Check applying Toffoli to three qubit density matrix."""
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     initial_rho = random_density_matrix(3)
     gate = gates.TOFFOLI(0, 1, 2)
     gate.density_matrix = True
@@ -139,14 +122,11 @@ def test_toffoli_gate(backend):
     matrix = np.array(gate.unitary)
     target_rho = np.einsum("ab,bc,cd->ad", matrix, initial_rho, matrix.conj().T)
     np.testing.assert_allclose(final_rho, target_rho)
-    qibo.set_backend(original_backend)
 
 
 @pytest.mark.parametrize("nqubits", [1, 2, 3])
 def test_unitary_gate(backend, nqubits):
     """Check applying `gates.Unitary` to density matrix."""
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     shape = 2 * (2 ** nqubits,)
     matrix = np.random.random(shape) + 1j * np.random.random(shape)
     initial_rho = random_density_matrix(nqubits)
@@ -160,13 +140,10 @@ def test_unitary_gate(backend, nqubits):
         final_rho = gate(np.copy(initial_rho))
         target_rho = np.einsum("ab,bc,cd->ad", matrix, initial_rho, matrix.conj().T)
         np.testing.assert_allclose(final_rho, target_rho)
-    qibo.set_backend(original_backend)
 
 
 def test_cu1gate_application_twoqubit(backend):
     """Check applying two qubit gate to three qubit density matrix."""
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     theta = 0.1234
     nqubits = 3
     initial_rho = random_density_matrix(nqubits)
@@ -179,26 +156,20 @@ def test_cu1gate_application_twoqubit(backend):
     matrix = np.kron(matrix, np.eye(2))
     target_rho = matrix.dot(initial_rho).dot(matrix.T.conj())
     np.testing.assert_allclose(final_rho, target_rho)
-    qibo.set_backend(original_backend)
 
 
 def test_flatten_density_matrix(backend):
     """Check ``Flatten`` gate works with density matrices."""
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     target_rho = random_density_matrix(3)
     initial_rho = np.zeros(6 * (2,))
     gate = gates.Flatten(target_rho)
     gate.density_matrix = True
     final_rho = np.reshape(gate(initial_rho), (8, 8))
     np.testing.assert_allclose(final_rho, target_rho)
-    qibo.set_backend(original_backend)
 
 
 def test_controlled_by_no_effect(backend):
     """Check controlled_by SWAP that should not be applied."""
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     from qibo.models import Circuit
     initial_rho = np.zeros((16, 16))
     initial_rho[0, 0] = 1
@@ -212,13 +183,10 @@ def test_controlled_by_no_effect(backend):
     c.add(gates.X(0))
     target_rho = c(np.copy(initial_rho)).numpy()
     np.testing.assert_allclose(final_rho, target_rho)
-    qibo.set_backend(original_backend)
 
 
 def test_controlled_with_effect(backend):
     """Check controlled_by SWAP that should be applied."""
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     from qibo.models import Circuit
     initial_rho = np.zeros((16, 16))
     initial_rho[0, 0] = 1
@@ -235,14 +203,11 @@ def test_controlled_with_effect(backend):
     c.add(gates.SWAP(1, 3))
     target_rho = c(np.copy(initial_rho)).numpy()
     np.testing.assert_allclose(final_rho, target_rho)
-    qibo.set_backend(original_backend)
 
 
 @pytest.mark.parametrize("nqubits", [4, 5])
 def test_controlled_by_random(backend, nqubits):
     """Check controlled_by method on gate."""
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     from qibo.models import Circuit
     from qibo.tests.utils import random_state
     initial_psi = random_state(nqubits)
@@ -258,13 +223,10 @@ def test_controlled_by_random(backend, nqubits):
     target_psi = c(np.copy(initial_psi))
     target_rho = np.outer(target_psi, np.conj(target_psi))
     np.testing.assert_allclose(final_rho, target_rho)
-    qibo.set_backend(original_backend)
 
 
 @pytest.mark.parametrize("qubit", [0, 1, 2])
 def test_partial_trace_gate(backend, qubit):
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     gate = gates.PartialTrace(qubit)
     gate.density_matrix = True
     initial_rho = random_density_matrix(3)
@@ -280,12 +242,9 @@ def test_partial_trace_gate(backend, qubit):
         target_state = np.einsum("ABcabc,Dd->ABDabd", target_state, zero_state)
     target_state = np.reshape(target_state, (8, 8))
     np.testing.assert_allclose(final_state, target_state)
-    qibo.set_backend(original_backend)
 
 
 def test_partial_trace_gate_errors(backend):
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     gate = gates.PartialTrace(0, 1)
     # attempt to create unitary matrix
     with pytest.raises(ValueError):
@@ -294,12 +253,9 @@ def test_partial_trace_gate_errors(backend):
     state = np.random.random(16) + 1j * np.random.random(16)
     with pytest.raises(RuntimeError):
         gate(state)
-    qibo.set_backend(original_backend)
 
 
 def test_channel_gate_setters(backend):
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     a1 = np.sqrt(0.4) * np.array([[0, 1], [1, 0]])
     a2 = np.sqrt(0.6) * np.array([[1, 0, 0, 0], [0, 1, 0, 0],
                                   [0, 0, 0, 1], [0, 0, 1, 0]])
@@ -314,13 +270,10 @@ def test_channel_gate_setters(backend):
         if gate is not None:
             assert gate.nqubits == 5
             assert gate.density_matrix
-    qibo.set_backend(original_backend)
 
 
 def test_measurement_density_matrix(backend):
     from qibo.tests.test_measurement_gate import assert_result
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     state = np.zeros(4)
     state[2] = 1
     rho = np.outer(state, state.conj())
@@ -335,13 +288,10 @@ def test_measurement_density_matrix(backend):
                   binary_samples=target_binary_samples,
                   decimal_frequencies={2: 100},
                   binary_frequencies={"10": 100})
-    qibo.set_backend(original_backend)
 
 
 @pytest.mark.parametrize("nqubits", [5, 6])
 def test_variational_layer_density_matrix(backend, nqubits):
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     from qibo.models import Circuit
     theta = 2 * np.pi * np.random.random(nqubits)
     c = Circuit(nqubits, density_matrix=True)
@@ -359,4 +309,3 @@ def test_variational_layer_density_matrix(backend, nqubits):
     gate.density_matrix = True
     final_state = gate(c.get_initial_state())
     np.testing.assert_allclose(target_state, final_state)
-    qibo.set_backend(original_backend)

--- a/src/qibo/tests/test_core_gates_features.py
+++ b/src/qibo/tests/test_core_gates_features.py
@@ -1,7 +1,6 @@
 """Test special features of core gates."""
 import pytest
 import numpy as np
-import qibo
 from qibo import K, gates
 from qibo.models import Circuit
 from qibo.tests.utils import random_state

--- a/src/qibo/tests/test_core_gates_features.py
+++ b/src/qibo/tests/test_core_gates_features.py
@@ -31,11 +31,8 @@ GATES = [
 @pytest.mark.parametrize("gate,qubits,target_matrix", GATES)
 def test_construct_unitary(backend, gate, qubits, target_matrix):
     """Check that `construct_unitary` method constructs the proper matrix."""
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     gate = getattr(gates, gate)(*qubits)
     np.testing.assert_allclose(gate.unitary, target_matrix)
-    qibo.set_backend(original_backend)
 
 
 GATES = [
@@ -50,20 +47,15 @@ GATES = [
 @pytest.mark.parametrize("gate,target_matrix", GATES)
 def test_construct_unitary_rotations(backend, gate, target_matrix):
     """Check that `construct_unitary` method constructs the proper matrix."""
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     theta = 0.1234
     if gate == "CU1":
         gate = getattr(gates, gate)(0, 1, theta)
     else:
         gate = getattr(gates, gate)(0, theta)
     np.testing.assert_allclose(gate.unitary, target_matrix(theta))
-    qibo.set_backend(original_backend)
 
 
 def test_construct_unitary_controlled(backend):
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     theta = 0.1234
     rotation = np.array([[np.cos(theta / 2.0), -np.sin(theta / 2.0)],
                          [np.sin(theta / 2.0), np.cos(theta / 2.0)]])
@@ -75,17 +67,12 @@ def test_construct_unitary_controlled(backend):
     gate = gates.RY(0, theta).controlled_by(1, 2)
     with pytest.raises(NotImplementedError):
         unitary = gate.unitary
-    qibo.set_backend(original_backend)
 
 ###############################################################################
 
 ########################### Test `Collapse` features ##########################
 @pytest.mark.parametrize("nqubits,targets", [(5, [2, 4]), (6, [3, 5])])
 def test_measurement_collapse_distributed(backend, accelerators, nqubits, targets):
-    # TODO: Add accelerators in this test once you fix `gates.M` collapse for
-    # distributed circuit
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     initial_state = random_state(nqubits)
     c = Circuit(nqubits, accelerators)
     output = c.add(gates.M(*targets, collapse=True))
@@ -100,12 +87,9 @@ def test_measurement_collapse_distributed(backend, accelerators, nqubits, target
     norm = (np.abs(target_state) ** 2).sum()
     target_state = target_state.ravel() / np.sqrt(norm)
     np.testing.assert_allclose(result.state(), target_state)
-    qibo.set_backend(original_backend)
 
 
 def test_collapse_after_measurement(backend):
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     qubits = [0, 2, 3]
     c = Circuit(5)
     c.add((gates.H(i) for i in range(5)))
@@ -122,7 +106,6 @@ def test_collapse_after_measurement(backend):
     ct.add((gates.H(i) for i in qubits))
     target_state = ct()
     np.testing.assert_allclose(final_state, target_state, atol=1e-15)
-    qibo.set_backend(original_backend)
 
 ###############################################################################
 
@@ -135,8 +118,6 @@ def test_rx_parameter_setter(backend):
                         [-1j * phase.imag, phase.real]])
         return gate.dot(np.ones(2)) / np.sqrt(2)
 
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     theta = 0.1234
     gate = gates.RX(0, theta=theta)
     initial_state = K.cast(np.ones(2) / np.sqrt(2))
@@ -150,7 +131,6 @@ def test_rx_parameter_setter(backend):
     final_state = gate(initial_state)
     target_state = exact_state(theta)
     np.testing.assert_allclose(final_state, target_state)
-    qibo.set_backend(original_backend)
 
 ###############################################################################
 
@@ -164,8 +144,6 @@ def test_rx_parameter_setter(backend):
 @pytest.mark.parametrize("use_toffolis", [True, False])
 def test_x_decomposition_execution(backend, target, controls, free, use_toffolis):
     """Check that applying the decomposition is equivalent to applying the multi-control gate."""
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     gate = gates.X(target).controlled_by(*controls)
     nqubits = max((target,) + controls + free) + 1
     initial_state = random_state(nqubits)
@@ -176,14 +154,11 @@ def test_x_decomposition_execution(backend, target, controls, free, use_toffolis
     c.add(gate.decompose(*free, use_toffolis=use_toffolis))
     final_state = c(np.copy(initial_state))
     np.testing.assert_allclose(final_state, target_state, atol=1e-6)
-    qibo.set_backend(original_backend)
 
 ###############################################################################
 
 ########################### Test gate decomposition ###########################
 def test_one_qubit_gate_multiplication(backend):
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     gate1 = gates.X(0)
     gate2 = gates.H(0)
     final_gate = gate1 @ gate2
@@ -202,12 +177,9 @@ def test_one_qubit_gate_multiplication(backend):
     gate2 = gates.X(1)
     assert (gate1 @ gate2).__class__.__name__ == "I"
     assert (gate2 @ gate1).__class__.__name__ == "I"
-    qibo.set_backend(original_backend)
 
 
 def test_two_qubit_gate_multiplication(backend):
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     theta, phi = 0.1234, 0.5432
     gate1 = gates.fSim(0, 1, theta=theta, phi=phi)
     gate2 = gates.SWAP(0, 1)
@@ -222,7 +194,6 @@ def test_two_qubit_gate_multiplication(backend):
     # Check that error is raised when target qubits do not agree
     with pytest.raises(NotImplementedError):
         final_gate = gate1 @ gates.SWAP(0, 2)
-    qibo.set_backend(original_backend)
 
 
 ###############################################################################
@@ -249,8 +220,6 @@ GATES = [
 ]
 @pytest.mark.parametrize("gate,args", GATES)
 def test_dagger(backend, gate, args):
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     gate = getattr(gates, gate)(*args)
     nqubits = len(gate.qubits)
     c = Circuit(nqubits)
@@ -258,7 +227,6 @@ def test_dagger(backend, gate, args):
     initial_state = random_state(nqubits)
     final_state = c(np.copy(initial_state))
     np.testing.assert_allclose(final_state, initial_state)
-    qibo.set_backend(original_backend)
 
 
 GATES = [
@@ -271,21 +239,16 @@ GATES = [
 ]
 @pytest.mark.parametrize("gate,args", GATES)
 def test_controlled_dagger(backend, gate, args):
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     gate = getattr(gates, gate)(*args).controlled_by(0, 1, 2)
     c = Circuit(4)
     c.add((gate, gate.dagger()))
     initial_state = random_state(4)
     final_state = c(np.copy(initial_state))
     np.testing.assert_allclose(final_state, initial_state)
-    qibo.set_backend(original_backend)
 
 
 @pytest.mark.parametrize("nqubits", [1, 2])
 def test_unitary_dagger(backend, nqubits):
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     matrix = np.random.random((2 ** nqubits, 2 ** nqubits))
     gate = gates.Unitary(matrix, *range(nqubits))
     c = Circuit(nqubits)
@@ -295,13 +258,10 @@ def test_unitary_dagger(backend, nqubits):
     target_state = np.dot(matrix, initial_state)
     target_state = np.dot(np.conj(matrix).T, target_state)
     np.testing.assert_allclose(final_state, target_state)
-    qibo.set_backend(original_backend)
 
 
 def test_controlled_unitary_dagger(backend):
     from scipy.linalg import expm
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     matrix = np.random.random((2, 2))
     matrix = expm(1j * (matrix + matrix.T))
     gate = gates.Unitary(matrix, 0).controlled_by(1, 2, 3, 4)
@@ -310,13 +270,10 @@ def test_controlled_unitary_dagger(backend):
     initial_state = random_state(5)
     final_state = c(np.copy(initial_state))
     np.testing.assert_allclose(final_state, initial_state)
-    qibo.set_backend(original_backend)
 
 
 def test_generalizedfsim_dagger(backend):
     from scipy.linalg import expm
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     phi = 0.2
     matrix = np.random.random((2, 2))
     matrix = expm(1j * (matrix + matrix.T))
@@ -326,13 +283,10 @@ def test_generalizedfsim_dagger(backend):
     initial_state = random_state(2)
     final_state = c(np.copy(initial_state))
     np.testing.assert_allclose(final_state, initial_state)
-    qibo.set_backend(original_backend)
 
 
 @pytest.mark.parametrize("nqubits", [4, 5])
 def test_variational_layer_dagger(backend, nqubits):
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     theta = 2 * np.pi * np.random.random((2, nqubits))
     pairs = list((i, i + 1) for i in range(0, nqubits - 1, 2))
     gate = gates.VariationalLayer(range(nqubits), pairs,
@@ -343,15 +297,11 @@ def test_variational_layer_dagger(backend, nqubits):
     initial_state = random_state(nqubits)
     final_state = c(np.copy(initial_state))
     np.testing.assert_allclose(final_state, initial_state)
-    qibo.set_backend(original_backend)
 
 ###############################################################################
 
 ##################### Test repeated execution with channels ###################
 def test_noise_channel_repeated(backend):
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
-
     thetas = np.random.random(4)
     probs = 0.1 * np.random.random([4, 3]) + 0.2
     gatelist = [gates.X, gates.Y, gates.Z]
@@ -373,13 +323,9 @@ def test_noise_channel_repeated(backend):
                     noiseless_c.add(gate(i))
         target_state.append(noiseless_c())
     np.testing.assert_allclose(final_state, target_state)
-    qibo.set_backend(original_backend)
 
 
 def test_reset_channel_repeated(backend):
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
-
     initial_state = random_state(5)
     c = Circuit(5)
     c.add(gates.ResetChannel(2, p0=0.3, p1=0.3, seed=123))
@@ -399,13 +345,9 @@ def test_reset_channel_repeated(backend):
             state = xgate(state)
         target_state.append(np.copy(state))
     np.testing.assert_allclose(final_state, target_state)
-    qibo.set_backend(original_backend)
 
 
 def test_thermal_relaxation_channel_repeated(backend):
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
-
     initial_state = random_state(5)
     c = Circuit(5)
     c.add(gates.ThermalRelaxationChannel(4, t1=1.0, t2=0.6, time=0.8,
@@ -429,6 +371,5 @@ def test_thermal_relaxation_channel_repeated(backend):
             state = xgate(state)
         target_state.append(np.copy(state))
     np.testing.assert_allclose(final_state, target_state)
-    qibo.set_backend(original_backend)
 
 ###############################################################################

--- a/src/qibo/tests/test_core_hamiltonians_trotter.py
+++ b/src/qibo/tests/test_core_hamiltonians_trotter.py
@@ -148,8 +148,6 @@ def test_trotter_hamiltonian_operation_errors():
 
 def test_trotter_hamiltonian_three_qubit_term(backend):
     """Test creating ``TrotterHamiltonian`` with three qubit term."""
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     from scipy.linalg import expm
     m1 = random_hermitian(3)
     m2 = random_hermitian(2)
@@ -182,8 +180,6 @@ def test_trotter_hamiltonian_three_qubit_term(backend):
         target_state = u[2].dot(u[1].dot(u[0])).dot(initial_state)
         target_state = u[0].dot(u[1].dot(u[2])).dot(target_state)
         np.testing.assert_allclose(final_state, target_state)
-
-    qibo.set_backend(original_backend)
 
 
 def test_trotter_hamiltonian_make_compatible_simple():

--- a/src/qibo/tests/test_core_states.py
+++ b/src/qibo/tests/test_core_states.py
@@ -1,27 +1,21 @@
 """Tests methods defined in `qibo/core/states.py`."""
 import pytest
 import numpy as np
-import qibo
 from qibo import K
 from qibo.core import states
 
 
 def test_state_shape_and_dtype(backend):
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     state = states.VectorState.zero_state(3)
     assert state.shape == (8,)
     assert state.dtype == K.dtypes('DTYPECPX')
     state = states.MatrixState.zero_state(3)
     assert state.shape == (8, 8)
     assert state.dtype == K.dtypes('DTYPECPX')
-    qibo.set_backend(original_backend)
 
 
 @pytest.mark.parametrize("nqubits", [None, 2])
 def test_vector_state_tensor_setter(backend, nqubits):
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     state = states.VectorState(nqubits)
     with pytest.raises(AttributeError):
         tensor = state.tensor
@@ -34,20 +28,15 @@ def test_vector_state_tensor_setter(backend, nqubits):
     np.testing.assert_allclose(state.state(numpy=False), np.ones(4))
     with pytest.raises(ValueError):
         state.tensor = np.zeros(5)
-    qibo.set_backend(original_backend)
 
 
 @pytest.mark.parametrize("nqubits", [None, 2])
 def test_matrix_state_tensor_setter(backend, nqubits):
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     # TODO: Fix this
-    qibo.set_backend(original_backend)
+    pass
 
 
 def test_zero_state_initialization(backend):
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     state = states.VectorState.zero_state(4)
     target_state = np.zeros(16)
     target_state[0] = 1
@@ -56,24 +45,18 @@ def test_zero_state_initialization(backend):
     target_state = np.zeros((8, 8))
     target_state[0, 0] = 1
     np.testing.assert_allclose(state.tensor, target_state)
-    qibo.set_backend(original_backend)
 
 
 def test_plus_state_initialization(backend):
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     state = states.VectorState.plus_state(4)
     target_state = np.ones(16) / 4
     np.testing.assert_allclose(state.tensor, target_state)
     state = states.MatrixState.plus_state(3)
     target_state = np.ones((8, 8)) / 8
     np.testing.assert_allclose(state.tensor, target_state)
-    qibo.set_backend(original_backend)
 
 
 def test_vector_state_to_density_matrix(backend):
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     vector = np.random.random(32) + 1j * np.random.random(32)
     vector = vector / np.sqrt((np.abs(vector) ** 2).sum())
     state = states.VectorState.from_tensor(vector)
@@ -83,7 +66,6 @@ def test_vector_state_to_density_matrix(backend):
     state = states.MatrixState.from_tensor(target_matrix)
     with pytest.raises(RuntimeError):
         state.to_density_matrix()
-    qibo.set_backend(original_backend)
 
 
 @pytest.mark.parametrize("state_type", ["VectorState", "MatrixState"])
@@ -155,8 +137,6 @@ def test_state_apply_bitflips():
 
 @pytest.mark.parametrize("trotter", [True, False])
 def test_vector_state_expectation(backend, trotter):
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     from qibo.hamiltonians import XXZ
     ham = XXZ(nqubits=5, delta=0.5, trotter=trotter)
     matrix = np.array(ham.matrix)
@@ -168,13 +148,10 @@ def test_vector_state_expectation(backend, trotter):
 
     np.testing.assert_allclose(state.expectation(ham), target_ev)
     np.testing.assert_allclose(state.expectation(ham, True), target_ev / norm)
-    qibo.set_backend(original_backend)
 
 
 @pytest.mark.parametrize("trotter", [True, False])
 def test_matrix_state_expectation(backend, trotter):
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     from qibo.hamiltonians import TFIM
     ham = TFIM(nqubits=2, h=1.0, trotter=trotter)
     matrix = np.array(ham.matrix)
@@ -187,4 +164,3 @@ def test_matrix_state_expectation(backend, trotter):
 
     np.testing.assert_allclose(state.expectation(ham), target_ev)
     np.testing.assert_allclose(state.expectation(ham, True), target_ev / norm)
-    qibo.set_backend(original_backend)

--- a/src/qibo/tests/test_measurement_gate.py
+++ b/src/qibo/tests/test_measurement_gate.py
@@ -1,7 +1,6 @@
 """Test :class:`qibo.abstractions.gates.M` as standalone and as part of circuit."""
 import pytest
 import numpy as np
-import qibo
 from qibo import models, gates
 
 
@@ -20,19 +19,14 @@ def assert_result(result, decimal_samples=None, binary_samples=None,
 @pytest.mark.parametrize("n", [0, 1])
 @pytest.mark.parametrize("nshots", [100, 1000000])
 def test_measurement_gate(backend, n, nshots):
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     state = np.zeros(4)
     state[-n] = 1
     result = gates.M(0)(state, nshots=nshots)
     assert_result(result, n * np.ones(nshots), n * np.ones((nshots, 1)),
                   {n: nshots}, {str(n): nshots})
-    qibo.set_backend(original_backend)
 
 
 def test_multiple_qubit_measurement_gate(backend):
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     state = np.zeros(4)
     state[2] = 1
     result = gates.M(0, 1)(state, nshots=100)
@@ -40,12 +34,9 @@ def test_multiple_qubit_measurement_gate(backend):
     target_binary_samples[:, 0] = 1
     assert_result(result, 2 * np.ones((100,)), target_binary_samples,
                   {2: 100}, {"10": 100})
-    qibo.set_backend(original_backend)
 
 
 def test_measurement_gate_errors(backend):
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     gate = gates.M(0)
     # attempting to use `controlled_by`
     with pytest.raises(NotImplementedError):
@@ -56,12 +47,9 @@ def test_measurement_gate_errors(backend):
     # calling on bad state
     with pytest.raises(TypeError):
         gate("test", 100)
-    qibo.set_backend(original_backend)
 
 
 def test_measurement_circuit(backend, accelerators):
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     c = models.Circuit(4, accelerators)
     c.add(gates.X(0))
     c.add(gates.M(0))
@@ -69,12 +57,9 @@ def test_measurement_circuit(backend, accelerators):
     assert_result(result,
                   np.ones((100,)), np.ones((100, 1)),
                   {1: 100}, {"1": 100})
-    qibo.set_backend(original_backend)
 
 
 def test_gate_after_measurement_error(backend, accelerators):
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     c = models.Circuit(4, accelerators)
     c.add(gates.X(0))
     c.add(gates.M(0))
@@ -82,13 +67,10 @@ def test_gate_after_measurement_error(backend, accelerators):
     # TODO: Change this to NotImplementedError
     with pytest.raises(ValueError):
         c.add(gates.H(0))
-    qibo.set_backend(original_backend)
 
 
 @pytest.mark.parametrize("registers", [False, True])
 def test_measurement_qubit_order_simple(backend, registers):
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     c = models.Circuit(2)
     c.add(gates.X(0))
     if registers:
@@ -102,13 +84,10 @@ def test_measurement_qubit_order_simple(backend, registers):
     target_binary_samples[:, 1] = 1
     assert_result(result, np.ones(100), target_binary_samples,
                   {1: 100}, {"01": 100})
-    qibo.set_backend(original_backend)
 
 
 @pytest.mark.parametrize("nshots", [100, 1000000])
 def test_measurement_qubit_order(backend, accelerators, nshots):
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     c = models.Circuit(6, accelerators)
     c.add(gates.X(0))
     c.add(gates.X(1))
@@ -120,12 +99,9 @@ def test_measurement_qubit_order(backend, accelerators, nshots):
     target_binary_samples[:, 3] = 1
     assert_result(result, 9 * np.ones(nshots), target_binary_samples,
                   {9: nshots}, {"1001": nshots})
-    qibo.set_backend(original_backend)
 
 
 def test_multiple_measurement_gates_circuit(backend):
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     c = models.Circuit(4)
     c.add(gates.X(1))
     c.add(gates.X(2))
@@ -138,12 +114,9 @@ def test_multiple_measurement_gates_circuit(backend):
     target_binary_samples[:, 0] = 0
     assert_result(result, 3 * np.ones(100), target_binary_samples,
                   {3: 100}, {"011": 100})
-    qibo.set_backend(original_backend)
 
 
 def test_circuit_with_unmeasured_qubits(backend, accelerators):
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     c = models.Circuit(5, accelerators)
     c.add(gates.X(4))
     c.add(gates.X(2))
@@ -157,12 +130,9 @@ def test_circuit_with_unmeasured_qubits(backend, accelerators):
     target_binary_samples[:, 3] = 1
     assert_result(result, 5 * np.ones(100), target_binary_samples,
                   {5: 100}, {"0101": 100})
-    qibo.set_backend(original_backend)
 
 
 def test_circuit_addition_with_measurements(backend):
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     c = models.Circuit(2)
     c.add(gates.H(0))
     c.add(gates.H(1))
@@ -173,12 +143,9 @@ def test_circuit_addition_with_measurements(backend):
     c += meas_c
     assert len(c.measurement_gate.target_qubits) == 2
     assert c.measurement_tuples == {"register0": (0, 1)}
-    qibo.set_backend(original_backend)
 
 
 def test_circuit_addition_with_measurements_in_both_circuits(backend, accelerators):
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     c1 = models.Circuit(4, accelerators)
     c1.add(gates.H(0))
     c1.add(gates.H(1))
@@ -191,12 +158,9 @@ def test_circuit_addition_with_measurements_in_both_circuits(backend, accelerato
     c = c1 + c2
     assert len(c.measurement_gate.target_qubits) == 2
     assert c.measurement_tuples == {"a": (1,), "b": (0,)}
-    qibo.set_backend(original_backend)
 
 
 def test_gate_after_measurement_with_addition_error(backend, accelerators):
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     c = models.Circuit(4, accelerators)
     c.add(gates.H(0))
     c.add(gates.M(1))
@@ -211,12 +175,9 @@ def test_gate_after_measurement_with_addition_error(backend, accelerators):
     c2.add(gates.M(1, register_name="a"))
     with pytest.raises(ValueError):
         c += c2
-    qibo.set_backend(original_backend)
 
 
 def test_circuit_copy_with_measurements(backend, accelerators):
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     c1 = models.Circuit(6, accelerators)
     c1.add([gates.X(0), gates.X(1), gates.X(3)])
     c1.add(gates.M(5, 1, 3, register_name="a"))
@@ -232,12 +193,9 @@ def test_circuit_copy_with_measurements(backend, accelerators):
     assert rg1.keys() == rg2.keys()
     for k in rg1.keys():
         assert rg1[k] == rg2[k]
-    qibo.set_backend(original_backend)
 
 
 def test_measurement_compiled_circuit(backend):
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     from qibo import K
     if K.op is not None:
         # use native gates because custom gates do not support compilation
@@ -256,13 +214,10 @@ def test_measurement_compiled_circuit(backend):
     target_state = np.zeros_like(c.final_state)
     target_state[2] = 1
     np.testing.assert_allclose(c.final_state, target_state)
-    qibo.set_backend(original_backend)
 
 
 def test_final_state(backend, accelerators):
     """Check that final state is logged correctly when using measurements."""
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     c = models.Circuit(4, accelerators)
     c.add(gates.X(1))
     c.add(gates.X(2))
@@ -278,7 +233,6 @@ def test_final_state(backend, accelerators):
     target_state = c()
 
     np.testing.assert_allclose(c.final_state, target_state)
-    qibo.set_backend(original_backend)
 
 
 def test_measurement_gate_bitflip_errors():

--- a/src/qibo/tests/test_measurement_gate_collapse.py
+++ b/src/qibo/tests/test_measurement_gate_collapse.py
@@ -1,7 +1,6 @@
 """Test :class:`qibo.abstractions.gates.M` as standalone and as part of circuit."""
 import pytest
 import numpy as np
-import qibo
 from qibo import models, gates, K
 from qibo.tests.utils import random_state, random_density_matrix
 
@@ -10,8 +9,6 @@ from qibo.tests.utils import random_state, random_density_matrix
                          [(2, [1]), (3, [1]), (4, [1, 3]), (5, [0, 3, 4]),
                           (6, [1, 3]), (4, [0, 2])])
 def test_measurement_collapse(backend, nqubits, targets):
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     initial_state = random_state(nqubits)
     gate = gates.M(*targets, collapse=True)
     final_state = gate(np.copy(initial_state), nshots=1)
@@ -26,14 +23,11 @@ def test_measurement_collapse(backend, nqubits, targets):
     norm = (np.abs(target_state) ** 2).sum()
     target_state = target_state.ravel() / np.sqrt(norm)
     np.testing.assert_allclose(final_state, target_state)
-    qibo.set_backend(original_backend)
 
 
 @pytest.mark.parametrize("nqubits,targets",
                          [(2, [1]), (3, [1]), (4, [1, 3]), (5, [0, 3, 4])])
 def test_measurement_collapse_density_matrix(backend, nqubits, targets):
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     initial_rho = random_density_matrix(nqubits)
     gate = gates.M(*targets, collapse=True)
     gate.density_matrix = True
@@ -51,22 +45,16 @@ def test_measurement_collapse_density_matrix(backend, nqubits, targets):
     target_rho = np.reshape(target_rho, initial_rho.shape)
     target_rho = target_rho / np.trace(target_rho)
     np.testing.assert_allclose(final_rho, target_rho)
-    qibo.set_backend(original_backend)
 
 
 def test_measurement_collapse_errors(backend):
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     gate = gates.M(0, 1, collapse=True)
     state = np.ones(4) / 4
     with pytest.raises(ValueError):
         state = gate(state, nshots=100)
-    qibo.set_backend(original_backend)
 
 
 def test_measurement_collapse_bitflip_noise(backend, accelerators):
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     K.set_seed(123)
     c = models.Circuit(4, accelerators)
     output = c.add(gates.M(0, 1, p0=0.2, collapse=True))
@@ -81,13 +69,10 @@ def test_measurement_collapse_bitflip_noise(backend, accelerators):
     _, target_frequencies = np.unique(target_samples, return_counts=True)
     target_frequencies = {i: v for i, v in enumerate(target_frequencies)}
     assert output.frequencies(binary=False) == target_frequencies
-    qibo.set_backend(original_backend)
 
 
 @pytest.mark.parametrize("effect", [False, True])
 def test_measurement_result_parameters(backend, accelerators, effect):
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     c = models.Circuit(4, accelerators)
     if effect:
         c.add(gates.X(0))
@@ -99,12 +84,9 @@ def test_measurement_result_parameters(backend, accelerators, effect):
         target_c.add(gates.X(0))
         target_c.add(gates.RX(1, theta=np.pi / 4))
     np.testing.assert_allclose(c(), target_c())
-    qibo.set_backend(original_backend)
 
 
 def test_measurement_result_parameters_random(backend, accelerators):
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     test_device = K.cpu_devices[0] if accelerators else K.default_device
     initial_state = random_state(4)
     K.set_seed(123)
@@ -122,13 +104,10 @@ def test_measurement_result_parameters_random(backend, accelerators):
             target_state = gates.RY(0, theta=np.pi / 5)(target_state)
             target_state = gates.RX(2, theta=np.pi / 4)(target_state)
     np.testing.assert_allclose(result, target_state)
-    qibo.set_backend(original_backend)
 
 
 @pytest.mark.parametrize("use_loop", [True, False])
 def test_measurement_result_parameters_repeated_execution(backend, accelerators, use_loop):
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     test_device = K.cpu_devices[0] if accelerators else K.default_device
     initial_state = random_state(4)
     K.set_seed(123)
@@ -152,12 +131,9 @@ def test_measurement_result_parameters_repeated_execution(backend, accelerators,
                 target_state = gates.RX(2, theta=np.pi / 4)(target_state)
             target_states.append(np.copy(target_state))
     np.testing.assert_allclose(final_states, target_states)
-    qibo.set_backend(original_backend)
 
 
 def test_measurement_result_parameters_repeated_execution_final_measurements(backend, accelerators):
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     test_device = K.cpu_devices[0] if accelerators else K.default_device
     initial_state = random_state(4)
     K.set_seed(123)
@@ -181,12 +157,9 @@ def test_measurement_result_parameters_repeated_execution_final_measurements(bac
                 target_result = gates.M(0, 1, 2, 3)(target_state)
                 target_samples.append(target_result.decimal[0])
     np.testing.assert_allclose(result.samples(binary=False), target_samples)
-    qibo.set_backend(original_backend)
 
 
 def test_measurement_result_parameters_multiple_qubits(backend):
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     initial_state = random_state(4)
     K.set_seed(123)
     c = models.Circuit(4)
@@ -203,4 +176,3 @@ def test_measurement_result_parameters_multiple_qubits(backend):
     if int(collapse.result.outcome(2)):
         target_state = gates.RX(3, theta=np.pi / 3)(target_state)
     np.testing.assert_allclose(result, target_state)
-    qibo.set_backend(original_backend)

--- a/src/qibo/tests/test_measurement_gate_probabilistic.py
+++ b/src/qibo/tests/test_measurement_gate_probabilistic.py
@@ -9,9 +9,7 @@ from qibo.tests.test_measurement_gate import assert_result
 
 @pytest.mark.parametrize("use_samples", [True, False])
 def test_probabilistic_measurement(backend, accelerators, use_samples):
-    original_backend = qibo.get_backend()
     original_threads = qibo.get_threads()
-    qibo.set_backend(backend)
     # set single-thread to fix the random values generated from the frequency custom op
     qibo.set_threads(1)
     c = models.Circuit(4, accelerators)
@@ -37,15 +35,12 @@ def test_probabilistic_measurement(backend, accelerators, use_samples):
             decimal_frequencies = {0: 271, 1: 239, 2: 242, 3: 248}
     assert sum(result.frequencies().values()) == 1000
     assert_result(result, decimal_frequencies=decimal_frequencies)
-    qibo.set_backend(original_backend)
     qibo.set_threads(original_threads)
 
 
 @pytest.mark.parametrize("use_samples", [True, False])
 def test_unbalanced_probabilistic_measurement(backend, use_samples):
-    original_backend = qibo.get_backend()
     original_threads = qibo.get_threads()
-    qibo.set_backend(backend)
     # set single-thread to fix the random values generated from the frequency custom op
     qibo.set_threads(1)
     state = np.array([1, 1, 1, np.sqrt(3)]) / np.sqrt(6)
@@ -70,14 +65,11 @@ def test_unbalanced_probabilistic_measurement(backend, use_samples):
             decimal_frequencies = {0: 168, 1: 188, 2: 154, 3: 490}
     assert sum(result.frequencies().values()) == 1000
     assert_result(result, decimal_frequencies=decimal_frequencies)
-    qibo.set_backend(original_backend)
     qibo.set_threads(original_threads)
 
 
 def test_measurements_with_probabilistic_noise(backend):
     """Check measurements when simulating noise with repeated execution."""
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     thetas = np.random.random(5)
     c = models.Circuit(5)
     c.add((gates.RX(i, t) for i, t in enumerate(thetas)))
@@ -102,7 +94,6 @@ def test_measurements_with_probabilistic_noise(backend):
         target_samples.append(noiseless_c(nshots=1).samples())
     target_samples = np.concatenate(target_samples, axis=0)
     np.testing.assert_allclose(samples, target_samples)
-    qibo.set_backend(original_backend)
 
 
 @pytest.mark.parametrize("i,probs", [(0, [0.0, 0.0, 0.0]),
@@ -110,8 +101,6 @@ def test_measurements_with_probabilistic_noise(backend):
                                      (2, [0.5, 0.5, 0.5])])
 def test_post_measurement_bitflips_on_circuit(backend, accelerators, i, probs):
     """Check bitflip errors on circuit measurements."""
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     K.set_seed(123)
     c = models.Circuit(5, accelerators=accelerators)
     c.add([gates.X(0), gates.X(2), gates.X(3)])
@@ -125,13 +114,10 @@ def test_post_measurement_bitflips_on_circuit(backend, accelerators, i, probs):
         targets = [{5: 30}, {5: 16, 7: 10, 6: 2, 3: 1, 4: 1},
                    {3: 6, 5: 6, 7: 5, 2: 4, 4: 3, 0: 2, 1: 2, 6: 2}]
     assert result == targets[i]
-    qibo.set_backend(original_backend)
 
 
 def test_post_measurement_bitflips_on_circuit_result(backend):
     """Check bitflip errors on ``CircuitResult`` objects."""
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     thetas = np.random.random(4)
     c = models.Circuit(4)
     c.add((gates.RX(i, theta=t) for i, t in enumerate(thetas)))
@@ -152,4 +138,3 @@ def test_post_measurement_bitflips_on_circuit_result(backend):
     # Check register samples
     np.testing.assert_allclose(register_samples["a"], target_samples[:, :2])
     np.testing.assert_allclose(register_samples["b"], target_samples[:, 2:])
-    qibo.set_backend(original_backend)

--- a/src/qibo/tests/test_measurement_gate_registers.py
+++ b/src/qibo/tests/test_measurement_gate_registers.py
@@ -1,7 +1,6 @@
 """Test :class:`qibo.abstractions.gates.M` when used with registers."""
 import pytest
 import numpy as np
-import qibo
 from qibo import models, gates
 
 
@@ -31,8 +30,6 @@ def assert_register_result(result, decimal_samples=None, binary_samples=None,
 
 
 def test_register_measurements(backend):
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     c = models.Circuit(3)
     c.add(gates.X(0))
     c.add(gates.X(1))
@@ -49,24 +46,18 @@ def test_register_measurements(backend):
     binary_frequencies = {"register0": {"10": 100}, "register1": {"1": 100}}
     assert_register_result(result, decimal_samples, binary_samples,
                            decimal_frequencies, binary_frequencies)
-    qibo.set_backend(original_backend)
 
 
 def test_register_name_error(backend):
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     c = models.Circuit(2)
     c.add(gates.X(0))
     c.add(gates.M(0, register_name="a"))
     with pytest.raises(KeyError):
         c.add(gates.M(1, register_name="a"))
-    qibo.set_backend(original_backend)
 
 
 def test_registers_with_same_name_error(backend):
     """Check that circuits that contain registers with the same name cannot be added."""
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     c1 = models.Circuit(2)
     c1.add(gates.H(0))
     c1.add(gates.M(0))
@@ -77,12 +68,9 @@ def test_registers_with_same_name_error(backend):
 
     with pytest.raises(KeyError):
         c = c1 + c2
-    qibo.set_backend(original_backend)
 
 
 def test_measurement_qubit_order_multiple_registers(backend, accelerators):
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     c = models.Circuit(6, accelerators)
     c.add(gates.X(0))
     c.add(gates.X(1))
@@ -109,13 +97,10 @@ def test_measurement_qubit_order_multiple_registers(backend, accelerators):
     binary_frequencies = {"a": {"011": 100}, "b": {"01": 100}}
     assert_register_result(result, decimal_samples, binary_samples,
                            decimal_frequencies, binary_frequencies)
-    qibo.set_backend(original_backend)
 
 
 def test_registers_in_circuit_with_unmeasured_qubits(backend, accelerators):
     """Check that register measurements are unaffected by unmeasured qubits."""
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     c = models.Circuit(5, accelerators)
     c.add(gates.X(1))
     c.add(gates.X(2))
@@ -133,4 +118,3 @@ def test_registers_in_circuit_with_unmeasured_qubits(backend, accelerators):
     binary_frequencies = {"A": {"01": 100}, "B": {"10": 100}}
     assert_register_result(result, decimal_samples, binary_samples,
                            decimal_frequencies, binary_frequencies)
-    qibo.set_backend(original_backend)

--- a/src/qibo/tests/test_models_circuit.py
+++ b/src/qibo/tests/test_models_circuit.py
@@ -1,7 +1,6 @@
 """Test methods defined in `qibo/models/circuit.py`."""
 import numpy as np
 import pytest
-import qibo
 from qibo import gates, models
 from qibo.tests.utils import random_state
 
@@ -42,20 +41,15 @@ def exact_qft(x: np.ndarray, inverse: bool = False) -> np.ndarray:
 
 @pytest.mark.parametrize("nqubits", [4, 10, 100])
 def test_qft_circuit_size(backend, nqubits):
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     c = models.QFT(nqubits)
     assert c.nqubits == nqubits
     assert c.depth == 2 * nqubits
     assert c.ngates == nqubits ** 2 // 2 + nqubits
-    qibo.set_backend(original_backend)
 
 
 @pytest.mark.parametrize("nqubits", [5, 6, 12])
 @pytest.mark.parametrize("random", [False, True])
 def test_qft_execution(backend, accelerators, nqubits, random):
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     c = models.QFT(nqubits)
     if random:
         initial_state = random_state(nqubits)
@@ -65,7 +59,6 @@ def test_qft_execution(backend, accelerators, nqubits, random):
         final_state = c()
     target_state = exact_qft(initial_state)
     np.testing.assert_allclose(final_state, target_state)
-    qibo.set_backend(original_backend)
 
 
 def test_qft_errors():

--- a/src/qibo/tests/test_models_grover.py
+++ b/src/qibo/tests/test_models_grover.py
@@ -1,13 +1,10 @@
 """Test Grover model defined in `qibo/models/grover.py`."""
 import pytest
-import qibo
 from qibo import gates
 from qibo.models import Circuit, Grover
 
 
 def test_grover_init(backend):
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     oracle = Circuit(5 + 1)
     oracle.add(gates.X(5).controlled_by(*range(5)))
     superposition = Circuit(5)
@@ -24,12 +21,9 @@ def test_grover_init(backend):
     assert grover.sup_qubits == 5
     assert grover.sup_size == 32
     assert not grover.iterative
-    qibo.set_backend(original_backend)
 
 
 def test_grover_init_default_superposition(backend):
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     oracle = Circuit(5 + 1)
     oracle.add(gates.X(5).controlled_by(*range(5)))
     # try to initialize without passing `superposition_qubits`
@@ -42,12 +36,9 @@ def test_grover_init_default_superposition(backend):
     assert grover.sup_size == 16
     assert grover.superposition.depth == 1
     assert grover.superposition.ngates == 4
-    qibo.set_backend(original_backend)
 
 
 def test_grover_initial_state(backend):
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     oracle = Circuit(5 + 1)
     oracle.add(gates.X(5).controlled_by(*range(5)))
     initial_state = Circuit(5)
@@ -56,25 +47,18 @@ def test_grover_initial_state(backend):
     assert grover.initial_state_circuit == initial_state
     solution, iterations = grover(logs=True)
     assert solution == ["11111"]
-    qibo.set_backend(original_backend)
 
-    
+
 def test_grover_target_amplitude(backend):
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     oracle = Circuit(5 + 1)
     oracle.add(gates.X(5).controlled_by(*range(5)))
     grover = Grover(oracle, superposition_qubits=5, target_amplitude = 1/2**(5/2))
     solution, iterations = grover(logs=True)
     assert len(solution) == 1
     assert solution == ['11111']
-    qibo.set_backend(original_backend)
-    
+
 
 def test_grover_wrong_solution(backend):
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
-
     def check(result):
         for i in result:
             if int(i) != 1:
@@ -86,19 +70,15 @@ def test_grover_wrong_solution(backend):
     grover = Grover(oracle, superposition_qubits=5, check=check, number_solutions=2)
     solution, iterations = grover(logs=True)
     assert len(solution) == 2
-    qibo.set_backend(original_backend)
 
 
 def test_grover_iterative(backend):
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
-
     def check(result):
         for i in result:
             if int(i) != 1:
                 return False
         return True
-    
+
     def check_false(result):
         return False
 
@@ -113,14 +93,10 @@ def test_grover_iterative(backend):
     grover = Grover(oracle, superposition_qubits=5, check=check, iterative=True)
     solution, iterations = grover(logs=True)
     assert solution == "11111"
-    qibo.set_backend(original_backend)
 
 
 @pytest.mark.parametrize("num_sol", [None, 1])
 def test_grover_execute(backend, num_sol):
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
-
     def check(result):
         for i in result:
             if int(i) != 1:
@@ -136,4 +112,3 @@ def test_grover_execute(backend, num_sol):
         assert iterations == 4
     else:
         assert solution == "11111"
-    qibo.set_backend(original_backend)

--- a/src/qibo/tests/test_models_hep.py
+++ b/src/qibo/tests/test_models_hep.py
@@ -1,7 +1,6 @@
 """Testing HEP models."""
 import numpy as np
 import pytest
-import qibo
 from qibo.models.hep import qPDF
 
 
@@ -25,11 +24,8 @@ test_values = [
 @pytest.mark.parametrize(test_names, test_values)
 def test_qpdf(backend, ansatz, layers, nqubits, multi_output, output):
     """Performs a qPDF circuit minimization test."""
-    original_backend = qibo.get_backend()
-    qibo.set_backend(backend)
     model = qPDF(ansatz, layers, nqubits, multi_output)
     np.random.seed(0)
     params = np.random.rand(model.nparams)
     result = model.predict(params, [0.1])
     np.testing.assert_allclose(result, output, atol=1e-5)
-    qibo.set_backend(original_backend)

--- a/src/qibo/tests/test_parallel.py
+++ b/src/qibo/tests/test_parallel.py
@@ -15,9 +15,7 @@ def test_parallel_circuit_evaluation(backend):
     if 'GPU' in qibo.get_device() or os.name == 'nt': # pragma: no cover
         pytest.skip("unsupported configuration")
     original_threads = qibo.get_threads()
-    original_backend = qibo.get_backend()
     qibo.set_threads(1)
-    qibo.set_backend(backend)
 
     nqubits = 10
     np.random.seed(0)
@@ -32,7 +30,6 @@ def test_parallel_circuit_evaluation(backend):
     r2 = parallel_execution(c, states=states, processes=2)
     np.testing.assert_allclose(r1, r2)
     qibo.set_threads(original_threads)
-    qibo.set_backend(original_backend)
 
 
 def test_parallel_parametrized_circuit(backend):
@@ -40,9 +37,7 @@ def test_parallel_parametrized_circuit(backend):
     if 'GPU' in qibo.get_device() or os.name == 'nt': # pragma: no cover
         pytest.skip("unsupported configuration")
     original_threads = qibo.get_threads()
-    original_backend = qibo.get_backend()
     qibo.set_threads(1)
-    qibo.set_backend(backend)
 
     nqubits = 5
     nlayers  = 10
@@ -68,4 +63,3 @@ def test_parallel_parametrized_circuit(backend):
     r2 = parallel_parametrized_execution(c, parameters=parameters, initial_state=state, processes=2)
     np.testing.assert_allclose(r1, r2)
     qibo.set_threads(original_threads)
-    qibo.set_backend(original_backend)


### PR DESCRIPTION
Currently we use the following three lines
```Python
original_backend = qibo.get_backend()
qibo.set_backend(backend)
# ... test code here ...
qibo.set_backend(original_backend)
```
in every test that runs with all different backends. This PR creates a pytest fixture that does this manipulation through the `conftest.py` so that we don't have to include the above lines in every test and avoid code repetition.
